### PR TITLE
Address issue #240 by removing some classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Environment :: Console


### PR DESCRIPTION
… in `setup.cfg`, related to old versions of Python.

Moreover, it removes explicity Windows support, since we don't have any
CI in place targetting Windows.

(#240)