### PR TITLE
Remove coding: utf-8 comment in Python files

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # This file is execfile()d with the current directory set to its containing dir.
 #

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -313,8 +313,6 @@ extension which defines the ``define_awesome_files`` action:
     def my_awesome_file(opts):
         return dedent(
             """\
-            # -*- coding: utf-8 -*-
-
             __author__ = "{author}"
             __copyright__ = "{author}"
             __license__ = "{license}"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Setup file for PyScaffold."""
 import sys
 

--- a/src/pyscaffold/__init__.py
+++ b/src/pyscaffold/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from pkg_resources import DistributionNotFound, get_distribution
 
 try:

--- a/src/pyscaffold/api/__init__.py
+++ b/src/pyscaffold/api/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Exposed API for accessing PyScaffold via Python.
 

--- a/src/pyscaffold/api/helpers.py
+++ b/src/pyscaffold/api/helpers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Useful functions for manipulating the action list and project structure.
 """

--- a/src/pyscaffold/cli.py
+++ b/src/pyscaffold/cli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Command-Line-Interface of PyScaffold
 """

--- a/src/pyscaffold/exceptions.py
+++ b/src/pyscaffold/exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Custom exceptions used by PyScaffold to identify common deviations from the
 expected behavior.

--- a/src/pyscaffold/extensions/__init__.py
+++ b/src/pyscaffold/extensions/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Built-in extensions for PyScaffold.
 """

--- a/src/pyscaffold/extensions/cirrus.py
+++ b/src/pyscaffold/extensions/cirrus.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Extension that generates configuration for Cirrus CI."""
 import argparse
 

--- a/src/pyscaffold/extensions/gitlab_ci.py
+++ b/src/pyscaffold/extensions/gitlab_ci.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Extension that generates configuration and script files for GitLab CI.
 """

--- a/src/pyscaffold/extensions/namespace.py
+++ b/src/pyscaffold/extensions/namespace.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Extension that adjust project file tree to include a namespace package.
 

--- a/src/pyscaffold/extensions/no_skeleton.py
+++ b/src/pyscaffold/extensions/no_skeleton.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Extension that omits the creation of file `skeleton.py`
 """

--- a/src/pyscaffold/extensions/pre_commit.py
+++ b/src/pyscaffold/extensions/pre_commit.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Extension that generates configuration files for Yelp `pre-commit`_.
 

--- a/src/pyscaffold/extensions/tox.py
+++ b/src/pyscaffold/extensions/tox.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Extension that generates configuration files for the Tox test automation tool.
 """

--- a/src/pyscaffold/extensions/travis.py
+++ b/src/pyscaffold/extensions/travis.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Extension that generates configuration and script files for Travis CI.
 """

--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Provide general information about the system, user etc.
 """

--- a/src/pyscaffold/log.py
+++ b/src/pyscaffold/log.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Custom logging infrastructure to provide execution information for the user.
 """

--- a/src/pyscaffold/repo.py
+++ b/src/pyscaffold/repo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Functionality for working with a git repository
 """

--- a/src/pyscaffold/shell.py
+++ b/src/pyscaffold/shell.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Shell commands like git, django-admin etc.
 """

--- a/src/pyscaffold/structure.py
+++ b/src/pyscaffold/structure.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Functionality to generate and work with the directory structure of a project
 
 .. versionchanged:: 4.0

--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Templates for all files of a project's scaffold
 """

--- a/src/pyscaffold/templates/__init__.template
+++ b/src/pyscaffold/templates/__init__.template
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from pkg_resources import DistributionNotFound, get_distribution
 
 try:

--- a/src/pyscaffold/templates/conftest_py.template
+++ b/src/pyscaffold/templates/conftest_py.template
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     Dummy conftest.py for ${package}.
 

--- a/src/pyscaffold/templates/namespace.template
+++ b/src/pyscaffold/templates/namespace.template
@@ -1,2 +1,1 @@
-# -*- coding: utf-8 -*-
 __import__("pkg_resources").declare_namespace(__name__)

--- a/src/pyscaffold/templates/setup_py.template
+++ b/src/pyscaffold/templates/setup_py.template
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     Setup file for ${package}.
     Use setup.cfg to configure your project.

--- a/src/pyscaffold/templates/skeleton.template
+++ b/src/pyscaffold/templates/skeleton.template
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This is a skeleton file that can serve as a starting point for a Python
 console script. To run this script uncomment the following lines in the

--- a/src/pyscaffold/templates/sphinx_conf.template
+++ b/src/pyscaffold/templates/sphinx_conf.template
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # This file is execfile()d with the current directory set to its containing dir.
 #

--- a/src/pyscaffold/templates/test_skeleton.template
+++ b/src/pyscaffold/templates/test_skeleton.template
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 import pytest
 

--- a/src/pyscaffold/templates/test_skeleton.template
+++ b/src/pyscaffold/templates/test_skeleton.template
@@ -1,4 +1,3 @@
-
 import pytest
 
 from ${qual_pkg}.skeleton import fib

--- a/src/pyscaffold/termui.py
+++ b/src/pyscaffold/termui.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Basic support for ANSI code formatting.
 """

--- a/src/pyscaffold/update.py
+++ b/src/pyscaffold/update.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Functionality to update one PyScaffold version to another
 """

--- a/src/pyscaffold/utils.py
+++ b/src/pyscaffold/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Miscellaneous utilities and tools
 """

--- a/src/pyscaffold/warnings.py
+++ b/src/pyscaffold/warnings.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Warnings used by PyScaffold to identify issues that can be safely ignored
 but that should be displayed to the user.

--- a/tests/api/test_helpers.py
+++ b/tests/api/test_helpers.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 from pathlib import PurePath as Path
 
 import pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import builtins
 import logging
 import os

--- a/tests/demoapp/runner.py
+++ b/tests/demoapp/runner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Runner module for demoapp"""
 
 import argparse

--- a/tests/demoapp/setup.py
+++ b/tests/demoapp/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
     Setup file for our unittest demo application
 """

--- a/tests/demoapp_data/runner.py
+++ b/tests/demoapp_data/runner.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Runner module for demoapp_data"""
 
 import argparse

--- a/tests/demoapp_data/setup.py
+++ b/tests/demoapp_data/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
     Setup file for our unittest demo application
 """

--- a/tests/extensions/test_cirrus.py
+++ b/tests/extensions/test_cirrus.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import sys
 from os.path import exists as path_exists
 

--- a/tests/extensions/test_namespace.py
+++ b/tests/extensions/test_namespace.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import sys
 from pathlib import Path
 

--- a/tests/extensions/test_no_skeleton.py
+++ b/tests/extensions/test_no_skeleton.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import sys
 from pathlib import Path
 

--- a/tests/extensions/test_pre_commit.py
+++ b/tests/extensions/test_pre_commit.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import logging
 import sys
 from pathlib import Path

--- a/tests/extensions/test_tox.py
+++ b/tests/extensions/test_tox.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import sys
 from pathlib import Path
 

--- a/tests/extensions/test_travis.py
+++ b/tests/extensions/test_travis.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import sys
 from pathlib import Path
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 import os
 import stat

--- a/tests/log_helpers.py
+++ b/tests/log_helpers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 import re
 

--- a/tests/system/helpers.py
+++ b/tests/system/helpers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 import os
 import shlex

--- a/tests/system/test_common.py
+++ b/tests/system/test_common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import sys
 from os import environ

--- a/tests/system/test_dependency_managers.py
+++ b/tests/system/test_dependency_managers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import json
 import os
 from os import environ

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from os.path import getmtime
 from pathlib import Path
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import logging
 import os
 import sys

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import getpass
 import os
 import socket

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pyscaffold
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Unit tests of everything related to retrieving the version
 
 There are four tree states we want to check:

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 import re
 from os import getcwd

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os.path
 import shutil
 import subprocess

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 import re
 from os.path import exists as path_exists

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from os.path import isdir, isfile
 
 import pytest

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import sys
 
 import pytest
@@ -9,7 +8,7 @@ from pyscaffold import templates
 def test_get_template():
     template = templates.get_template("setup_py")
     content = template.safe_substitute()
-    assert content.split("\n", 1)[0] == "# -*- coding: utf-8 -*-"
+    assert content.split("\n", 1)[0] == '"""'
 
 
 @pytest.fixture

--- a/tests/test_termui.py
+++ b/tests/test_termui.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from importlib import reload
 from io import StringIO
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 import os
 import re

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import logging
 import os
 import re


### PR DESCRIPTION
The coding comment is unnecessary now that Python 2 is no longer
officially supported.

This commit removes the comments for both PyScaffold's code and the
files being generated by putup.t

Closes #266.