### PR TITLE
Potential fix for #238

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ ds =
     pyscaffoldext-dsproject
 # Add here test dependencies (used by tox and pytest-runner)
 testing =
+    ipython
     sphinx  # required for system tests
     flake8  # required for system tests
     pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import logging
 import os
 import shlex
 import stat
+import sys
 from collections import namedtuple
 from contextlib import contextmanager
 from importlib import reload
@@ -13,6 +14,8 @@ from shutil import rmtree
 from pkg_resources import DistributionNotFound
 
 import pytest
+
+from pytest_virtualenv import VirtualEnv
 
 from .helpers import uniqstr
 
@@ -44,8 +47,9 @@ def command_exception(content):
 
 
 @pytest.fixture
-def venv(virtualenv):
+def venv():
     """Create a virtualenv for each test"""
+    virtualenv = VirtualEnv(python=sys.executable)
     return virtualenv
 
 


### PR DESCRIPTION
Hi @abravalheri, would this solve the issue with pytest-virtualenv? According to the output when running `tox -- -k test_sdist_install_with_1_0_tag`:
```
Already using interpreter /Users/fwilhelm/Sources/pyscaffold/.tox/default/bin/python
Using real prefix '/Users/fwilhelm/anaconda/envs/pyscaffold'
New python executable in /var/folders/s7/6tn210s12s524j8w7vftx5mw39526l/T/tmp8d2d9kfm/.env/bin/python
Installing setuptools, pip, wheel...
```
it seems like the correct Python interpreter from Tox is used. Would this solve #238?