### PR TITLE
Unify tox -e docs/doctests using generative setcion names

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ If you have `make`_ and `Sphinx`_ installed in your computer, build the
 documentation with ``make -C docs html`` and run doctests with
 ``make -C docs doctest``.
 Alternatively, if your project was created with the ``--tox``
-option, simply run ``tox -e doc`` ot ``tox -e doctest``.
+option, simply run ``tox -e docs`` ot ``tox -e doctests``.
 
 
 

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -157,7 +157,7 @@ If you have `make`_ and `Sphinx`_ installed in your computer, build the
 documentation with ``make -C docs html`` and run doctests with
 ``make -C docs doctest``.
 Alternatively, if your project was created with the ``--tox``
-option, simply run ``tox -e doc`` ot ``tox -e doctest``.
+option, simply run ``tox -e docs`` ot ``tox -e doctests``.
 
 
 Dependency Management in a Breeze

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -62,7 +62,7 @@ your virtual environment:
 
 Alternatively, you can setup build automation with **tox**. An easy way to do
 that is to generate your project passing the ``--tox`` option.
-The commands ``tox`` and ``tox -e doc`` should be able to run your tests or
+The commands ``tox`` and ``tox -e docs`` should be able to run your tests or
 build your docs out of the box.
 
 .. _setuptools: https://pypi.python.org/pypi/setuptools/

--- a/src/pyscaffold/templates/tox_ini.template
+++ b/src/pyscaffold/templates/tox_ini.template
@@ -3,10 +3,11 @@
 # THIS SCRIPT IS SUPPOSED TO BE AN EXAMPLE. MODIFY IT ACCORDING TO YOUR NEEDS!
 
 [tox]
-minversion = 2.4
+minversion = 3.15
 envlist = default
 
 [testenv]
+description = invoke pytest to run automated tests
 setenv =
     TOXINIDIR = {toxinidir}
 passenv =
@@ -17,20 +18,16 @@ extras =
     all
     testing
 
-[testenv:doc]
-description = invoke sphinx-build to build the HTML docs
+[testenv:{docs,doctests}]
+description = invoke sphinx-build to build the docs/run doctests
 setenv =
     DOCSDIR = {toxinidir}/docs
     BUILDDIR = {toxinidir}/docs/_build
+    docs: BUILD = html
+    doctests: BUILD = doctest
 deps =
     sphinx
     # sphinx_rtd_theme
+    # any docs/requirements.txt for/shared with Read The Docs?
 commands =
-    sphinx-build -b html -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/html" {posargs}
-
-[testenv:doctest]
-description = invoke sphinx-build to run doctests
-setenv = {[testenv:doc]setenv}
-deps = {[testenv:doc]deps}
-commands =
-    sphinx-build -b doctest -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/doctest" {posargs}
+    sphinx-build -b {env:BUILD} -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/{env:BUILD}" {posargs}

--- a/tests/system/test_common.py
+++ b/tests/system/test_common.py
@@ -115,19 +115,19 @@ def test_tox_docs(cwd, tox):
     # Given pyscaffold project is created with --tox
     run("putup myproj --tox")
     with cwd.join("myproj").as_cwd():
-        # when we can call tox -e doc
-        run("{} -e doc".format(tox))
+        # when we can call tox -e docs
+        run("{} -e docs".format(tox))
         # then documentation will be generated.
         assert exists("docs/api/modules.rst")
         assert exists("docs/_build/html/index.html")
 
 
-def test_tox_doctest(cwd, tox):
+def test_tox_doctests(cwd, tox):
     # Given pyscaffold project is created with --tox
     run("putup myproj --tox")
     with cwd.join("myproj").as_cwd():
         # when we can call tox
-        run("{} -e doctest".format(tox))
+        run("{} -e doctests".format(tox))
         # then tests will execute
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,11 @@
 # Use `setup.cfg` as single-source of truth for dependency specification
 
 [tox]
-minversion = 2.4
+minversion = 3.15
 envlist = default
 
 [testenv]
+description = invoke pytest to run automated tests
 setenv =
     TOXINIDIR = {toxinidir}
 passenv =
@@ -27,13 +28,16 @@ extras =
     all
     testing
 
-[testenv:docs]
-description = invoke sphinx-build to build the HTML docs
+[testenv:{docs,doctests}]
+description = invoke sphinx-build to build the docs/run doctests
 setenv =
     DOCSDIR = {toxinidir}/docs
     BUILDDIR = {toxinidir}/docs/_build
+    docs: BUILD = html
+    doctests: BUILD = doctest
 deps =
-    -r {toxinidir}/requirements.txt
     sphinx_rtd_theme
+    -r {toxinidir}/requirements.txt
+    # ^  requirements.txt shared with Read The Docs
 commands =
-    sphinx-build -b html -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/html" {posargs}
+    sphinx-build -b {env:BUILD} -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/{env:BUILD}" {posargs}


### PR DESCRIPTION
Thanks to [tox's generative section names](https://tox.readthedocs.io/en/latest/config.html#generative-section-names) we can avoid duplication in sphinx tasks.