### PR TITLE
Remove coverage combine from CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -181,5 +181,4 @@ coverage_task:
     - pre-commit run --all-files
   <<: *REGULAR_TASK_TEMPLATE
   coverage_script:
-    - coverage combine .coverage
     - coveralls


### PR DESCRIPTION
It seams that now pytest-cov and pytest-dist work very well together and
already do `coverage combine` before the tests finish running.

Closes #285.