### PR TITLE
Add tests for inplace update (#138)

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -126,6 +126,19 @@ Try to remove all the egg files or the complete egg folder, i.e. ``.eggs``, as w
 as the ``*.egg-info`` folders in the ``src`` folder or potentially in the root of your
 project. Afterwards run ``python setup.py egg_info --egg-base .`` again.
 
+    I've got a strange syntax error when running the test suite. It looks
+    like the tests are trying to run with Python 2.7 …
+
+Try to create a dedicated venv using Python 3.6+ (or the most recent version
+supported by PyScaffold) and use a ``tox`` binary freshly installed in this
+venv. For example::
+
+    python3 -m venv .venv
+    source .venv/bin/activate
+    .venv/bin/pip install tox
+    .venv/bin/tox -e all
+
+
 .. _Travis: https://travis-ci.org/pyscaffold/pyscaffold
 .. _PyPI: https://pypi.python.org/
 .. _Blue Yonder: http://www.blue-yonder.com/en/

--- a/setup.cfg
+++ b/setup.cfg
@@ -124,6 +124,7 @@ norecursedirs =
     .tox
 testpaths = tests
 markers =
+    only: for debugging purposes, a single, failing, test can be required to run
     slow: mark tests as slow (deselect with '-m "not slow"')
     system: mark system tests
     original_logger: do not isolate logger in specific tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,7 @@ def logger():
 
 @pytest.fixture
 def with_coverage():
-    return strtobool(os.environ['COVERAGE'])
+    return strtobool(os.environ.get('COVERAGE', '0'))
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
This PR adds a test as described in #138.

@FlorianWilhelm, the test is very simple. Please let me know if you have any other ideas on what should be tested.

I also have a doubt:
- Right now if I first start the project with no description and I try to update the project later using the `-d/--description` flag, the given text is not update in `setup.cfg`.
Is this the expected behaviour?