### PR TITLE
Improve Cirrus CI for Windows and OSX

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,53 +9,40 @@ env:
   LC_ALL: C.UTF-8
   LANG: C.UTF-8
   COVERAGE: NO
-  PIPX: pipx
-
-# Use custom cloning since otherwise git tags are missing
-.clone_script: &clone_script |
-  if [ -z "$CIRRUS_PR" ]; then
-    git clone --recursive --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
-    git reset --hard $CIRRUS_CHANGE_IN_REPO
-  else
-    git clone --recursive https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
-    git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
-    git reset --hard $CIRRUS_CHANGE_IN_REPO
-  fi
 
 # This template is used in all tasks
 .regular_task_template: &REGULAR_TASK_TEMPLATE
   tox_install_script:
-    # Tox is a bit exigent about the name of the python executable,
-    # (for example, tox requires a `python3.7` to be available)
-    # and the shape of the directory python is installed to.
-    # Because of that, some errors might appear in some kinds of installation
-    # (e.g. OSX with homebrew).
-    # Luckily, pipx install tox inside its own unique virtualenv, which
-    # resembles a very standard installation directory.
-    # So here we install tox using pipx to avoid such problems
-    - python -m pip install --upgrade pip setuptools
-    - python -m pip install --user $PIPX
-    - pipx install tox
+    - python -m pip install --upgrade pip setuptools tox
   prepare_script: &prepare_script
-    # This particular script is also used in Windows, so the shell is not POSIX
+    # This script is also used in Windows, so the shell is not POSIX
     - git config --global user.email "you@example.com"
     - git config --global user.name "Your Name"
   clean_workspace_script:
     # Avoid information carried from one run to the other
     - rm -rf .coverage junit-*.xml .tox
-  test_script:
+  test_script: &test_script
+    # This script is also used in Windows, so the shell is not POSIX
     - python setup.py egg_info --egg-base .
-    - tox -e all -- -n 5 -rfEx --durations 10 --color yes
+    - python -m tox -e all -- -n 5 -rfEx --durations 10 --color yes
+    # ^  tox is better if invoked as a module on Windows/OSX
 
 
 # Task definitions:
 linux_mac_task:
-  clone_script: *clone_script
+  # Use custom cloning since otherwise git tags are missing
+  clone_script: &clone_script |
+    if [ -z "$CIRRUS_PR" ]; then
+      git clone --recursive --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+      git reset --hard $CIRRUS_CHANGE_IN_REPO
+    else
+      git clone --recursive https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+      git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
+      git reset --hard $CIRRUS_CHANGE_IN_REPO
+    fi
   matrix:
     - name: test (Linux - 3.5)
       container: {image: "python:3.5-buster"}
-      env:
-        PIPX: pipx==0.1.0
       pip_cache: &pip-cache
         folder: $PIP_CACHE
       install_script: &debian-install
@@ -101,6 +88,7 @@ windows_task:
       - ps: echo "$env:CIRRUS_OS - nuget v5.6.0 - git v2.27.0"
     populate_script:
       - ps: (mkdir 'C:\tools')
+      # ^  use parentheses to suppress errors
       - ps: Invoke-WebRequest -OutFile 'C:\tools\nuget.exe' 'https://dist.nuget.org/win-x86-commandline/v5.6.0/nuget.exe'
       - ps: nuget install GitForWindows -Version 2.27.0 -NonInteractive -OutputDirectory 'C:\tools'
   workaround_git_script:
@@ -149,11 +137,7 @@ windows_task:
     # Avoid information carried from one run to the other
     # CMD is not capable of globbing, so we have to use PowerShell
     - ps: (rm -Recurse -Force -ErrorAction SilentlyContinue .tox,junit-*.xml)
-    # ^  use parentheses to suppress errors
-  test_script:
-    - ps: python setup.py egg_info --egg-base .
-    - ps: python -m tox -e all -- -n 5 -rfEx --durations 10 --color yes
-    # ^  tox exe is not on Path by default
+  test_script: *test_script
 
 
 coverage_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -143,9 +143,7 @@ windows_task:
     # Set Windows encoding to UTF-8
     - REG ADD "HKEY_CURRENT_USER\Software\Microsoft\Command Processor" /v Autorun /t REG_SZ /d "@chcp 65001>nul" /f
     - python -m ensurepip
-    - python -m pip install -U --user pip setuptools certifi
-    - python -m pip install -U --user tox pytest-cov pytest-xdist pytest-virtualenv pytest-shutil pytest-fixture-config cookiecutter django
-    - python -m pip list
+    - python -m pip install -U --user pip setuptools certifi tox
   prepare_script: *prepare_script
   clean_workspace_script:
     # Avoid information carried from one run to the other

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ env:
     # Luckily, pipx install tox inside its own unique virtualenv, which
     # resembles a very standard installation directory.
     # So here we install tox using pipx to avoid such problems
-    - python -m pip install --upgrade pip
+    - python -m pip install --upgrade pip setuptools
     - python -m pip install --user $PIPX
     - pipx install tox
   prepare_script: &prepare_script
@@ -143,13 +143,12 @@ windows_task:
     # Set Windows encoding to UTF-8
     - REG ADD "HKEY_CURRENT_USER\Software\Microsoft\Command Processor" /v Autorun /t REG_SZ /d "@chcp 65001>nul" /f
     - python -m ensurepip
-    - python -m pip install -U --user pip setuptools certifi tox
+    - python -m pip install --upgrade --user pip setuptools certifi tox
   prepare_script: *prepare_script
   clean_workspace_script:
     # Avoid information carried from one run to the other
     # CMD is not capable of globbing, so we have to use PowerShell
-    - ps: (rm junit-*.xml)
-    - ps: (rm -Recurse -Force .tox)
+    - ps: (rm -Recurse -Force -ErrorAction SilentlyContinue .tox,junit-*.xml)
     # ^  use parentheses to suppress errors
   test_script:
     - ps: python setup.py egg_info --egg-base .

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,15 +4,15 @@ auto_cancellation: false
 env:
   PATH: ${HOME}/.local/bin:${PATH}
   # ^  add user paths
-  COVERALLS_REPO_TOKEN: lScFGt1v3B8mes62l8VeOldqGGUC4Up8R
+  COVERALLS_REPO_TOKEN: ENCRYPTED[7ada9fe1105610d2b5ac314f5eb4cc2fea3d42a5fa1e1bfa263000277146022b71b80f7d2f00dc6058e08bd1c9034be7]
   PIP_CACHE: ${HOME}/.cache/pip
   LC_ALL: C.UTF-8
   LANG: C.UTF-8
   COVERAGE: NO
   PIPX: pipx
 
-# use custom cloning since otherwise git tags are missing
-clone_script: &clone_script |
+# Use custom cloning since otherwise git tags are missing
+.clone_script: &clone_script |
   if [ -z "$CIRRUS_PR" ]; then
     git clone --recursive --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
     git reset --hard $CIRRUS_CHANGE_IN_REPO
@@ -23,7 +23,7 @@ clone_script: &clone_script |
   fi
 
 # This template is used in all tasks
-regular_task_template: &REGULAR_TASK_TEMPLATE
+.regular_task_template: &REGULAR_TASK_TEMPLATE
   tox_install_script:
     # Tox is a bit exigent about the name of the python executable,
     # (for example, tox requires a `python3.7` to be available)
@@ -37,10 +37,12 @@ regular_task_template: &REGULAR_TASK_TEMPLATE
     - python -m pip install --user $PIPX
     - pipx install tox
   prepare_script: &prepare_script
+    # This particular script is also used in Windows, so the shell is not POSIX
     - git config --global user.email "you@example.com"
     - git config --global user.name "Your Name"
-    - rm -rf .coverage junit-*.xml
-    # ^  avoid information carried from one run to the other
+  clean_workspace_script:
+    # Avoid information carried from one run to the other
+    - rm -rf .coverage junit-*.xml .tox
   test_script:
     - python setup.py egg_info --egg-base .
     - tox -e all -- -n 5 -rfEx --durations 10 --color yes
@@ -78,8 +80,7 @@ linux_mac_task:
       osx_instance: {image: "catalina-xcode"}
       env:
         PYTHON_VERSION: 3.7
-        # ^ it is important to update this env vars when the default version
-        #   of python in homebrew changes
+        # ^  update when the default version of python in homebrew changes
         PATH: "${HOME}/.local/bin:${HOME}/Library/Python/${PYTHON_VERSION}/bin:/usr/local/opt/python/libexec/bin:${PATH}"
         # ^  add user and homebrew paths
         PIP_CACHE: "${HOME}/Library/Caches/pip"
@@ -94,9 +95,18 @@ linux_mac_task:
 
 windows_task:
   name: test (Windows)
+  tools_cache:
+    folder: 'C:\tools'
+    fingerprint_script:
+      - ps: echo "$env:CIRRUS_OS - nuget v5.6.0 - git v2.27.0"
+    populate_script:
+      - ps: (mkdir 'C:\tools')
+      - ps: Invoke-WebRequest -OutFile 'C:\tools\nuget.exe' 'https://dist.nuget.org/win-x86-commandline/v5.6.0/nuget.exe'
+      - ps: nuget install GitForWindows -Version 2.27.0 -NonInteractive -OutputDirectory 'C:\tools'
   workaround_git_script:
     - git config --system core.longpaths true  # Fix for windows git checkout problems
   clone_script:
+    # Use custom cloning since otherwise git tags are missing
     CMD.exe /C ECHO ON &
     IF NOT DEFINED CIRRUS_PR (
     git clone --recursive --branch=%CIRRUS_BRANCH% https://x-access-token:%CIRRUS_REPO_CLONE_TOKEN%@github.com/%CIRRUS_REPO_FULL_NAME%.git %CIRRUS_WORKING_DIR% &
@@ -107,32 +117,24 @@ windows_task:
     git reset --hard %CIRRUS_CHANGE_IN_REPO%
     )
   windows_container:
-    image: "cirrusci/windowsservercore:cmake"
-    # ^  this image have MSYS2 pre-installed, which means we can use some
-    #    of the GNU tools (like the `rm` command)
+    image: "python:3.8-windowsservercore"
     os_version: 2019
   env:
-    # Single quotes are used bellow to escape Windows backslash and %
-    # (YAML restrictions).
-    PYTHON_HOME: 'C:\Python38'
+    # Single quotes are used bellow to escape Windows backslash and % (YAML restrictions).
+    PYTHON_HOME: 'C:\Python'
     PYTHON_APPDATA: '%APPDATA%\Python\Python38'
-    # ^ it is important to update these 2 env vars when the default version
-    #   of python in chocolatey changes
-    MSYS_HOME: 'C:\tools\msys64'
+    # ^  update when python version changes
+    GIT_HOME: 'C:\tools\GitForWindows.2.27.0\tools'
+    # ^ update when git version changes
     HOME: '%USERPROFILE%'
-    USERNAME: 'ContainerAdministrator'
-    # ^  Ensure USERNAME is set in Windows, so the getpass module doesn't
-    #    raise exceptions
-    ToolsDir: 'C:\tools'
-    PATH: '%HOME%\.local\bin\;%PYTHON_APPDATA%\Scripts\;%PYTHON_HOME%\;%PYTHON_HOME%\Scripts\;%MSYS_HOME%\bin\;%MSYS_HOME%\usr\bin\;%MSYS_HOME%\usr\local\bin\;%PATH%'
-    # ^  add user, chocolatey and msys paths
-    CHOCOLATEY_CACHE: '%LocalAppData%\chocolatey\Cache'
+    USERNAME: ContainerAdministrator
+    # ^  ensure USERNAME is set in Windows, so the getpass module doesn't raise exceptions
+    PATH: '%HOME%\.local\bin\;%PYTHON_APPDATA%\Scripts\;%PYTHON_HOME%\;%PYTHON_HOME%\Scripts\;C:\tools\;%GIT_HOME%\cmd\;%GIT_HOME%\usr\bin\;%PATH%'
+    # ^  add user paths
     PIP_CACHE: '%LocalAppData%\pip\Cache'
     PIP_TRUSTED_HOST: 'pypi.org pypi.python.org files.pythonhosted.org'
     PIP_CONFIG_FILE: '%AppData%\pip\pip.ini'
     COVERAGE: 'NO'
-  chocolatey_cache:
-    folder: '%CHOCOLATEY_CACHE%'
   pip_cache:
     folder: '%PIP_CACHE%'
   install_script:
@@ -140,20 +142,21 @@ windows_task:
     - REG ADD HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f
     # Set Windows encoding to UTF-8
     - REG ADD "HKEY_CURRENT_USER\Software\Microsoft\Command Processor" /v Autorun /t REG_SZ /d "@chcp 65001>nul" /f
-    - choco config set cacheLocation %CHOCOLATEY_CACHE%
-    - choco install --no-progress -y python --version=3.8.1
     - python -m ensurepip
     - python -m pip install -U --user pip setuptools certifi
     - python -m pip install -U --user tox pytest-cov pytest-xdist pytest-virtualenv pytest-shutil pytest-fixture-config cookiecutter django
     - python -m pip list
   prepare_script: *prepare_script
-  windows_clean_script:
-    # use parentheses to suppress errors
+  clean_workspace_script:
+    # Avoid information carried from one run to the other
+    # CMD is not capable of globbing, so we have to use PowerShell
     - ps: (rm junit-*.xml)
     - ps: (rm -Recurse -Force .tox)
+    # ^  use parentheses to suppress errors
   test_script:
-    - ps: python setup.py egg_info
+    - ps: python setup.py egg_info --egg-base .
     - ps: python -m tox -e all -- -n 5 -rfEx --durations 10 --color yes
+    # ^  tox exe is not on Path by default
 
 
 coverage_task:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -132,9 +132,14 @@ Troubleshooting
     I've got a strange error related to versions in ``test_update.py`` when
     executing the test suite or about an *entry_point* that cannot be found.
 
-Try to remove all the egg files or the complete egg folder, i.e. ``.eggs``, as well
-as the ``*.egg-info`` folders in the ``src`` folder or potentially in the root of your
-project. Afterwards run ``python setup.py egg_info --egg-base .`` again.
+Make sure to fetch all the tags from the upstream repository, the command ``git
+describe --abbrev=0 --tags`` should return the version you are expecting. If
+you are trying to run the CI scripts in a fork repository, make sure to push
+all the tags.
+You can also try to remove all the egg files or the complete egg folder, i.e.
+``.eggs``, as well as the ``*.egg-info`` folders in the ``src`` folder or
+potentially in the root of your project. Afterwards run ``python setup.py
+egg_info --egg-base .`` again.
 
 .. _Cirrus-CI: https://cirrus-ci.com/github/pyscaffold/pyscaffold
 .. _PyPI: https://pypi.python.org/

--- a/README.rst
+++ b/README.rst
@@ -171,7 +171,7 @@ PyScaffold comes with several extensions:
   after having installed `pyscaffoldext-dsproject`_.
 
 * Create a `Django project`_ with the flag ``--django`` which is equivalent to
-  ``django-admin.py startproject my_project`` enhanced by PyScaffold's features.
+  ``django-admin startproject my_project`` enhanced by PyScaffold's features.
 
 * Create a template for your own PyScaffold extension with ``--custom-extension``
   after having installed `pyscaffoldext-custom-extension`_ with ``pip``.

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -255,7 +255,7 @@ PyScaffold comes with several extensions:
   after having installed `pyscaffoldext-dsproject`_.
 
 * Create a `Django project`_ with the flag ``--django`` which is equivalent to
-  ``django-admin.py startproject my_project`` enhanced by PyScaffold's features.
+  ``django-admin startproject my_project`` enhanced by PyScaffold's features.
 
 * Create a template for your own PyScaffold extension with ``--custom-extension``
   after having installed `pyscaffoldext-custom-extension`_ with ``pip``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,8 @@ ds =
     pyscaffoldext-dsproject
 # Add here test dependencies (used by tox)
 testing =
+    django
+    cookiecutter
     sphinx  # required for system tests
     flake8  # required for system tests
     pytest

--- a/src/pyscaffold/extensions/django.py
+++ b/src/pyscaffold/extensions/django.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Extension that creates a base structure for the project using django-admin.py.
+Extension that creates a base structure for the project using django-admin.
 
 Warning:
     *Deprecation Notice* - In the next major release the Django extension
@@ -67,7 +67,7 @@ def enforce_django_options(struct, opts):
 
 
 def create_django_proj(struct, opts):
-    """Creates a standard Django project with django-admin.py
+    """Creates a standard Django project with django-admin
 
     Args:
         struct (dict): project representation as (possibly) nested
@@ -79,7 +79,7 @@ def create_django_proj(struct, opts):
         struct, opts: updated project representation and options
 
     Raises:
-        :obj:`RuntimeError`: raised if django-admin.py is not installed
+        :obj:`RuntimeError`: raised if django-admin is not installed
     """
     if opts.get("update"):
         helpers.logger.warning(UpdateNotSupported(extension="django"))
@@ -104,9 +104,9 @@ def create_django_proj(struct, opts):
 
 
 class DjangoAdminNotInstalled(RuntimeError):
-    """This extension depends on the ``django-admin.py`` cli script."""
+    """This extension depends on the ``django-admin`` cli script."""
 
-    DEFAULT_MESSAGE = "django-admin.py is not installed, " "run: pip install django"
+    DEFAULT_MESSAGE = "django-admin is not installed, " "run: pip install django"
 
     def __init__(self, message=DEFAULT_MESSAGE, *args, **kwargs):
         super(DjangoAdminNotInstalled, self).__init__(message, *args, **kwargs)

--- a/src/pyscaffold/shell.py
+++ b/src/pyscaffold/shell.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Shell commands like git, django-admin.py etc.
+Shell commands like git, django-admin etc.
 """
 
 import functools
@@ -123,5 +123,5 @@ def command_exists(cmd):
 #: Command for git
 git = get_git_cmd()
 
-#: Command for django-admin.py
-django_admin = ShellCommand("django-admin.py")
+#: Command for django-admin
+django_admin = ShellCommand("django-admin")

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -5,14 +5,13 @@ env:
   PATH: ${HOME}/.local/bin:${PATH}
   # ^  add user paths
   COVERALLS_REPO_TOKEN: ENCRYPTED[]
-  # ^ ADD YOUR ENCRYPTED TOKEN HERE
-  #   https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables
+  # ^ ADD YOUR ENCRYPTED TOKEN HERE: https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables
   PIP_CACHE: ${HOME}/.cache/pip
   LC_ALL: C.UTF-8
   LANG: C.UTF-8
 
 # This template is used in all tasks
-regular_task_template: &REGULAR_TASK_TEMPLATE
+.regular_task_template: &REGULAR_TASK_TEMPLATE
   tox_install_script:
     # Tox is a bit exigent about the name of the python executable,
     # (for example, tox requires a `python3.7` to be available)
@@ -25,16 +24,16 @@ regular_task_template: &REGULAR_TASK_TEMPLATE
     - python -m pip install --upgrade pip setuptools
     - python -m pip install --user pipx
     - pipx install tox
-  prepare_script:
+  clean_workspace_script:
+    # Avoid information carried from one run to the other
     - rm -rf .coverage junit-*.xml
-    # ^  avoid information carried from one run to the other
   test_script:
     - tox -- --color yes
 
 
 # Task definitions:
 linux_mac_task:
-  # use custom cloning since otherwise git tags are missing
+  # Use custom cloning since otherwise git tags are missing
   clone_script: &clone_script |
     if [ -z "$CIRRUS_PR" ]; then
       git clone --recursive --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
@@ -67,8 +66,7 @@ linux_mac_task:
       osx_instance: {image: "catalina-xcode"}
       env:
         PYTHON_VERSION: 3.7
-        # ^ it is important to update this env vars when the default version
-        #   of python in homebrew changes
+        # ^  update when the default version of python in homebrew changes
         PATH: "${HOME}/.local/bin:${HOME}/Library/Python/${PYTHON_VERSION}/bin:/usr/local/opt/python/libexec/bin:${PATH}"
         # ^  add user and homebrew paths
         PIP_CACHE: "${HOME}/Library/Caches/pip"
@@ -85,8 +83,16 @@ linux_mac_task:
 # please check the .cirrus.yml file of PyScaffold itself for some workarounds.
 windows_task:
   name: test (Windows)
-  # use custom cloning since otherwise git tags are missing
+  tools_cache:
+    folder: 'C:\tools'
+    fingerprint_script:
+      - ps: echo "$env:CIRRUS_OS - nuget v5.6.0 - git v2.27.0"
+    populate_script:
+      - ps: (mkdir 'C:\tools')
+      - ps: Invoke-WebRequest -OutFile 'C:\tools\nuget.exe' 'https://dist.nuget.org/win-x86-commandline/v5.6.0/nuget.exe'
+      - ps: nuget install GitForWindows -Version 2.27.0 -NonInteractive -OutputDirectory 'C:\tools'
   clone_script:
+    # Use custom cloning since otherwise git tags are missing
     CMD.exe /C ECHO ON &
     IF NOT DEFINED CIRRUS_PR (
       git clone --recursive --branch=%CIRRUS_BRANCH% https://x-access-token:%CIRRUS_REPO_CLONE_TOKEN%@github.com/%CIRRUS_REPO_FULL_NAME%.git %CIRRUS_WORKING_DIR% &
@@ -97,50 +103,43 @@ windows_task:
       git reset --hard %CIRRUS_CHANGE_IN_REPO%
     )
   windows_container:
-    image: "cirrusci/windowsservercore:cmake"
-    # ^  this image have MSYS2 pre-installed, which means we can use some
-    #    of the GNU tools (like the `rm` command)
+    image: "python:3.8-windowsservercore"
     os_version: 2019
   env:
-    # Single quotes are used bellow to escape Windows backslash and %
-    # (YAML restrictions).
-    PYTHON_HOME: 'C:\Python38'
+    # Single quotes are used bellow to escape Windows backslash and % (YAML restrictions).
+    PYTHON_HOME: 'C:\Python'
     PYTHON_APPDATA: '%APPDATA%\Python\Python38'
-    # ^ it is important to update these 2 env vars when the default version
-    #   of python in chocolatey changes
-    MSYS_HOME: 'C:\tools\msys64'
+    # ^  update when python version changes
+    GIT_HOME: 'C:\tools\GitForWindows.2.27.0\tools'
+    # ^ update when git version changes
     HOME: '%USERPROFILE%'
     USERNAME: ContainerAdministrator
-    # ^  Ensure USERNAME is set in Windows, so the getpass module doesn't
-    #    raise exceptions
-    PATH: '%HOME%\.local\bin\;%PYTHON_APPDATA%\Scripts\;%PYTHON_HOME%\;%PYTHON_HOME%\Scripts\;%MSYS_HOME%\bin\;%MSYS_HOME%\usr\bin\;%MSYS_HOME%\usr\local\bin\;%PATH%'
-    # ^  add user, chocolatey and msys paths
-    CHOCOLATEY_CACHE: '%LocalAppData%\chocolatey\Cache'
+    # ^  ensure USERNAME is set in Windows, so the getpass module doesn't raise exceptions
+    PATH: '%HOME%\.local\bin\;%PYTHON_APPDATA%\Scripts\;%PYTHON_HOME%\;%PYTHON_HOME%\Scripts\;C:\tools\;%GIT_HOME%\cmd\;%PATH%'
+    # ^  add user paths
     PIP_CACHE: '%LocalAppData%\pip\Cache'
     PIP_TRUSTED_HOST: 'pypi.org pypi.python.org files.pythonhosted.org'
     PIP_CONFIG_FILE: '%AppData%\pip\pip.ini'
-  chocolatey_cache:
-    folder: '%CHOCOLATEY_CACHE%'
   pip_cache:
     folder: '%PIP_CACHE%'
   install_script:
-    - choco config set cacheLocation %CHOCOLATEY_CACHE%
-    - choco install --no-progress -y python --version=3.8.1
-  tox_install_script:
+    - python -m ensurepip
     - python -m pip install --upgrade --user pip setuptools
     - python -m pip install --user certifi tox
-  prepare_script:
-    - rm -rf .coverage junit-*.xml
-    # ^  avoid information carried from one run to the other
-  test_script:
-    - python -m tox -- --color yes
-  windows_clean_script:
+  clean_workspace_script:
+    # Avoid information carried from one run to the other
     # CMD is not capable of globbing, so we have to use PowerShell
     - ps: (rm junit-*.xml)
+    - ps: (rm -Recurse -Force .tox)
+    # ^  use parentheses to suppress errors
+  test_script:
+    - ps: python -m tox -- -rfEx --color yes
+    # ^  tox exe is not on Path by default
 
 
 coverage_task:
   name: coverage (Linux)
+  clone_script: *clone_script
   container: {image: "python:3.6-buster"}
   depends_on:
     - test (Linux - 3.6)

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -26,7 +26,7 @@ env:
     - pipx install tox
   clean_workspace_script:
     # Avoid information carried from one run to the other
-    - rm -rf .coverage junit-*.xml
+    - rm -rf .coverage junit-*.xml .tox
   test_script:
     - tox -- --color yes
 
@@ -124,13 +124,11 @@ windows_task:
     folder: '%PIP_CACHE%'
   install_script:
     - python -m ensurepip
-    - python -m pip install --upgrade --user pip setuptools
-    - python -m pip install --user certifi tox
+    - python -m pip install --upgrade --user pip setuptools certifi tox
   clean_workspace_script:
     # Avoid information carried from one run to the other
     # CMD is not capable of globbing, so we have to use PowerShell
-    - ps: (rm junit-*.xml)
-    - ps: (rm -Recurse -Force .tox)
+    - ps: (rm -Recurse -Force -ErrorAction SilentlyContinue .tox,junit-*.xml)
     # ^  use parentheses to suppress errors
   test_script:
     - ps: python -m tox -- -rfEx --color yes

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -13,22 +13,14 @@ env:
 # This template is used in all tasks
 .regular_task_template: &REGULAR_TASK_TEMPLATE
   tox_install_script:
-    # Tox is a bit exigent about the name of the python executable,
-    # (for example, tox requires a `python3.7` to be available)
-    # and the shape of the directory python is installed to.
-    # Because of that, some errors might appear in some kinds of installation
-    # (e.g. OSX with homebrew).
-    # Luckily, pipx install tox inside its own unique virtualenv, which
-    # resembles a very standard installation directory.
-    # So here we install tox using pipx to avoid such problems
-    - python -m pip install --upgrade pip setuptools
-    - python -m pip install --user pipx
-    - pipx install tox
+    - python -m pip install --upgrade pip setuptools tox
   clean_workspace_script:
     # Avoid information carried from one run to the other
     - rm -rf .coverage junit-*.xml .tox
-  test_script:
-    - tox -- --color yes
+  test_script: &test_script
+    # This script is also used in Windows, so the shell is not POSIX
+    - python -m tox -- -rfEx --color yes
+    # ^  tox is better if invoked as a module on Windows/OSX
 
 
 # Task definitions:
@@ -89,6 +81,7 @@ windows_task:
       - ps: echo "$env:CIRRUS_OS - nuget v5.6.0 - git v2.27.0"
     populate_script:
       - ps: (mkdir 'C:\tools')
+      # ^  use parentheses to suppress errors
       - ps: Invoke-WebRequest -OutFile 'C:\tools\nuget.exe' 'https://dist.nuget.org/win-x86-commandline/v5.6.0/nuget.exe'
       - ps: nuget install GitForWindows -Version 2.27.0 -NonInteractive -OutputDirectory 'C:\tools'
   clone_script:
@@ -116,7 +109,7 @@ windows_task:
     USERNAME: ContainerAdministrator
     # ^  ensure USERNAME is set in Windows, so the getpass module doesn't raise exceptions
     PATH: '%HOME%\.local\bin\;%PYTHON_APPDATA%\Scripts\;%PYTHON_HOME%\;%PYTHON_HOME%\Scripts\;C:\tools\;%GIT_HOME%\cmd\;%PATH%'
-    # ^  add user paths
+    # ^  add user paths (if POSIX tools are needed you can try also adding %GIT_HOME\usr\bin\)
     PIP_CACHE: '%LocalAppData%\pip\Cache'
     PIP_TRUSTED_HOST: 'pypi.org pypi.python.org files.pythonhosted.org'
     PIP_CONFIG_FILE: '%AppData%\pip\pip.ini'
@@ -129,10 +122,7 @@ windows_task:
     # Avoid information carried from one run to the other
     # CMD is not capable of globbing, so we have to use PowerShell
     - ps: (rm -Recurse -Force -ErrorAction SilentlyContinue .tox,junit-*.xml)
-    # ^  use parentheses to suppress errors
-  test_script:
-    - ps: python -m tox -- -rfEx --color yes
-    # ^  tox exe is not on Path by default
+  test_script: *test_script
 
 
 coverage_task:

--- a/src/pyscaffold/templates/tox_ini.template
+++ b/src/pyscaffold/templates/tox_ini.template
@@ -7,7 +7,8 @@ minversion = 2.4
 envlist = default
 
 [testenv]
-setenv = TOXINIDIR = {toxinidir}
+setenv =
+    TOXINIDIR = {toxinidir}
 passenv =
     HOME
 commands =

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 from os.path import join as path_join
+from pathlib import Path
 
 from pkg_resources import parse_version, working_set
 
@@ -150,7 +151,8 @@ class VenvManager(object):
                 return self.venv.run(cmd, capture=True, **kwargs).strip()
 
     def get_file(self, path):
-        return self.run("cat {}".format(path))
+        with chdir(self.tmpdir):
+            return Path(path).read_text()
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -6,13 +6,15 @@ minversion = 2.4
 envlist = default
 
 [testenv]
-setenv = TOXINIDIR = {toxinidir}
+setenv =
+    TOXINIDIR = {toxinidir}
 passenv =
     HOME
     USER
     USERNAME
     COVERAGE
     PIP_CACHE
+    PIP_TRUSTED_HOST
 deps =
     certifi
     pytest


### PR DESCRIPTION
1. Replace the base image for the Windows tests with the official Python windows container:

   For some reason, some of the latest builds fail on Windows due to the mysterious [` [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1108) -- Some packages may not be found!` error](https://cirrus-ci.com/task/5871278840086528) (again).

   We are already installing `certifi`, so my intuitive attempt to fix that was to update Python on windows to the latest version (hopefully the certificates will be fine for the latest builds). However installing the latest stable version of Python via chocolatey [results in error](https://cirrus-ci.com/task/5472321609662464).

   This PR changes Cirrus CI to use the windows container created directly by the Python project, so we have a trustworthy and updated installation of the language run time. This implies in installing some other tools instead (such as git). The solution for installing those tools was to rely on `nuget` since it is officially maintained by microsoft.

2. Remove pipx workaround for OSX:

   It is tricky to run the tox executable script directly in OSX because the directory where homebrew installs Python does not follow the structure expected by tox.
   Therefore, we were using pipx to install tox since it relies on virtualenvs that ressembles a standard directory structure, as expected by tox.
   By observing the Windows scripts I noticed we could avoid that workaround by calling tox directly as a module (`python -m`). This eliminates a few steps, make the CI run faster and remove some duplication in `.cirrus.yml`.

3. Improve sync between PyScaffold's own `.cirrus.yml` and those generated from the template.