### PR TITLE
Fixed path to travis_install.sh

### DIFF
--- a/pyscaffold/data/travis.template
+++ b/pyscaffold/data/travis.template
@@ -12,7 +12,7 @@ env:
     - DISTRIB="conda" PYTHON_VERSION="3.3" COVERAGE="false"
     - DISTRIB="conda" PYTHON_VERSION="3.4" COVERAGE="false"
 install:
-  - source tests/install.sh
+  - source tests/travis_install.sh
   - pip install -r requirements.txt
 before_script:
   - git config --global user.email "you@example.com"


### PR DESCRIPTION
Currently pyscaffold generates a Travis installation script named `travis_install.sh` yet `.travis.yml` refers to `install.sh`. Consequently Travis builds fail unless the developer manually modifies the path. This minor change results in a Travis setup that works out of the box.
