### PR TITLE
Fix --with-tox failure due to spurious trailing comma

### DIFF
--- a/pyscaffold/structure.py
+++ b/pyscaffold/structure.py
@@ -85,7 +85,7 @@ def make_structure(args):
     if args.pre_commit:
         proj_dir[".pre-commit-config.yaml"] = templates.pre_commit_config(args)
     if args.tox:
-        proj_dir["tox.ini"] = templates.tox(args),
+        proj_dir["tox.ini"] = templates.tox(args)
     if args.update and not args.force:  # Do not overwrite following files
         safe = {args.project: {
             ".gitignore": None,

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -3,6 +3,7 @@
 import os
 from os.path import isdir, isfile
 
+import six
 import pytest
 from pyscaffold import runner, structure
 
@@ -97,6 +98,7 @@ def test_make_structure_with_tox():
     struct = structure.make_structure(args)
     assert isinstance(struct, dict)
     assert "tox.ini" in struct["project"]
+    assert isinstance(struct["project"]["tox.ini"], six.string_types)
 
 
 def test_check_files_exist(tmpdir):  # noqa


### PR DESCRIPTION
without this patch it fails as:

```
$ putup --with-tox testproject
Don't know what to do with content type <type 'tuple'>.
```
