### PR TITLE
Double quote $HOME in  travis_install.template

### DIFF
--- a/src/pyscaffold/templates/travis_install.template
+++ b/src/pyscaffold/templates/travis_install.template
@@ -27,7 +27,7 @@ if [[ "$DISTRIB" == "conda" ]]; then
         # itself
         wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
             -O miniconda.sh
-        chmod +x miniconda.sh && ./miniconda.sh -b -p $HOME/miniconda
+        chmod +x miniconda.sh && ./miniconda.sh -b -p "$HOME/miniconda"
     fi
     export PATH=$HOME/miniconda/bin:$PATH
     # Make sure to use the most updated version


### PR DESCRIPTION
Double quote to prevent globbing and word splitting
https://github.com/koalaman/shellcheck/wiki/SC2086