### PR TITLE
Remove unnecessary shebangs.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ md =
 testing =
     sphinx  # required for system tests
     flake8  # required for system tests
-    pytest
+    pytest<4.0.0
     pytest-cov
     pytest-virtualenv
     pytest-xdist

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ testing =
     pytest-cov
     pytest-virtualenv
     pytest-xdist
+    virtualenv
     # We keep pytest-xdist in the test dependencies, so the developer can
     # easily opt-in for distributed tests by adding, for example, the `-n 15`
     # arguments in the command-line.

--- a/src/pyscaffold/templates/conftest_py.template
+++ b/src/pyscaffold/templates/conftest_py.template
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
     Dummy conftest.py for ${package}.

--- a/src/pyscaffold/templates/setup_py.template
+++ b/src/pyscaffold/templates/setup_py.template
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
     Setup file for ${package}.

--- a/src/pyscaffold/templates/skeleton.template
+++ b/src/pyscaffold/templates/skeleton.template
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 This is a skeleton file that can serve as a starting point for a Python

--- a/src/pyscaffold/templates/test_skeleton.template
+++ b/src/pyscaffold/templates/test_skeleton.template
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import pytest

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -9,7 +9,7 @@ from pyscaffold import templates
 def test_get_template():
     template = templates.get_template("setup_py")
     content = template.safe_substitute()
-    assert content.split(os.linesep, 1)[0] == '#!/usr/bin/env python'
+    assert content.split(os.linesep, 1)[0] == '# -*- coding: utf-8 -*-'
 
 
 def test_all_licenses():


### PR DESCRIPTION
* `conftest.py` is auto-loaded by pytest; it was never intended to be run.
* `setup.py` should never be run directly. The recommended command is
  `pip install .`.
* `skeleton.py` is meant to be run via setuptools' `console_scripts`
  option (see #100, for example)
* `test_skeleton.py` contains no main code and is meant to be run via
  pytest, not the interpreter directly.