### PR TITLE
Improve determinism in extensions

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -430,6 +430,13 @@ already activates the extension will be created, based on the dasherized
 version of the name in `setuptools entry point`_ you created. In the example
 above, the automatically generated option will be ``--awesome-files``.
 
+.. note::
+
+    In order to guarantee consistency and allow PyScaffold to unequivocally find
+    your extension, the name of the entry point should be a underscored version
+    of the name of the extension class (e.g. an entry point ``awesome_files``
+    for the ``AwesomeFiles`` class).
+
 For more sophisticated extensions which need to read and parse their
 own command line arguments it is necessary to override
 :obj:`~pyscaffold.api.Extension.augment_cli` that receives an

--- a/src/pyscaffold/cli.py
+++ b/src/pyscaffold/cli.py
@@ -23,7 +23,7 @@ def add_default_args(parser):
         parser (argparse.ArgumentParser): CLI parser object
     """
 
-    # Here we can api.DEFAULT_OPTIONS to provide the help text, but we should avoid
+    # Here we can use api.DEFAULT_OPTIONS to provide the help text, but we should avoid
     # passing a `default` value to argparse, since that would shadow
     # `api.bootstrap_options`.
     # Setting defaults with `api.bootstrap_options` guarantees we do that in a
@@ -155,12 +155,10 @@ def parse_args(args):
     parser.set_defaults(extensions=[], config_files=[], command=run_scaffold)
     add_default_args(parser)
     # load and instantiate extensions
-    cli_extensions = [
+    cli_extensions = utils.deterministic_sort(
         extension.load()(extension.name)
         for extension in iter_entry_points("pyscaffold.cli")
-        # TODO: sort in the same way the extensions are activated for
-        # determinism
-    ]
+    )
 
     # find out if any of the extensions are mutually exclusive
     is_mutex = attrgetter("mutually_exclusive")

--- a/src/pyscaffold/utils.py
+++ b/src/pyscaffold/utils.py
@@ -318,7 +318,7 @@ def chmod(path, mode, pretend=False):
     return path
 
 
-def dasherize(word):
+def dasherize(word: str) -> str:
     """Replace underscores with dashes in the string.
 
     Example::
@@ -333,6 +333,41 @@ def dasherize(word):
         input word with underscores replaced by dashes
     """
     return word.replace("_", "-")
+
+
+CAMEL_CASE_SPLITTER = re.compile(r"\W+|([A-Z][^A-Z\W]*)")
+
+
+def underscore(word: str) -> str:
+    """Convert CamelCasedStrings or dasherized-strings into underscore_strings.
+
+    Example::
+
+        >>> underscore("FooBar-foo")
+        "foo_bar_foo"
+    """
+    return "_".join(w for w in CAMEL_CASE_SPLITTER.split(word) if w).lower()
+
+
+def deterministic_name(ext):
+    """Private API that returns an string that can be used to deterministically
+    reduplicate and sort extensions.
+    Not available for use outside PyScaffold's core.
+    """
+    return ".".join(
+        [ext.__module__, getattr(ext, "__qualname__", ext.__class__.__qualname__)]
+    )
+
+
+def deterministic_sort(extensions):
+    """Private API that remove duplicates and order a list of extensions
+    lexicographically which is needed for determinism, also internal before external:
+    "pyscaffold.*" < "pyscaffoldext.*"
+    Not available for use outside PyScaffold's core.
+    """
+    deduplicated = {deterministic_name(e): e for e in extensions}
+    # ^  duplicated keys will overwrite each other, so just one of them is left
+    return [v for (_k, v) in sorted(deduplicated.items())]
 
 
 def get_id(function):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,7 +33,7 @@ def create_extension(*hooks):
                 actions = self.register(actions, hook, after="define_structure")
             return actions
 
-    return TestExtension("TestExtension")
+    return TestExtension()
 
 
 def test_discover_actions():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -267,6 +267,23 @@ def test_pretend_move(tmpfolder):
     assert tmpfolder.join("another-file.txt").check()
 
 
+def test_dasherize():
+    assert utils.dasherize("hello_world") == "hello-world"
+    assert utils.dasherize("helloworld") == "helloworld"
+    assert utils.dasherize("") == ""
+
+
+def test_underscore():
+    assert utils.underscore("HelloWorld") == "hello_world"
+    assert utils.underscore("Hello-World") == "hello_world"
+    assert utils.underscore("Hello   World") == "hello_world"
+    assert utils.underscore("Hello---World") == "hello_world"
+    assert utils.underscore("HelLo-WorLd") == "hel_lo_wor_ld"
+    assert utils.underscore("helloworld") == "helloworld"
+    assert utils.underscore("PYTHON") == "p_y_t_h_o_n"
+    assert utils.underscore("") == ""
+
+
 def test_get_id():
     def custom_action(structure, options):
         return structure, options


### PR DESCRIPTION
Sort extensions as they are retrieved from setuptools entry points or (de)serialized into pyscaffold's section of setup.cfg. This improves determinism in the order `augment_cli` will be called.