### PR TITLE
Python 3.8 on Linux and Windows

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -110,8 +110,8 @@ windows_task:
   env:
     # Single quotes are used bellow to escape Windows backslash and %
     # (YAML restrictions).
-    PYTHON_HOME: 'C:\Python37'
-    PYTHON_APPDATA: '%APPDATA%\Python\Python37'
+    PYTHON_HOME: 'C:\Python38'
+    PYTHON_APPDATA: '%APPDATA%\Python\Python38'
     # ^ it is important to update these 2 env vars when the default version
     #   of python in chocolatey changes
     MSYS_HOME: 'C:\tools\msys64'

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,6 +64,10 @@ linux_mac_task:
       container: {image: "python:3.7-buster"}
       pip_cache: *pip-cache
       install_script: *debian-install
+    - name: test (Linux - 3.8)
+      container: {image: "python:3.8-buster"}
+      pip_cache: *pip-cache
+      install_script: *debian-install
     - name: test (Linux - Anaconda)
       container: {image: "continuumio/anaconda3:2019.03"}
       pip_cache: *pip-cache
@@ -158,6 +162,7 @@ coverage_task:
     - test (Linux - 3.5)
     - test (Linux - 3.6)
     - test (Linux - 3.7)
+    - test (Linux - 3.8)
     - test (Linux - Anaconda)
     - test (OS X)
     - test (Windows)


### PR DESCRIPTION
The Windows choco package has been updated to use Python 3.8.
Lots of users will also been switching to Python 3.8 as a result, so adjust CI to continue using the default choco package.