### PR TITLE
Introduce global config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Version 4.0
 - Cookiecutter and Django extracted to their own repositories, issue #175
 - Support for Python 3.4 dropped, issue #226
 - Dropped deprecated ``requirements.txt`` file, issue #182
+- Added support for global configuration/PyScaffold's presets, issue #236
 
 
 Current versions

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,8 @@ Version 4.0
 - Cookiecutter and Django extracted to their own repositories, issue #175
 - Support for Python 3.4 dropped, issue #226
 - Dropped deprecated ``requirements.txt`` file, issue #182
-- Added support for global configuration/PyScaffold's presets, issue #236
+- Added support for global configuration (avoid retyping common ``putup``'s
+  options), issue #236
 
 
 Current versions

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -148,6 +148,21 @@ venv. For example::
     .venv/bin/pip install tox
     .venv/bin/tox -e all
 
+..
+
+    I am trying to debug the automatic test suite, but it is very hard to
+    understand what is happening.
+
+`Pytest can drop you`_ in a interactive session in the case an error occurs.
+In order to do that you need to pass a ``--pdb`` option (for example by running
+``tox -- -k NAME_OF_THE_FALLING_TEST --pdb``).
+While ``pdb`` does not have the best user interface in the world, if you feel
+courageous, it is possible to use an alternate implementation like `ptpdb`_ and
+`bpdb`_ (please notice some of them might require additional options, such as
+``--pdbcls ptpdb:PtPdb``/``--pdbcls bpdb:BPdb``). You will need to temporarily
+add the respective package as a dependency in your ``tox.ini`` file.
+You can also setup breakpoints manually instead of using the ``--pdb`` option.
+
 
 .. _Travis: https://travis-ci.org/pyscaffold/pyscaffold
 .. _Cirrus-CI: https://cirrus-ci.com/github/pyscaffold/pyscaffold
@@ -162,3 +177,6 @@ venv. For example::
 .. _tox: https://tox.readthedocs.io/
 .. _flake8: http://flake8.pycqa.org/
 .. _ci-tester: https://github.com/pyscaffold/ci-tester
+.. _Pytest can drop you: https://docs.pytest.org/en/stable/usage.html#dropping-to-pdb-python-debugger-at-the-start-of-a-test
+.. _ptpdb: https://pypi.org/project/ptpdb/
+.. _bpdb: https://docs.bpython-interpreter.org/en/latest/bpdb.html?highlight=bpdb

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4,6 +4,9 @@
 Configuration
 =============
 
+Package Configuration
+=====================
+
 Projects set up with PyScaffold feature an easy package configuration with
 ``setup.cfg``. Check out the example below as well as the documentation of
 `setuptools`_.
@@ -16,24 +19,23 @@ Projects set up with PyScaffold feature an easy package configuration with
 
 .. _default-cfg:
 
-Reusing Presets
-===============
+PyScaffold's Own Configuration
+==============================
 
-PyScaffold also allows you to save your favourite CLI parameters to a file that
+PyScaffold also allows you to save your favourite configuration to a file that
 will be automatically read every time you run ``putup``, this way you can avoid
 always retyping the same command line options.
 
-The locations of the preset files vary slightly across platforms, but in
+The locations of the configuration files vary slightly across platforms, but in
 general the following rule applies:
 
 - Linux: ``$XDG_CONFIG_HOME/pyscaffold/default.cfg`` with fallback to ``~/.config/pyscaffold/default.cfg``
 - OSX: ``~/Library/Preferences/pyscaffold/default.cfg``
-- Windows(≥7): ``C:\Users\<username>\AppData\Local\pyscaffold\pyscaffold\default.cfg``
+- Windows(≥7): ``%APPDATA%\pyscaffold\pyscaffold\default.cfg``
 
 The file format resembles the ``setup.cfg`` generated automatically by
 PyScaffold, but with only the ``metadata`` and ``pyscaffold`` sections, for
 example:
-
 
 .. code-block:: ini
 
@@ -48,7 +50,7 @@ example:
         travis
         pre-commit
 
-With this preset file in place, typing only::
+With this file in place, typing only::
 
     $ putup myproj
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -12,3 +12,53 @@ Projects set up with PyScaffold feature an easy package configuration with
     :language: Ini
 
 .. _setuptools: http://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
+
+
+.. _default-cfg:
+
+Reusing Presets
+===============
+
+PyScaffold also allows you to save your favourite CLI parameters to a file that
+will be automatically read every time you run ``putup``, this way you can avoid
+always retyping the same command line options.
+
+The locations of the preset files vary slightly across platforms, but in
+general the following rule applies:
+
+- Linux: ``$XDG_CONFIG_HOME/pyscaffold/default.cfg`` with fallback to ``~/.config/pyscaffold/default.cfg``
+- OSX: ``~/Library/Preferences/pyscaffold/default.cfg``
+- Windows(≥7): ``C:\Users\<username>\AppData\Local\pyscaffold\pyscaffold\default.cfg``
+
+The file format resembles the ``setup.cfg`` generated automatically by
+PyScaffold, but with only the ``metadata`` and ``pyscaffold`` sections, for
+example:
+
+
+.. code-block:: ini
+
+    [metadata]
+    author = John Doe
+    author-email = john.joe@gmail.com
+    license = mozilla
+
+    [pyscaffold]
+    extensions =
+        tox
+        travis
+        pre-commit
+
+With this preset file in place, typing only::
+
+    $ putup myproj
+
+will have the same effect as if you had typed::
+
+    $ putup --license mozilla --tox --travis --pre-commit myproj
+
+
+.. warning::
+
+    *Experimental Feature* - We are still evaluating how this new and exciting
+    feature will work, so its API (including file format) is not considered
+    stable and might change between minor versions.

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -324,6 +324,15 @@ options that were initially used to put up the scaffold under the ``[pyscaffold]
 section in ``setup.cfg``. Be aware that right now PyScaffold provides no way to
 remove a feature which was once added.
 
+Saving your favourite combos (and some typing)
+==============================================
+
+After start using PyScaffold, you probably will notice yourself repeating the
+same options most of the time.
+Don't worry, PyScaffold now allows you to skip the boring boilerplate with its
+**experimental** ``default.cfg`` preset file.
+Check out our :ref:`Configuration <default-cfg>` section to get started.
+
 
 .. _setuptools: http://setuptools.readthedocs.io/en/latest/setuptools.html
 .. _setuptools' documentation: http://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -330,7 +330,7 @@ Saving your favourite combos (and some typing)
 After start using PyScaffold, you probably will notice yourself repeating the
 same options most of the time.
 Don't worry, PyScaffold now allows you to skip the boring boilerplate with its
-**experimental** ``default.cfg`` preset file.
+**experimental** ``default.cfg`` file.
 Check out our :ref:`Configuration <default-cfg>` section to get started.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,7 +39,8 @@ on how to develop a command-line application with the help of PyScaffold.
    PyScaffold 4 is compatible with Python 3.6 and greater
    *(you might be able to run it on Python 3.5, however that is not
    officially supported)*.
-   For legacy Python 2.7 support please install PyScaffold 2.5.
+   For legacy Python 2.7 please install PyScaffold 2.5
+   *(not officially supported)*.
 
 
 Contents

--- a/setup.cfg
+++ b/setup.cfg
@@ -131,6 +131,8 @@ markers =
     system: mark system tests
     original_logger: do not isolate logger in specific tests
 log_level = DEBUG
+log_cli = True
+log_cli_level = CRITICAL
 
 [aliases]
 dists = sdist bdist_wheel

--- a/src/pyscaffold/api/__init__.py
+++ b/src/pyscaffold/api/__init__.py
@@ -98,12 +98,14 @@ class Extension(object):
 # -------- Options --------
 
 (NO_CONFIG,) = list(Enum("ConfigFiles", "NO_CONFIG"))
-"""This constant is used to tell PyScaffold to not load any configuration file,
-not even the default ones.
+"""This constant is used to tell PyScaffold to not load any extra configuration file,
+not even the default ones
 Usage::
 
     create_project(opts, config_files=NO_CONFIG)
 
+Please notice that the ``setup.cfg`` file inside an project being updated will
+still be considered.
 """
 
 DEFAULT_OPTIONS = {

--- a/src/pyscaffold/api/__init__.py
+++ b/src/pyscaffold/api/__init__.py
@@ -117,8 +117,7 @@ DEFAULT_OPTIONS = {
     "version": pyscaffold.__version__,
     "classifiers": ["Development Status :: 4 - Beta", "Programming Language :: Python"],
     "extensions": [],
-    "config_files": [f for f in [info.config_file(default=None)] if f and f.exists()]
-    #                ^ make sure the file exists before passing it ahead
+    "config_files": [],  # Overloaded in bootstrap_options for lazy evaluation
 }
 
 
@@ -136,9 +135,16 @@ def bootstrap_options(opts=None, **kwargs):
     opts = opts if opts else {}
     opts.update(kwargs)
     given_opts = opts
+
+    # Defaults:
     opts = DEFAULT_OPTIONS.copy()
-    opts.update({k: v for k, v in given_opts.items() if v not in (None, "")})
+    default_files = [info.config_file(default=None)]
+    opts["config_files"] = [f for f in default_files if f and f.exists()]
+    # ^ make sure the file exists before passing it ahead
+
+    opts.update({k: v for k, v in given_opts.items() if v or v is False})
     # ^  Remove empty items, so we ensure setdefault works
+
     return _read_existing_config(opts)
     # ^  Add options stored in config files
 

--- a/src/pyscaffold/contrib/__init__.py
+++ b/src/pyscaffold/contrib/__init__.py
@@ -13,19 +13,21 @@ Currently the contrib packages are:
 1) setuptools_scm v3.3.3
 2) pytest-runner 5.1
 3) configupdater 1.0
+4) appdirs 1.4.4
 
 The packages/modules were just copied over.
 """
 
 # Following dummy definitions are here in case PyScaffold version < 3
 # is still installed and setuptools checks the registered entry_points.
-SCM_HG_FILES_COMMAND = ''
-SCM_GIT_FILES_COMMAND = ''
+SCM_HG_FILES_COMMAND = ""
+SCM_GIT_FILES_COMMAND = ""
 
 
 def warn_about_deprecated_pyscaffold():
-    raise RuntimeError("A PyScaffold version less than 3.0 was detected, "
-                       "please upgrade!")
+    raise RuntimeError(
+        "A PyScaffold version less than 3.0 was detected, " "please upgrade!"
+    )
 
 
 def scm_find_files(*args, **kwargs):

--- a/src/pyscaffold/contrib/appdirs.py
+++ b/src/pyscaffold/contrib/appdirs.py
@@ -1,0 +1,655 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2005-2010 ActiveState Software Inc.
+# Copyright (c) 2013 Eddy Petrișor
+
+# vendor-ized file to avoid setup_requires problems. Original license:
+
+# # This is the MIT license
+#
+# Copyright (c) 2010 ActiveState Software Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+"""Utilities for determining application-specific dirs.
+
+See <http://github.com/ActiveState/appdirs> for details and usage.
+"""
+# Dev Notes:
+# - MSDN on where to store app data files:
+#   http://support.microsoft.com/default.aspx?scid=kb;en-us;310294#XSLTH3194121123120121120120
+# - Mac OS X: http://developer.apple.com/documentation/MacOSX/Conceptual/BPFileSystem/index.html
+# - XDG spec for Un*x: http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+
+__version__ = "1.4.4"
+__version_info__ = tuple(int(segment) for segment in __version__.split("."))
+
+
+import sys
+import os
+
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    unicode = str
+
+if sys.platform.startswith("java"):
+    import platform
+
+    os_name = platform.java_ver()[3][0]
+    if os_name.startswith("Windows"):  # "Windows XP", "Windows 7", etc.
+        system = "win32"
+    elif os_name.startswith("Mac"):  # "Mac OS X", etc.
+        system = "darwin"
+    else:  # "Linux", "SunOS", "FreeBSD", etc.
+        # Setting this to "linux2" is not ideal, but only Windows or Mac
+        # are actually checked for and the rest of the module expects
+        # *sys.platform* style strings.
+        system = "linux2"
+else:
+    system = sys.platform
+
+
+def user_data_dir(appname=None, appauthor=None, version=None, roaming=False):
+    r"""Return full path to the user-specific data dir for this application.
+
+        "appname" is the name of application.
+            If None, just the system directory is returned.
+        "appauthor" (only used on Windows) is the name of the
+            appauthor or distributing body for this application. Typically
+            it is the owning company name. This falls back to appname. You may
+            pass False to disable it.
+        "version" is an optional version path element to append to the
+            path. You might want to use this if you want multiple versions
+            of your app to be able to run independently. If used, this
+            would typically be "<major>.<minor>".
+            Only applied when appname is present.
+        "roaming" (boolean, default False) can be set True to use the Windows
+            roaming appdata directory. That means that for users on a Windows
+            network setup for roaming profiles, this user data will be
+            sync'd on login. See
+            <http://technet.microsoft.com/en-us/library/cc766489(WS.10).aspx>
+            for a discussion of issues.
+
+    Typical user data directories are:
+        Mac OS X:               ~/Library/Application Support/<AppName>
+        Unix:                   ~/.local/share/<AppName>    # or in $XDG_DATA_HOME, if defined
+        Win XP (not roaming):   C:\Documents and Settings\<username>\Application Data\<AppAuthor>\<AppName>
+        Win XP (roaming):       C:\Documents and Settings\<username>\Local Settings\Application Data\<AppAuthor>\<AppName>
+        Win 7  (not roaming):   C:\Users\<username>\AppData\Local\<AppAuthor>\<AppName>
+        Win 7  (roaming):       C:\Users\<username>\AppData\Roaming\<AppAuthor>\<AppName>
+
+    For Unix, we follow the XDG spec and support $XDG_DATA_HOME.
+    That means, by default "~/.local/share/<AppName>".
+    """
+    if system == "win32":
+        if appauthor is None:
+            appauthor = appname
+        const = roaming and "CSIDL_APPDATA" or "CSIDL_LOCAL_APPDATA"
+        path = os.path.normpath(_get_win_folder(const))
+        if appname:
+            if appauthor is not False:
+                path = os.path.join(path, appauthor, appname)
+            else:
+                path = os.path.join(path, appname)
+    elif system == "darwin":
+        path = os.path.expanduser("~/Library/Application Support/")
+        if appname:
+            path = os.path.join(path, appname)
+    else:
+        path = os.getenv("XDG_DATA_HOME", os.path.expanduser("~/.local/share"))
+        if appname:
+            path = os.path.join(path, appname)
+    if appname and version:
+        path = os.path.join(path, version)
+    return path
+
+
+def site_data_dir(appname=None, appauthor=None, version=None, multipath=False):
+    r"""Return full path to the user-shared data dir for this application.
+
+        "appname" is the name of application.
+            If None, just the system directory is returned.
+        "appauthor" (only used on Windows) is the name of the
+            appauthor or distributing body for this application. Typically
+            it is the owning company name. This falls back to appname. You may
+            pass False to disable it.
+        "version" is an optional version path element to append to the
+            path. You might want to use this if you want multiple versions
+            of your app to be able to run independently. If used, this
+            would typically be "<major>.<minor>".
+            Only applied when appname is present.
+        "multipath" is an optional parameter only applicable to *nix
+            which indicates that the entire list of data dirs should be
+            returned. By default, the first item from XDG_DATA_DIRS is
+            returned, or '/usr/local/share/<AppName>',
+            if XDG_DATA_DIRS is not set
+
+    Typical site data directories are:
+        Mac OS X:   /Library/Application Support/<AppName>
+        Unix:       /usr/local/share/<AppName> or /usr/share/<AppName>
+        Win XP:     C:\Documents and Settings\All Users\Application Data\<AppAuthor>\<AppName>
+        Vista:      (Fail! "C:\ProgramData" is a hidden *system* directory on Vista.)
+        Win 7:      C:\ProgramData\<AppAuthor>\<AppName>   # Hidden, but writeable on Win 7.
+
+    For Unix, this is using the $XDG_DATA_DIRS[0] default.
+
+    WARNING: Do not use this on Windows. See the Vista-Fail note above for why.
+    """
+    if system == "win32":
+        if appauthor is None:
+            appauthor = appname
+        path = os.path.normpath(_get_win_folder("CSIDL_COMMON_APPDATA"))
+        if appname:
+            if appauthor is not False:
+                path = os.path.join(path, appauthor, appname)
+            else:
+                path = os.path.join(path, appname)
+    elif system == "darwin":
+        path = os.path.expanduser("/Library/Application Support")
+        if appname:
+            path = os.path.join(path, appname)
+    else:
+        # XDG default for $XDG_DATA_DIRS
+        # only first, if multipath is False
+        path = os.getenv(
+            "XDG_DATA_DIRS", os.pathsep.join(["/usr/local/share", "/usr/share"])
+        )
+        pathlist = [
+            os.path.expanduser(x.rstrip(os.sep)) for x in path.split(os.pathsep)
+        ]
+        if appname:
+            if version:
+                appname = os.path.join(appname, version)
+            pathlist = [os.sep.join([x, appname]) for x in pathlist]
+
+        if multipath:
+            path = os.pathsep.join(pathlist)
+        else:
+            path = pathlist[0]
+        return path
+
+    if appname and version:
+        path = os.path.join(path, version)
+    return path
+
+
+def user_config_dir(appname=None, appauthor=None, version=None, roaming=False):
+    r"""Return full path to the user-specific config dir for this application.
+
+        "appname" is the name of application.
+            If None, just the system directory is returned.
+        "appauthor" (only used on Windows) is the name of the
+            appauthor or distributing body for this application. Typically
+            it is the owning company name. This falls back to appname. You may
+            pass False to disable it.
+        "version" is an optional version path element to append to the
+            path. You might want to use this if you want multiple versions
+            of your app to be able to run independently. If used, this
+            would typically be "<major>.<minor>".
+            Only applied when appname is present.
+        "roaming" (boolean, default False) can be set True to use the Windows
+            roaming appdata directory. That means that for users on a Windows
+            network setup for roaming profiles, this user data will be
+            sync'd on login. See
+            <http://technet.microsoft.com/en-us/library/cc766489(WS.10).aspx>
+            for a discussion of issues.
+
+    Typical user config directories are:
+        Mac OS X:               same as user_data_dir
+        Unix:                   ~/.config/<AppName>     # or in $XDG_CONFIG_HOME, if defined
+        Win *:                  same as user_data_dir
+
+    For Unix, we follow the XDG spec and support $XDG_CONFIG_HOME.
+    That means, by default "~/.config/<AppName>".
+    """
+    if system in ["win32", "darwin"]:
+        path = user_data_dir(appname, appauthor, None, roaming)
+    else:
+        path = os.getenv("XDG_CONFIG_HOME", os.path.expanduser("~/.config"))
+        if appname:
+            path = os.path.join(path, appname)
+    if appname and version:
+        path = os.path.join(path, version)
+    return path
+
+
+def site_config_dir(appname=None, appauthor=None, version=None, multipath=False):
+    r"""Return full path to the user-shared data dir for this application.
+
+        "appname" is the name of application.
+            If None, just the system directory is returned.
+        "appauthor" (only used on Windows) is the name of the
+            appauthor or distributing body for this application. Typically
+            it is the owning company name. This falls back to appname. You may
+            pass False to disable it.
+        "version" is an optional version path element to append to the
+            path. You might want to use this if you want multiple versions
+            of your app to be able to run independently. If used, this
+            would typically be "<major>.<minor>".
+            Only applied when appname is present.
+        "multipath" is an optional parameter only applicable to *nix
+            which indicates that the entire list of config dirs should be
+            returned. By default, the first item from XDG_CONFIG_DIRS is
+            returned, or '/etc/xdg/<AppName>', if XDG_CONFIG_DIRS is not set
+
+    Typical site config directories are:
+        Mac OS X:   same as site_data_dir
+        Unix:       /etc/xdg/<AppName> or $XDG_CONFIG_DIRS[i]/<AppName> for each value in
+                    $XDG_CONFIG_DIRS
+        Win *:      same as site_data_dir
+        Vista:      (Fail! "C:\ProgramData" is a hidden *system* directory on Vista.)
+
+    For Unix, this is using the $XDG_CONFIG_DIRS[0] default, if multipath=False
+
+    WARNING: Do not use this on Windows. See the Vista-Fail note above for why.
+    """
+    if system in ["win32", "darwin"]:
+        path = site_data_dir(appname, appauthor)
+        if appname and version:
+            path = os.path.join(path, version)
+    else:
+        # XDG default for $XDG_CONFIG_DIRS
+        # only first, if multipath is False
+        path = os.getenv("XDG_CONFIG_DIRS", "/etc/xdg")
+        pathlist = [
+            os.path.expanduser(x.rstrip(os.sep)) for x in path.split(os.pathsep)
+        ]
+        if appname:
+            if version:
+                appname = os.path.join(appname, version)
+            pathlist = [os.sep.join([x, appname]) for x in pathlist]
+
+        if multipath:
+            path = os.pathsep.join(pathlist)
+        else:
+            path = pathlist[0]
+    return path
+
+
+def user_cache_dir(appname=None, appauthor=None, version=None, opinion=True):
+    r"""Return full path to the user-specific cache dir for this application.
+
+        "appname" is the name of application.
+            If None, just the system directory is returned.
+        "appauthor" (only used on Windows) is the name of the
+            appauthor or distributing body for this application. Typically
+            it is the owning company name. This falls back to appname. You may
+            pass False to disable it.
+        "version" is an optional version path element to append to the
+            path. You might want to use this if you want multiple versions
+            of your app to be able to run independently. If used, this
+            would typically be "<major>.<minor>".
+            Only applied when appname is present.
+        "opinion" (boolean) can be False to disable the appending of
+            "Cache" to the base app data dir for Windows. See
+            discussion below.
+
+    Typical user cache directories are:
+        Mac OS X:   ~/Library/Caches/<AppName>
+        Unix:       ~/.cache/<AppName> (XDG default)
+        Win XP:     C:\Documents and Settings\<username>\Local Settings\Application Data\<AppAuthor>\<AppName>\Cache
+        Vista:      C:\Users\<username>\AppData\Local\<AppAuthor>\<AppName>\Cache
+
+    On Windows the only suggestion in the MSDN docs is that local settings go in
+    the `CSIDL_LOCAL_APPDATA` directory. This is identical to the non-roaming
+    app data dir (the default returned by `user_data_dir` above). Apps typically
+    put cache data somewhere *under* the given dir here. Some examples:
+        ...\Mozilla\Firefox\Profiles\<ProfileName>\Cache
+        ...\Acme\SuperApp\Cache\1.0
+    OPINION: This function appends "Cache" to the `CSIDL_LOCAL_APPDATA` value.
+    This can be disabled with the `opinion=False` option.
+    """
+    if system == "win32":
+        if appauthor is None:
+            appauthor = appname
+        path = os.path.normpath(_get_win_folder("CSIDL_LOCAL_APPDATA"))
+        if appname:
+            if appauthor is not False:
+                path = os.path.join(path, appauthor, appname)
+            else:
+                path = os.path.join(path, appname)
+            if opinion:
+                path = os.path.join(path, "Cache")
+    elif system == "darwin":
+        path = os.path.expanduser("~/Library/Caches")
+        if appname:
+            path = os.path.join(path, appname)
+    else:
+        path = os.getenv("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
+        if appname:
+            path = os.path.join(path, appname)
+    if appname and version:
+        path = os.path.join(path, version)
+    return path
+
+
+def user_state_dir(appname=None, appauthor=None, version=None, roaming=False):
+    r"""Return full path to the user-specific state dir for this application.
+
+        "appname" is the name of application.
+            If None, just the system directory is returned.
+        "appauthor" (only used on Windows) is the name of the
+            appauthor or distributing body for this application. Typically
+            it is the owning company name. This falls back to appname. You may
+            pass False to disable it.
+        "version" is an optional version path element to append to the
+            path. You might want to use this if you want multiple versions
+            of your app to be able to run independently. If used, this
+            would typically be "<major>.<minor>".
+            Only applied when appname is present.
+        "roaming" (boolean, default False) can be set True to use the Windows
+            roaming appdata directory. That means that for users on a Windows
+            network setup for roaming profiles, this user data will be
+            sync'd on login. See
+            <http://technet.microsoft.com/en-us/library/cc766489(WS.10).aspx>
+            for a discussion of issues.
+
+    Typical user state directories are:
+        Mac OS X:  same as user_data_dir
+        Unix:      ~/.local/state/<AppName>   # or in $XDG_STATE_HOME, if defined
+        Win *:     same as user_data_dir
+
+    For Unix, we follow this Debian proposal <https://wiki.debian.org/XDGBaseDirectorySpecification#state>
+    to extend the XDG spec and support $XDG_STATE_HOME.
+
+    That means, by default "~/.local/state/<AppName>".
+    """
+    if system in ["win32", "darwin"]:
+        path = user_data_dir(appname, appauthor, None, roaming)
+    else:
+        path = os.getenv("XDG_STATE_HOME", os.path.expanduser("~/.local/state"))
+        if appname:
+            path = os.path.join(path, appname)
+    if appname and version:
+        path = os.path.join(path, version)
+    return path
+
+
+def user_log_dir(appname=None, appauthor=None, version=None, opinion=True):
+    r"""Return full path to the user-specific log dir for this application.
+
+        "appname" is the name of application.
+            If None, just the system directory is returned.
+        "appauthor" (only used on Windows) is the name of the
+            appauthor or distributing body for this application. Typically
+            it is the owning company name. This falls back to appname. You may
+            pass False to disable it.
+        "version" is an optional version path element to append to the
+            path. You might want to use this if you want multiple versions
+            of your app to be able to run independently. If used, this
+            would typically be "<major>.<minor>".
+            Only applied when appname is present.
+        "opinion" (boolean) can be False to disable the appending of
+            "Logs" to the base app data dir for Windows, and "log" to the
+            base cache dir for Unix. See discussion below.
+
+    Typical user log directories are:
+        Mac OS X:   ~/Library/Logs/<AppName>
+        Unix:       ~/.cache/<AppName>/log  # or under $XDG_CACHE_HOME if defined
+        Win XP:     C:\Documents and Settings\<username>\Local Settings\Application Data\<AppAuthor>\<AppName>\Logs
+        Vista:      C:\Users\<username>\AppData\Local\<AppAuthor>\<AppName>\Logs
+
+    On Windows the only suggestion in the MSDN docs is that local settings
+    go in the `CSIDL_LOCAL_APPDATA` directory. (Note: I'm interested in
+    examples of what some windows apps use for a logs dir.)
+
+    OPINION: This function appends "Logs" to the `CSIDL_LOCAL_APPDATA`
+    value for Windows and appends "log" to the user cache dir for Unix.
+    This can be disabled with the `opinion=False` option.
+    """
+    if system == "darwin":
+        path = os.path.join(os.path.expanduser("~/Library/Logs"), appname)
+    elif system == "win32":
+        path = user_data_dir(appname, appauthor, version)
+        version = False
+        if opinion:
+            path = os.path.join(path, "Logs")
+    else:
+        path = user_cache_dir(appname, appauthor, version)
+        version = False
+        if opinion:
+            path = os.path.join(path, "log")
+    if appname and version:
+        path = os.path.join(path, version)
+    return path
+
+
+class AppDirs(object):
+    """Convenience wrapper for getting application dirs."""
+
+    def __init__(
+        self, appname=None, appauthor=None, version=None, roaming=False, multipath=False
+    ):
+        self.appname = appname
+        self.appauthor = appauthor
+        self.version = version
+        self.roaming = roaming
+        self.multipath = multipath
+
+    @property
+    def user_data_dir(self):
+        return user_data_dir(
+            self.appname, self.appauthor, version=self.version, roaming=self.roaming
+        )
+
+    @property
+    def site_data_dir(self):
+        return site_data_dir(
+            self.appname, self.appauthor, version=self.version, multipath=self.multipath
+        )
+
+    @property
+    def user_config_dir(self):
+        return user_config_dir(
+            self.appname, self.appauthor, version=self.version, roaming=self.roaming
+        )
+
+    @property
+    def site_config_dir(self):
+        return site_config_dir(
+            self.appname, self.appauthor, version=self.version, multipath=self.multipath
+        )
+
+    @property
+    def user_cache_dir(self):
+        return user_cache_dir(self.appname, self.appauthor, version=self.version)
+
+    @property
+    def user_state_dir(self):
+        return user_state_dir(self.appname, self.appauthor, version=self.version)
+
+    @property
+    def user_log_dir(self):
+        return user_log_dir(self.appname, self.appauthor, version=self.version)
+
+
+# ---- internal support stuff
+
+
+def _get_win_folder_from_registry(csidl_name):
+    """This is a fallback technique at best. I'm not sure if using the
+    registry for this guarantees us the correct answer for all CSIDL_*
+    names.
+    """
+    if PY3:
+        import winreg as _winreg
+    else:
+        import _winreg
+
+    shell_folder_name = {
+        "CSIDL_APPDATA": "AppData",
+        "CSIDL_COMMON_APPDATA": "Common AppData",
+        "CSIDL_LOCAL_APPDATA": "Local AppData",
+    }[csidl_name]
+
+    key = _winreg.OpenKey(
+        _winreg.HKEY_CURRENT_USER,
+        r"Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders",
+    )
+    dir, type = _winreg.QueryValueEx(key, shell_folder_name)
+    return dir
+
+
+def _get_win_folder_with_pywin32(csidl_name):
+    from win32com.shell import shellcon, shell
+
+    dir = shell.SHGetFolderPath(0, getattr(shellcon, csidl_name), 0, 0)
+    # Try to make this a unicode path because SHGetFolderPath does
+    # not return unicode strings when there is unicode data in the
+    # path.
+    try:
+        dir = unicode(dir)
+
+        # Downgrade to short path name if have highbit chars. See
+        # <http://bugs.activestate.com/show_bug.cgi?id=85099>.
+        has_high_char = False
+        for c in dir:
+            if ord(c) > 255:
+                has_high_char = True
+                break
+        if has_high_char:
+            try:
+                import win32api
+
+                dir = win32api.GetShortPathName(dir)
+            except ImportError:
+                pass
+    except UnicodeError:
+        pass
+    return dir
+
+
+def _get_win_folder_with_ctypes(csidl_name):
+    import ctypes
+
+    csidl_const = {
+        "CSIDL_APPDATA": 26,
+        "CSIDL_COMMON_APPDATA": 35,
+        "CSIDL_LOCAL_APPDATA": 28,
+    }[csidl_name]
+
+    buf = ctypes.create_unicode_buffer(1024)
+    ctypes.windll.shell32.SHGetFolderPathW(None, csidl_const, None, 0, buf)
+
+    # Downgrade to short path name if have highbit chars. See
+    # <http://bugs.activestate.com/show_bug.cgi?id=85099>.
+    has_high_char = False
+    for c in buf:
+        if ord(c) > 255:
+            has_high_char = True
+            break
+    if has_high_char:
+        buf2 = ctypes.create_unicode_buffer(1024)
+        if ctypes.windll.kernel32.GetShortPathNameW(buf.value, buf2, 1024):
+            buf = buf2
+
+    return buf.value
+
+
+def _get_win_folder_with_jna(csidl_name):
+    import array
+    from com.sun import jna
+    from com.sun.jna.platform import win32
+
+    buf_size = win32.WinDef.MAX_PATH * 2
+    buf = array.zeros("c", buf_size)
+    shell = win32.Shell32.INSTANCE
+    shell.SHGetFolderPath(
+        None,
+        getattr(win32.ShlObj, csidl_name),
+        None,
+        win32.ShlObj.SHGFP_TYPE_CURRENT,
+        buf,
+    )
+    dir = jna.Native.toString(buf.tostring()).rstrip("\0")
+
+    # Downgrade to short path name if have highbit chars. See
+    # <http://bugs.activestate.com/show_bug.cgi?id=85099>.
+    has_high_char = False
+    for c in dir:
+        if ord(c) > 255:
+            has_high_char = True
+            break
+    if has_high_char:
+        buf = array.zeros("c", buf_size)
+        kernel = win32.Kernel32.INSTANCE
+        if kernel.GetShortPathName(dir, buf, buf_size):
+            dir = jna.Native.toString(buf.tostring()).rstrip("\0")
+
+    return dir
+
+
+if system == "win32":
+    try:
+        import win32com.shell
+
+        _get_win_folder = _get_win_folder_with_pywin32
+    except ImportError:
+        try:
+            from ctypes import windll
+
+            _get_win_folder = _get_win_folder_with_ctypes
+        except ImportError:
+            try:
+                import com.sun.jna
+
+                _get_win_folder = _get_win_folder_with_jna
+            except ImportError:
+                _get_win_folder = _get_win_folder_from_registry
+
+
+# ---- self test code
+
+if __name__ == "__main__":
+    appname = "MyApp"
+    appauthor = "MyCompany"
+
+    props = (
+        "user_data_dir",
+        "user_config_dir",
+        "user_cache_dir",
+        "user_state_dir",
+        "user_log_dir",
+        "site_data_dir",
+        "site_config_dir",
+    )
+
+    print("-- app dirs %s --" % __version__)
+
+    print("-- app dirs (with optional 'version')")
+    dirs = AppDirs(appname, appauthor, version="1.0")
+    for prop in props:
+        print("%s: %s" % (prop, getattr(dirs, prop)))
+
+    print("\n-- app dirs (without optional 'version')")
+    dirs = AppDirs(appname, appauthor)
+    for prop in props:
+        print("%s: %s" % (prop, getattr(dirs, prop)))
+
+    print("\n-- app dirs (without optional 'appauthor')")
+    dirs = AppDirs(appname)
+    for prop in props:
+        print("%s: %s" % (prop, getattr(dirs, prop)))
+
+    print("\n-- app dirs (with disabled 'appauthor')")
+    dirs = AppDirs(appname, appauthor=False)
+    for prop in props:
+        print("%s: %s" % (prop, getattr(dirs, prop)))

--- a/src/pyscaffold/exceptions.py
+++ b/src/pyscaffold/exceptions.py
@@ -102,5 +102,14 @@ class NoPyScaffoldProject(RuntimeError):
 class ShellCommandException(RuntimeError):
     """Outputs proper logging when a ShellCommand fails"""
 
-    def __init__(self, message, *args, **kwargs):
+
+class ImpossibleToFindConfigDir(RuntimeError):
+    """An expected error occurred when trying to find the config dir.
+
+    This might be related to not being able to read the $HOME env var in Unix
+    systems, or %USERPROFILE% in Windows, or even the username.
+    """
+
+    def __init__(self, message=None, *args, **kwargs):
+        message = message or self.__class__.__doc__
         super().__init__(message, *args, **kwargs)

--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -265,7 +265,7 @@ def config_dir(prog=PKG_NAME, org=None, default=RAISE_EXCEPTION):
         put the configs.
     """
     try:
-        return Path(appdirs.user_config_dir(prog, org))
+        return Path(appdirs.user_config_dir(prog, org, roaming=True))
     except Exception as ex:
         if default is not RAISE_EXCEPTION:
             logger.debug("Error when trying to find config dir %s", ex, exc_info=True)

--- a/src/pyscaffold/update.py
+++ b/src/pyscaffold/update.py
@@ -111,6 +111,9 @@ def read_setupcfg(path, filename=None):
 
     updater = ConfigUpdater()
     updater.read(path, encoding="utf-8")
+
+    logger.report("read", path)
+
     return updater
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,18 +99,18 @@ def fake_home(tmp_path, monkeypatch):
     Avoid interference of an existing config dir in the developer's
     machine
     """
-    fake_home = tmp_path / ("home" + uniqstr())
-    fake_home.mkdir()
-    _config_git(fake_home)
+    fake = tmp_path / ("home" + uniqstr())
+    fake.mkdir()
+    _config_git(fake)
 
     original_expand = os.path.expanduser
     monkeypatch.setattr(
-        "os.path.expanduser", _fake_expanduser(original_expand, fake_home)
+        "os.path.expanduser", _fake_expanduser(original_expand, fake)
     )
-    monkeypatch.setenv("HOME", str(fake_home))
-    monkeypatch.setenv("USERPROFILE", str(fake_home))  # Windows?
+    monkeypatch.setenv("HOME", str(fake))
+    monkeypatch.setenv("USERPROFILE", str(fake))  # Windows?
 
-    yield fake_home
+    yield fake
 
 
 @pytest.fixture(autouse=True)
@@ -119,8 +119,9 @@ def fake_xdg_config_home(fake_home, monkeypatch):
     Avoid interference of an existing config dir in the developer's
     machine
     """
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(fake_home))
-    yield fake_xdg_config_home
+    home = str(fake_home)
+    monkeypatch.setenv("XDG_CONFIG_HOME", home)
+    yield home
 
 
 @pytest.fixture(autouse=True)
@@ -142,6 +143,7 @@ def venv(fake_home, fake_xdg_config_home):
 
     virtualenv = VirtualEnv()
     virtualenv.env["HOME"] = str(fake_home)
+    virtualenv.env["USERPROFILE"] = str(fake_home)
     virtualenv.env["XDG_CONFIG_HOME"] = str(fake_xdg_config_home)
     return virtualenv
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,18 @@ def command_exception(content):
     return ShellCommandException(content)
 
 
+@pytest.fixture(autouse=True)
+def with_tmp_config_dir(tmp_path, monkeypatch):
+    """
+    Avoid interference of an existing config dir in the developer's
+    machine
+    """
+    confdir = tmp_path / ("conf" + uniqstr())
+    confdir.mkdir()
+    monkeypatch.setattr("pyscaffold.info.config_dir", lambda *_, **__: confdir)
+    yield confdir
+
+
 @pytest.fixture
 def venv():
     """Create a virtualenv for each test"""

--- a/tests/extensions/test_tox.py
+++ b/tests/extensions/test_tox.py
@@ -43,7 +43,7 @@ def test_cli_with_tox(tmpfolder):
 
 def test_cli_without_tox(tmpfolder):
     # Given the command line without the tox option,
-    sys.argv = ["pyscaffold", "proj"]
+    sys.argv = ["pyscaffold", "proj", "-vv"]
 
     # when pyscaffold runs,
     run()

--- a/tests/system/test_common.py
+++ b/tests/system/test_common.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 import sys
 from os import environ
 from os.path import exists, isdir
@@ -213,5 +214,16 @@ def test_new_project_does_not_fail_pre_commit(cwd):
     with cwd.join(name).as_cwd():
         # then the newly generated files should not result in errors when
         # pre-commit runs...
-        run("pre-commit install")
-        run("pre-commit run --all")
+        try:
+            run("pre-commit install")
+            run("pre-commit run --all")
+        except CalledProcessError as ex:
+            if os.name == "nt" and (
+                "filename or extension is too long"
+                in ((ex.stdout or "") + (ex.stderr or ""))
+            ):
+                pytest.skip("Sometimes Windows have problems with nested files")
+                # Even if we try to change that by configuring the CI
+                # environment
+            else:
+                raise

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from importlib import reload
 from os.path import getmtime
 from pathlib import Path
 
@@ -280,7 +279,7 @@ def test_bootstrap_using_config_file(tmpfolder):
 
 
 @pytest.fixture
-def with_default_config(with_tmp_config_dir):
+def with_default_config(fake_config_dir):
     config = """\
     [metadata]
     name = project
@@ -294,27 +293,18 @@ def with_default_config(with_tmp_config_dir):
         travis
     namespace = my_namespace.my_sub_namespace
     """
-    tmp = with_tmp_config_dir
-    cfg = tmp / info.DEFAULT_CONFIG_FILE
+    cfg = fake_config_dir / info.DEFAULT_CONFIG_FILE
     cfg.write_text(config)
 
-    from pyscaffold import api
-
-    reload(api)
-    # ^  since DEFAULT_OPTIONS is evaluated eagerly, we need to reload the API
-    #    so the monkeypatch takes place
-    yield (tmp, api)
-
-    cfg.unlink()
-    reload(api)
+    yield cfg
 
 
 def test_bootstrap_with_default_config(tmpfolder, with_default_config):
     # Given a default config file exists and contains stuff
-    _, api = with_default_config
+    _ = with_default_config
     # when bootstrapping options
     opts = dict(project_path="xoxo", url="")
-    new_opts = api.bootstrap_options(opts)
+    new_opts = bootstrap_options(opts)
     # the stuff will be considered
     assert new_opts["name"] == "project"
     assert new_opts["author"] == "John Doe"
@@ -328,10 +318,10 @@ def test_bootstrap_with_default_config(tmpfolder, with_default_config):
 
 def test_create_project_with_default_config(tmpfolder, with_default_config):
     # Given a default config file exists and contains stuff
-    _, api = with_default_config
+    _ = with_default_config
     project = Path(str(tmpfolder)) / "xoxo"
     # when a new project is created
-    api.create_project(project_path="xoxo")
+    create_project(project_path="xoxo")
     # then the default config is considered
     assert (project / "src/my_namespace/my_sub_namespace/project").exists()
     assert (project / "tox.ini").exists()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -152,7 +152,7 @@ class VenvManager(object):
                 return self.venv.run(cmd, capture=True, **kwargs).strip()
 
     def get_file(self, path):
-        return self.run("cat {}".format(path))
+        return Path(path).read_text()
 
 
 @pytest.fixture


### PR DESCRIPTION
As discussed in #236, this commit introduces the ability of storing your
"favourite" configuration for PyScaffold in a config file in the user's
home directory:

- OSX: ~/Library/Preferences/pyscaffold/default.cfg (or something like that)
- Windows: C:\Users\<username>\AppData\Local\pyscaffold\pyscaffold\default.cfg
- Linux/Others: $XDG_CONFIG_HOME/pyscaffold/default.cfg with fallback to ~/.config/pyscaffold/default.cfg

In order to provide these nice and compliant defaults, this commit
introduces a new vendorised package (`appdirs`) inside pyscaffold.contrib.
This is done to avoid adding dependencies to PyScaffold itself.
The `appdirs` module is very small and MIT-licensed, but rewriting its
features would be painful and require lots of efforts, specially for
testing. I assume that this feature is highly valuable for PyScaffold's
users (it gets really tedious after a while to type the same extensions
all the time), and therefore it is worthy.

There is an on going discussion about simplifying PyScaffold to not be
required in build time and therefore eliminating the needs for
vendorising dependencies. With the current written code, that is very
easy to change.

Future works not included in this PR:
- Add a `--config` flag to the CLI to specify passing a different config
  file/ `NO_CONFIG`.

Closes #236.