### PR TITLE
Check for environment vars for git config

### DIFF
--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -7,6 +7,7 @@ import copy
 import getpass
 import socket
 from operator import itemgetter
+import os
 
 from . import shell
 from .exceptions import (
@@ -74,8 +75,13 @@ def is_git_configured():
         bool: True if it is set globally, False otherwise
     """
     try:
-        for attr in ["name", "email"]:
-            shell.git("config", "--get", "user.{}".format(attr))
+        # git will prefer these env vars over config settings, so check them first
+        # see https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables#_committing
+        for env_var, attr in (
+            ("GIT_AUTHOR_NAME", "name"),
+            ("GIT_AUTHOR_EMAIL", "email")
+        ):
+            os.getenv(env_var) or shell.git("config", "--get", "user.{}".format(attr))
     except ShellCommandException:
         return False
     return True


### PR DESCRIPTION
Before checking for global git-config `author` and `name` entries, check
for the git environment variables.

Git will use these environment variables when creating commits, falling
back on git-config values if they aren't set:
https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables#_committing

Using the environment variables instead of a global git-config setting
is useful when dealing with repositories with different author settings
(eg https://knpw.rs/blog/multiple-git-users ).