### PR TITLE
Deprecate pytest-runner and sphinx integration to setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,28 +101,35 @@ well adjusted for Python projects and the most common tools.
 Sphinx Documentation
 ====================
 
-Build the documentation with ``python setup.py docs`` and run doctests with
-``python setup.py doctest`` after you have `Sphinx`_ installed.
+PyScaffold will prepare a `docs` directory with all you need to start writing
+your documentation.
 Start editing the file ``docs/index.rst`` to extend the documentation.
 The documentation also works with `Read the Docs`_.
 
 The `Numpy and Google style docstrings`_ are activated by default.
 Just make sure Sphinx 1.3 or above is installed.
 
+If you have `make`_ and `Sphinx`_ installed in your computer, build the
+documentation with ``make -C docs html`` and run doctests with
+``make -C docs doctest``.
+Alternatively, if your project was created with the ``--tox``
+option, simply run ``tox -e doc`` ot ``tox -e doctest``.
+
+
 
 Unittest & Coverage
 ===================
 
-Run ``python setup.py test`` to run all unittests defined in the subfolder
-``tests`` with the help of `py.test`_ and pytest-runner_. Some sane
-default flags for py.test are already defined in the ``[tool:pytest]`` section of
-``setup.cfg``. The py.test plugin `pytest-cov`_ is used to automatically
-generate a coverage report. It is also possible to provide additional
-parameters and flags on the commandline, e.g., type::
+PyScaffold relies on `py.test`_ to run all unittests defined in the subfolder
+``tests``.  Some sane default flags for py.test are already defined in the
+``[pytest]`` section of ``setup.cfg``. The py.test plugin `pytest-cov`_ is used
+to automatically generate a coverage report. It is also possible to provide
+additional parameters and flags on the commandline, e.g., type::
 
-    python setup.py test --addopts -h
+    py.test -h
 
-to show the help of py.test.
+to show the help of py.test (requires `py.test`_ to be installed in your system
+or virtualenv).
 
 .. rubric:: JUnit and Coverage HTML/XML
 
@@ -205,7 +212,6 @@ since the git repository of the existing project is not touched!
 .. _Sphinx: http://www.sphinx-doc.org/
 .. _Read the Docs: https://readthedocs.org/
 .. _Numpy and Google style docstrings: http://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
-.. _pytest-runner: https://pypi.python.org/pypi/pytest-runner
 .. _pytest-cov: https://github.com/schlamar/pytest-cov
 .. _Travis: https://travis-ci.org
 .. _Coveralls: https://coveralls.io/

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -69,10 +69,13 @@ name it whatever you want, but let's be explicit!) inside the
 runners can have a centralised configuration and authors can avoid double
 bookkeeping.
 
-If you use |pytest-runner|_ adding a ``--extras`` flag will do the trick of
-making sure these dependencies are installed, and if you use ``tox``, the same
-is accomplished with |extras|_. By default PyScaffold will take care of these
-configurations for you.
+If run ``py.test`` runner, you will have to install those dependencies
+manually, or do a editable install of your package with
+``pip install -e .[testing]``.
+
+If you use ``tox``, you can list ``testing`` under the |extras|_ option
+(PyScaffold template for ``tox.ini`` already takes care of this
+configuration for you).
 
 .. note:: If you prefer to use just ``tox`` and keep everything inside
     ``tox.ini``, please go ahead and move your test dependencies.
@@ -83,8 +86,6 @@ configurations for you.
     A good start is to create a new project passing the ``--tox`` option to
     ``putup`` and try running ``tox`` in your project root.
 
-.. |pytest-runner| replace:: ``pytest-runner``
-.. _pytest-runner: https://github.com/pytest-dev/pytest-runner
 .. |extras| replace:: the ``extras`` configuration field
 .. _extras: http://tox.readthedocs.io/en/latest/config.html#confval-extras=MULTI-LINE-LIST
 
@@ -94,8 +95,8 @@ Development Environment
 
 As previously mentioned, PyScaffold will get you covered when specifying the
 **abstract** or test dependencies of your package. We provide sensible
-configurations for ``setuptools``, ``tox`` and ``pytest-runner``
-out-of-the-box. In most of the cases this is enough, since developers in the
+configurations for ``setuptools`` and ``tox`` out-of-the-box.
+In most of the cases this is enough, since developers in the
 Python community are used to rely on tools like |virtualenv|_ and have a
 workflow that take advantage of such configurations. As an example, someone
 could do:
@@ -139,9 +140,9 @@ set is meant to store dependencies that are used only during development.
 
 This separation can be directly mapped to PyScaffold strategy: basically the
 default set should mimic the ``install_requires`` option in ``setup.cfg``,
-while the dev set should contain things like ``tox``, ``pytest-runner``,
-``sphinx``, ``pre-commit``, ``ptpython`` or any other tool the developer uses
-while developing.
+while the dev set should contain things like ``tox``, ``sphinx``,
+``pre-commit``, ``ptpython`` or any other tool the developer uses while
+developing.
 
 .. note:: Test dependencies are internally managed by the test runner,
     so we don't have to tell Pipenv about them.

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -145,13 +145,19 @@ adjusted for Python projects and the most common tools.
 Sphinx Documentation
 ====================
 
-Build the documentation with ``python setup.py docs`` and run doctests with
-``python setup.py doctest`` after you have `Sphinx`_ installed.
+PyScaffold will prepare a `docs` directory with all you need to start writing
+your documentation.
 Start editing the file ``docs/index.rst`` to extend the documentation.
 The documentation also works with `Read the Docs`_.
 
 The `Numpy and Google style docstrings`_ are activated by default.
 Just make sure Sphinx 1.3 or above is installed.
+
+If you have `make`_ and `Sphinx`_ installed in your computer, build the
+documentation with ``make -C docs html`` and run doctests with
+``make -C docs doctest``.
+Alternatively, if your project was created with the ``--tox``
+option, simply run ``tox -e doc`` ot ``tox -e doctest``.
 
 
 Dependency Management in a Breeze
@@ -176,16 +182,16 @@ what you have to do (details in :ref:`Dependency Management <dependencies>`).
 Unittest & Coverage
 ===================
 
-Run ``python setup.py test`` to run all unittests defined in the subfolder
-``tests`` with the help of `py.test`_ and `pytest-runner`_. Some sane
-default flags for py.test are already defined in the ``[pytest]`` section of
-``setup.cfg``. The py.test plugin `pytest-cov`_ is used to automatically
-generate a coverage report. It is also possible to provide additional
-parameters and flags on the commandline, e.g., type::
+PyScaffold relies on `py.test`_ to run all unittests defined in the subfolder
+``tests``.  Some sane default flags for py.test are already defined in the
+``[pytest]`` section of ``setup.cfg``. The py.test plugin `pytest-cov`_ is used
+to automatically generate a coverage report. It is also possible to provide
+additional parameters and flags on the commandline, e.g., type::
 
-    python setup.py test --addopts -h
+    py.test -h
 
-to show the help of py.test.
+to show the help of py.test (requires `py.test`_ to be installed in your system
+or virtualenv).
 
 .. rubric:: JUnit and Coverage HTML/XML
 
@@ -349,7 +355,6 @@ remove a feature which was once added.
 .. _pre-commit hooks: http://pre-commit.com/
 .. _setuptools_scm: https://pypi.python.org/pypi/setuptools_scm/
 .. _py.test: http://pytest.org/
-.. _pytest-runner: https://pypi.python.org/pypi/pytest-runner
 .. _Travis: https://travis-ci.org/
 .. _pytest-cov: https://github.com/schlamar/pytest-cov
 .. _Coveralls: https://coveralls.io/
@@ -364,3 +369,4 @@ remove a feature which was once added.
 .. _devpi: https://devpi.net/
 .. _Nexus: https://www.sonatype.com/product-nexus-repository
 .. _packaging, versioning and continuous integration: https://florianwilhelm.info/2018/01/ds_in_prod_packaging_ci/
+.. _make: https://en.wikipedia.org/wiki/Make_(software)

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -49,17 +49,21 @@ PyScaffold is also available at `conda-forge`_ and thus can be installed with `c
 Additional Requirements
 =======================
 
-If you run commands like ``python setup.py test`` and ``python setup.py docs``
-within your project, some additional requirements like py.test will be
-installed automatically as *egg*-files inside the ``.eggs`` folder. This is
-quite comfortable but can be confusing because these packages won't be
-available to other packages inside your virtual environment. In order to avoid
-this just install following packages inside your virtual environment before you
-run ``setup.py`` commands like *doc* and *test*:
+If you run commands like ``py.test`` and ``make -C docs`` within your project,
+some additional requirements like py.test and Sphinx may be required. It might
+be the case you are already have them installed but this can be confusing
+because these packages won't be available to other packages inside your virtual
+environment.  In order to avoid this just install following packages inside
+your virtual environment:
 
 * `Sphinx <http://sphinx-doc.org/>`_
 * `py.test <http://pytest.org/>`_
 * `pytest-cov <https://pypi.python.org/pypi/pytest-cov>`_
+
+Alternatively, you can setup build automation with **tox**. An easy way to do
+that is to generate your project passing the ``--tox`` option.
+The commands ``tox`` and ``tox -e doc`` should be able to run your tests or
+build your docs out of the box.
 
 .. _setuptools: https://pypi.python.org/pypi/setuptools/
 .. _Git: https://git-scm.com/

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -41,8 +41,8 @@ Let's start:
 #. In order to check that everything works, run ``python setup.py install`` and ``python setup.py sdist``.
    If those two commands don't work, check ``setup.cfg``, ``setup.py`` as well as your package under ``src`` again.
    Were all modules moved correctly? Is there maybe some ``__init__.py`` file missing?
-   After these basic commands, try also to run ``python setup.py docs`` and ``python setup.py test`` to check
-   that Sphinx and PyTest runs correctly.
+   After these basic commands, try also to run ``make -C docs html`` and ``py.test`` (or preferably their ``tox`` equivalents)
+   to check that Sphinx and PyTest run correctly.
 
 
 .. _documentation of setuptools: https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ md =
     pyscaffoldext-markdown
 ds =
     pyscaffoldext-dsproject
-# Add here test dependencies (used by tox and pytest-runner)
+# Add here test dependencies (used by tox)
 testing =
     sphinx  # required for system tests
     flake8  # required for system tests

--- a/src/pyscaffold/cli.py
+++ b/src/pyscaffold/cli.py
@@ -13,7 +13,7 @@ from pkg_resources import parse_version
 from . import __version__ as pyscaffold_version
 from . import api, info, shell, templates, utils
 from .exceptions import NoPyScaffoldProject
-from .log import ReportFormatter, configure_logger
+from .log import ReportFormatter, logger
 from .utils import get_id
 
 
@@ -166,7 +166,7 @@ def process_opts(opts):
     if opts["pretend"]:
         opts["log_level"] = logging.INFO
 
-    configure_logger(opts)
+    logger.reconfigure(opts)
 
     # In case of an update read and parse setup.cfg
     if opts["update"]:

--- a/src/pyscaffold/integration.py
+++ b/src/pyscaffold/integration.py
@@ -102,7 +102,7 @@ def build_cmd_docs():
                     PyScaffold 4.0. Please use the Makefile inside the docs folder,
                     or run `sphinx-build`.
 
-                    Alternatively, consider a virtualenv manager/task runner such
+                    Alternatively, consider a build automation tool such
                     as tox (https://tox.readthedocs.io/en/latest/)
                     or nox (https://nox.thea.codes/en/stable/).
                 """
@@ -119,7 +119,7 @@ class DeprecatedPyTest(ptr.PyTest):
             pytest-runner is deprecated and support for running `python setup.py test`
             will be removed in PyScaffold 4.0.
 
-            Please consider switching to a virtualenv manager/task runner such
+            Please consider switching to a build automation tool such
             as tox (https://tox.readthedocs.io/en/latest/)
             or nox (https://nox.thea.codes/en/stable/).
         """

--- a/src/pyscaffold/log.py
+++ b/src/pyscaffold/log.py
@@ -27,15 +27,16 @@ def configure_logger(opts):
 
     Args:
         opts (dict): command line parameters
-    """
-    if "log_level" in opts:
-        logger.level = opts["log_level"]
 
-    # if terminal supports, use colors
-    stream = getattr(logger.handler, "stream", None)
-    if termui.supports_color(stream):
-        logger.formatter = ColoredReportFormatter()
-        logger.handler.setFormatter(logger.formatter)
+    Warning:
+        *Deprecation Notice* - In the next major release, this function will be
+        removed. Please call :obj:`ReportLogger.reconfigure` instead::
+
+            from pyscaffold.log import logger
+
+            logger.reconfigure(...)
+    """
+    logger.reconfigure(opts)
 
 
 class ReportFormatter(Formatter):
@@ -307,6 +308,33 @@ class ReportLogger(LoggerAdapter):
         clone.nesting = self.nesting
 
         return clone
+
+    def reconfigure(self, opts={}, **kwargs):
+        """Reconfigure some aspects of the logger object.
+
+        Args:
+            opts (dict): dict with the same elements as the keyword arguments bellow
+
+        Keyword Args:
+            log_level: One of the log levels specified in the :obj:`logging` module.
+            use_colors: automatically set a colored formatter to the logger
+                if ANSI codes support is detected. (Defaults to `True`).
+
+        Additional keyword arguments will be ignored.
+        """
+        opts = opts.copy()
+        opts.update(kwargs)
+
+        if "log_level" in opts:
+            self.level = opts["log_level"]
+
+        # if terminal supports, use colors
+        stream = getattr(self.handler, "stream", None)
+        if opts.get("use_colors", True) and termui.supports_color(stream):
+            self.formatter = ColoredReportFormatter()
+            self.handler.setFormatter(self.formatter)
+
+        return self
 
 
 logger = ReportLogger()

--- a/src/pyscaffold/templates/gitlab_ci.template
+++ b/src/pyscaffold/templates/gitlab_ci.template
@@ -27,40 +27,38 @@ before_script:
   - git config --global user.email "you@example.com"
   - git config --global user.name "Your Name"
   # Install dependencies of your package and the testing environment
-  - pip install -r requirements.txt
-  - pip install -r test-requirements.txt
+  # You can skip this step if you use tox, just remember to edit `test_script` bellow
+  - pip install -e .[testing]
+
+.test_script: &test_script
+  script:
+  - py.test
+  # or use `tox` (recommended)
 
 # Run in different environments
-py27:
-  image: "python:2.7"
-  script:
-  - python setup.py test
-
-py33:
-  image: "python:3.3"
-  script:
-  - python setup.py test
-
-py34:
-  image: "python:3.4"
-  script:
-  - python setup.py test
-
 py35:
   image: "python:3.5"
-  script:
-  - python setup.py test
+  <<: *test_script
 
 py36:
   image: "python:3.6"
-  script:
-  - python setup.py test
+  <<: *test_script
+
+py37:
+  image: "python:3.5"
+  <<: *test_script
+
+py38:
+  image: "python:3.6"
+  <<: *test_script
+
 
 docs:
   before_script:
   - pip install Sphinx
   script:
-  - python setup.py docs
+  - make -C docs html
+  # or use `tox` (recommended)
 
 # This deploy job uses a simple deploy flow to Heroku, other providers, e.g. AWS Elastic Beanstalk
 # are supported too: https://github.com/travis-ci/dpl

--- a/src/pyscaffold/templates/tox_ini.template
+++ b/src/pyscaffold/templates/tox_ini.template
@@ -15,3 +15,21 @@ commands =
 extras =
     all
     testing
+
+[testenv:doc]
+description = invoke sphinx-build to build the HTML docs
+setenv =
+    DOCSDIR = {toxinidir}/docs
+    BUILDDIR = {toxinidir}/docs/_build
+deps =
+    sphinx
+    # sphinx_rtd_theme
+commands =
+    sphinx-build -b html -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/html" {posargs}
+
+[testenv:doctest]
+description = invoke sphinx-build to run doctests
+setenv = {[testenv:doc]setenv}
+deps = {[testenv:doc]deps}
+commands =
+    sphinx-build -b doctest -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/doctest" {posargs}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,14 +4,16 @@ import logging
 import os
 import shlex
 import stat
+import sys
 from collections import namedtuple
 from contextlib import contextmanager
 from distutils.util import strtobool
 from importlib import reload
+from importlib.util import find_spec
 from os import environ
 from os.path import isdir
 from os.path import join as path_join
-from shutil import rmtree
+from shutil import rmtree, which
 
 from pkg_resources import DistributionNotFound
 
@@ -381,3 +383,15 @@ def no_colorama_mock():
 def colorama_mock():
     with replace_import("colorama", obj(init=nop)):
         yield
+
+
+@pytest.fixture
+def tox():
+    if sys.platform == "win32":
+        pytest.skip("Windows tests don't play nicely with nested tox")
+    elif which("tox"):
+        yield "tox"
+    elif find_spec("tox"):
+        yield "{} -m tox".format(sys.executable)
+    else:
+        pytest.skip("For some reason tox cannot be found.")

--- a/tests/extensions/test_namespace.py
+++ b/tests/extensions/test_namespace.py
@@ -14,7 +14,7 @@ from pyscaffold.extensions.namespace import (
     enforce_namespace_options,
     move_old_package,
 )
-from pyscaffold.log import configure_logger
+from pyscaffold.log import logger
 from pyscaffold.utils import prepare_namespace
 
 
@@ -155,7 +155,7 @@ def test_pretend_move_old_package(tmpfolder, caplog, isolated_logger):
 
     opts = parse_args(["proj", "-p", "my_pkg", "--namespace", "my.ns", "--pretend"])
     opts = process_opts(opts)
-    configure_logger(opts)
+    logger.reconfigure(opts)
     struct = dict(proj={"src": {"my_pkg": {"file.py": ""}}})
 
     # when 'pretend' option is passed,

--- a/tests/system/test_common.py
+++ b/tests/system/test_common.py
@@ -111,6 +111,37 @@ def test_force(cwd):
 # -- Extensions --
 
 
+@pytest.mark.only
+def test_tox_docs(cwd):
+    # Given pyscaffold project is created with --tox
+    run("putup myproj --tox")
+    with cwd.join("myproj").as_cwd():
+        # when we can call tox -e doc
+        run("tox -e doc")
+        # then documentation will be generated.
+        assert exists("docs/api/modules.rst")
+        assert exists("docs/_build/html/index.html")
+
+
+@pytest.mark.only
+def test_tox_doctest(cwd):
+    # Given pyscaffold project is created with --tox
+    run("putup myproj --tox")
+    with cwd.join("myproj").as_cwd():
+        # when we can call tox
+        run("tox -e doctest")
+        # then tests will execute
+
+
+def test_tox_tests(cwd):
+    # Given pyscaffold project is created with --tox
+    run("putup myproj --tox")
+    with cwd.join("myproj").as_cwd():
+        # when we can call tox
+        run("tox")
+        # then tests will execute
+
+
 @pytest.mark.parametrize(
     "extension, kwargs, filename",
     (

--- a/tests/system/test_common.py
+++ b/tests/system/test_common.py
@@ -111,34 +111,32 @@ def test_force(cwd):
 # -- Extensions --
 
 
-@pytest.mark.only
-def test_tox_docs(cwd):
+def test_tox_docs(cwd, tox):
     # Given pyscaffold project is created with --tox
     run("putup myproj --tox")
     with cwd.join("myproj").as_cwd():
         # when we can call tox -e doc
-        run("tox -e doc")
+        run("{} -e doc".format(tox))
         # then documentation will be generated.
         assert exists("docs/api/modules.rst")
         assert exists("docs/_build/html/index.html")
 
 
-@pytest.mark.only
-def test_tox_doctest(cwd):
+def test_tox_doctest(cwd, tox):
     # Given pyscaffold project is created with --tox
     run("putup myproj --tox")
     with cwd.join("myproj").as_cwd():
         # when we can call tox
-        run("tox -e doctest")
+        run("{} -e doctest".format(tox))
         # then tests will execute
 
 
-def test_tox_tests(cwd):
+def test_tox_tests(cwd, tox):
     # Given pyscaffold project is created with --tox
     run("putup myproj --tox")
     with cwd.join("myproj").as_cwd():
         # when we can call tox
-        run("tox")
+        run(tox)
         # then tests will execute
 
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -201,6 +201,28 @@ def test_copy(caplog):
     )
 
 
+def test_reconfigure(monkeypatch, caplog, uniq_raw_logger):
+    # Given an environment that supports color, and a restrictive logger
+    caplog.set_level(logging.NOTSET)
+    monkeypatch.setattr("pyscaffold.termui.supports_color", lambda *_: True)
+    new_logger = ReportLogger(uniq_raw_logger, formatter=ReportFormatter())
+    new_logger.level = logging.INFO
+    # when the logger is reconfigured
+    new_logger.reconfigure()
+    name = uniqstr()
+    # then the messages should be displayed and use colors
+    new_logger.report("some1", name)
+    out = caplog.messages[-1]
+    assert re.search(ansi_pattern("some1") + ".+" + name, out)
+
+    # when the logger is reconfigured with a higher level
+    new_logger.reconfigure(log_level=logging.CRITICAL)
+    # then the messages should not be displayed
+    name = uniqstr()
+    new_logger.report("some2", name)
+    assert not re.search(ansi_pattern("some2") + ".+" + name, caplog.text)
+
+
 def test_other_methods(caplog):
     # Given the logger level is properly set,
     caplog.set_level(logging.DEBUG)
@@ -338,6 +360,7 @@ def test_colored_others_methods(caplog, uniq_raw_logger):
 
 
 def test_configure_logger(monkeypatch, caplog):
+    # ***** REMOVE in the next release *****
     # Given an environment that supports color,
     monkeypatch.setattr("pyscaffold.termui.supports_color", lambda *_: True)
     # when configure_logger in called,

--- a/tox.ini
+++ b/tox.ini
@@ -24,3 +24,14 @@ commands =
 extras =
     all
     testing
+
+[testenv:docs]
+description = invoke sphinx-build to build the HTML docs
+setenv =
+    DOCSDIR = {toxinidir}/docs
+    BUILDDIR = {toxinidir}/docs/_build
+deps =
+    -r {toxinidir}/requirements.txt
+    sphinx_rtd_theme
+commands =
+    sphinx-build -b html -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/html" {posargs}


### PR DESCRIPTION
As much as could find, I changed the documentation details.
Additionally, the tox template is taking the responsibility for the old commands.