### PR TITLE
Use sys.executable in tests

### DIFF
--- a/tests/system/helpers.py
+++ b/tests/system/helpers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import shlex
+import sys
 from os import environ
 from subprocess import STDOUT, check_output
 
@@ -11,6 +12,9 @@ def run(*args, **kwargs):
             args = shlex.split(args[0])
         else:
             args = args[0]
+
+    if args[0] == 'python' and sys.platform != 'win32':
+        args[0] += str(sys.version_info[0])
 
     opts = dict(stderr=STDOUT, universal_newlines=True)
     opts.update(kwargs)

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -2,6 +2,7 @@
 import os.path
 import shutil
 import subprocess
+import sys
 
 import pytest
 
@@ -74,10 +75,12 @@ def test_version_of_subdir(tmpfolder):
     shutil.move('inner_project', 'main_project/inner_project')
     with utils.chdir('main_project'):
         main_version = subprocess.check_output([
-            'python', 'setup.py', '--version']).strip().splitlines()[-1]
+            sys.executable, 'setup.py', '--version'
+            ]).strip().splitlines()[-1]
         with utils.chdir('inner_project'):
             inner_version = subprocess.check_output([
-                'python', 'setup.py', '--version']).strip().splitlines()[-1]
+                sys.executable, 'setup.py', '--version'
+                ]).strip().splitlines()[-1]
     assert main_version.strip() == inner_version.strip()
 
 


### PR DESCRIPTION
This is incomplete.

The motivation is packaging of PyScaffold for linux distros, and running the test suite outside of a venv where `python` may not exist at all, or points to `python2` instead of `python3` which causes problems when running the test suite on python3.

for reference, my project to package PyScaffold is at https://build.opensuse.org/package/show/home:jayvdb:PyScaffold/python-PyScaffold -- the .spec has some hacks in it which this patch is trying to tidy up.