### PR TITLE
Implement config options

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -61,12 +61,19 @@ will have the same effect as if you had typed::
 
 .. note::
 
-    Only the following parameters are accepted:
+    Only the following options are allowed in the config file:
 
     - **metadata** section: ``author``, ``author-email`` and ``license``
     - **pyscaffold** section: ``extensions`` (and associated opts)
 
     Options associated with extensions are the ones prefixed by an extension name.
+
+
+To prevent PyScaffold from reading an existing config file, you can pass the
+``--no-config`` option in the CLI. You can also save the given options when
+creating a new project with the ``--save-config`` option. Finally, to read the
+configurations from a location other then the default, use the ``--config
+PATH`` option.
 
 
 .. warning::

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -59,6 +59,16 @@ will have the same effect as if you had typed::
     $ putup --license mozilla --tox --travis --pre-commit myproj
 
 
+.. note::
+
+    Only the following parameters are accepted:
+
+    - **metadata** section: ``author``, ``author-email`` and ``license``
+    - **pyscaffold** section: ``extensions`` (and associated opts)
+
+    Options associated with extensions are the ones prefixed by an extension name.
+
+
 .. warning::
 
     *Experimental Feature* - We are still evaluating how this new and exciting

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -273,7 +273,7 @@ Structure Helper Methods
 
 PyScaffold also provides extra facilities to manipulate the project structure.
 The following functions are accessible through the
-:mod:`~pyscaffold.struct` module:
+:mod:`~pyscaffold.structure` module:
 
 - :obj:`~pyscaffold.structure.merge`
 - :obj:`~pyscaffold.structure.ensure`
@@ -425,17 +425,17 @@ to the ``options.entry_points`` section in ``setup.cfg``:
     pyscaffold.cli =
         awesome_files = your_package.your_module:AwesomeFiles
 
+.. note::
+
+    In order to guarantee consistency and allow PyScaffold to unequivocally find
+    your extension, the name of the entry point should be a "underscore" version
+    of the name of the extension class (e.g. an entry point ``awesome_files``
+    for the ``AwesomeFiles`` class).
+
 By inheriting from :obj:`pyscaffold.extensions.Extension`, a default CLI option that
 already activates the extension will be created, based on the dasherized
 version of the name in `setuptools entry point`_ you created. In the example
 above, the automatically generated option will be ``--awesome-files``.
-
-.. note::
-
-    In order to guarantee consistency and allow PyScaffold to unequivocally find
-    your extension, the name of the entry point should be a underscored version
-    of the name of the extension class (e.g. an entry point ``awesome_files``
-    for the ``AwesomeFiles`` class).
 
 For more sophisticated extensions which need to read and parse their
 own command line arguments it is necessary to override
@@ -451,6 +451,28 @@ as well as the `pyproject extension`_ which serves as a blueprint for new
 extensions. Another convention is to avoid storing state/parameters inside the
 extension class, instead store them as you would do regularly with
 :mod:`argparse` (inside the :obj:`argparse.Namespace` object).
+
+
+Persisting Extensions for Future Updates
+----------------------------------------
+
+PyScaffold will save the name of your extension in a **pyscaffold** section
+inside the ``setup.cfg`` files and automatically activate it again every time
+the user runs ``putup --update``. To prevent it from happening you can
+set ``persist = False`` in your extension instances or class.
+
+PyScaffold can also save extension-specific options if the names of those
+options start with an "underscore" version of your extension's name (and
+`setuptools entry point`_).
+For example, the :ref:`namespace extension <examples/namespace-extension>`
+stores the ``namespace`` option in ``setup.cfg``.
+
+If the name of your extension class is ``AwesomeFiles``, then anything like
+``opts["awesome_files"]``, ``opts["awesome_files1"]``,
+``opts["awesome_files_SOMETHING"]`` would be stored.
+Please ensure you have in mind the limitations of the :mod:`configparser`
+serialisation mechanism and supported data types to avoid errors (it should be
+safe to use string values without line breaks).
 
 
 Examples
@@ -473,7 +495,7 @@ and can be used as reference implementation:
 Public API
 ==========
 
-The following methods and functions are considered to be part of the public API
+The following methods, functions and constants are considered to be part of the public API
 of PyScaffold for creating extensions and will not change signature and
 described overall behaviour (although implementation details might change) in a
 backwards incompatible way between major releases (`semantic versioning`_):
@@ -481,10 +503,13 @@ backwards incompatible way between major releases (`semantic versioning`_):
 - :obj:`pyscaffold.actions.register`
 - :obj:`pyscaffold.actions.unregister`
 - :obj:`pyscaffold.extensions.Extension.__init__`
+- :obj:`pyscaffold.extensions.Extension.persist`
 - :obj:`pyscaffold.extensions.Extension.augment_cli`
 - :obj:`pyscaffold.extensions.Extension.activate`
 - :obj:`pyscaffold.extensions.Extension.register`
 - :obj:`pyscaffold.extensions.Extension.unregister`
+- :obj:`pyscaffold.extensions.include`
+- :obj:`pyscaffold.extensions.store_with`
 - :obj:`pyscaffold.operations.create`
 - :obj:`pyscaffold.operations.no_overwrite`
 - :obj:`pyscaffold.operations.skip_on_update`

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -9,7 +9,7 @@ application. It is, however, possible to write an external script or program
 that embeds PyScaffold and use it to perform some custom actions.
 
 The public Python API for embedding PyScaffold is composed by the main function
-:obj:`pyscaffold.api.create_project` in addition to
+:obj:`pyscaffold.api.create_project` in addition to :obj:`pyscaffold.api.NO_CONFIG`,
 :obj:`pyscaffold.log.DEFAULT_LOGGER`, :obj:`pyscaffold.log.logger` (partially,
 see details bellow), and the constructors for the extension classes belonging
 to the :mod:`pyscaffold.extenstions` module (the other methods and functions

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,6 +86,7 @@ distutils.setup_keywords =
 console_scripts =
     putup = pyscaffold.cli:run
 pyscaffold.cli =
+    config = pyscaffold.extensions.config:Config
     namespace = pyscaffold.extensions.namespace:Namespace
     no_skeleton = pyscaffold.extensions.no_skeleton:NoSkeleton
     pre_commit = pyscaffold.extensions.pre_commit:PreCommit

--- a/src/pyscaffold/actions.py
+++ b/src/pyscaffold/actions.py
@@ -231,15 +231,6 @@ def get_default_options(struct, opts):
     opts.setdefault("qual_pkg", opts["package"])
     opts.setdefault("pretend", False)
 
-    # Save cli params for later updating
-    extensions = set(opts.get("cli_params", {}).get("extensions", []))
-    args = opts.get("cli_params", {}).get("args", {})
-    for extension in opts["extensions"]:
-        extensions.add(extension.name)
-        if extension.args is not None:
-            args[extension.name] = extension.args
-    opts["cli_params"] = {"extensions": list(extensions), "args": args}
-
     return struct, opts
 
 

--- a/src/pyscaffold/api.py
+++ b/src/pyscaffold/api.py
@@ -12,7 +12,7 @@ from .exceptions import NoPyScaffoldProject
 
 # -------- Options --------
 
-(NO_CONFIG,) = list(Enum("ConfigFiles", "NO_CONFIG"))
+(NO_CONFIG,) = list(Enum("ConfigFiles", "NO_CONFIG"))  # type: ignore
 """This constant is used to tell PyScaffold to not load any extra configuration file,
 not even the default ones
 Usage::
@@ -104,6 +104,7 @@ def create_project(opts=None, **kwargs):
                             - **force** (*bool*)
                             - **pretend** (*bool*)
                             - **extensions** (*list*)
+                            - **config_files** (*list* | ``NO_CONFIG``)
 
     Some of these options are equivalent to the command line options, others
     are used for creating the basic python package meta information, but the
@@ -116,12 +117,18 @@ def create_project(opts=None, **kwargs):
     When the **pretend** flag is ``True``, the project will not be
     created/updated, but the expected outcome will be logged.
 
-    Finally, the **extensions** list may contain any function that follows the
+    The **extensions** list may contain any object that follows the
     `extension API <../extensions>`_. Note that some PyScaffold features, such
     as travis, tox and pre-commit support, are implemented as built-in
-    extensions.  In order to use these features it is necessary to include the
-    respective functions in the extension list.  All built-in extensions are
+    extensions. In order to use these features it is necessary to include the
+    respective objects in the extension list. All built-in extensions are
     accessible via :mod:`pyscaffold.extensions` submodule.
+
+    Finally, when ``setup.cfg``-like files are added to the **config_files** list,
+    PyScaffold will read it's options from there in addition to the ones already passed.
+    If the list is empty, the default configuration file is used. To avoid reading any
+    existing configuration, please pass ``config_file=NO_CONFIG``.
+    See https://pyscaffold.org/en/latest/configuration.html for more details.
 
     Note that extensions may define extra options. For example, the
     cookiecutter extension define a ``cookiecutter`` option that

--- a/src/pyscaffold/extensions/__init__.py
+++ b/src/pyscaffold/extensions/__init__.py
@@ -46,10 +46,12 @@ class Extension:
         Args:
             parser: current parser object
         """
-        help = self.__doc__[0].lower() + self.__doc__[1:]
-
         parser.add_argument(
-            self.flag, help=help, dest="extensions", action="append_const", const=self
+            self.flag,
+            dest="extensions",
+            action="append_const",
+            const=self,
+            help=self.__doc__[0].lower() + self.__doc__[1:],
         )
         return self
 

--- a/src/pyscaffold/extensions/cirrus.py
+++ b/src/pyscaffold/extensions/cirrus.py
@@ -1,10 +1,8 @@
 """Extension that generates configuration for Cirrus CI."""
-import argparse
-
 from .. import structure
 from ..operations import no_overwrite
 from ..templates import get_template
-from . import Extension
+from . import Extension, include
 from .pre_commit import PreCommit
 from .tox import Tox
 
@@ -26,7 +24,7 @@ class Cirrus(Extension):
         help = self.__doc__[0].lower() + self.__doc__[1:]
 
         parser.add_argument(
-            self.flag, help=help, nargs=0, dest="extensions", action=IncludeExtensions
+            self.flag, help=help, nargs=0, action=include(PreCommit(), Tox(), self)
         )
         return self
 
@@ -40,15 +38,6 @@ class Cirrus(Extension):
             list: updated list of actions
         """
         return self.register(actions, add_files, after="define_structure")
-
-
-class IncludeExtensions(argparse.Action):
-    """Automatically activate tox and pre-commit together with cirrus."""
-
-    def __call__(self, parser, namespace, _values, _option_string=None):
-        extensions = [PreCommit("pre_commit"), Tox("tox"), Cirrus("cirrus")]
-
-        namespace.extensions.extend(extensions)
 
 
 def add_files(struct, opts):

--- a/src/pyscaffold/extensions/config.py
+++ b/src/pyscaffold/extensions/config.py
@@ -1,0 +1,86 @@
+"""CLI options for using/saving preferences as PyScaffold config files."""
+
+import argparse
+from pathlib import Path
+
+from configupdater import ConfigUpdater
+
+from .. import api, info, operations, templates
+from . import Extension, store_with
+
+
+class Config(Extension):
+    """Add a few useful options for creating/using PyScaffold config files."""
+
+    persist = False
+
+    def augment_cli(self, parser: "argparse.ArgumentParser"):
+        default_file = info.config_file(default=None)
+        default_help = f" (defaults to: {default_file})" if default_file else ""
+        parser.add_argument(
+            "--config",
+            dest="config_files",
+            metavar="CONFIG_FILE",
+            nargs="+",
+            type=Path,
+            help=f"config file to read PyScaffold's preferences{default_help}",
+        )
+        parser.add_argument(
+            "--no-config",
+            dest="config_files",
+            action="store_const",
+            const=api.NO_CONFIG,
+            help="prevent PyScaffold from reading its default config file",
+        )
+        parser.add_argument(
+            "--save-config",
+            dest="save_config",
+            action=store_with(self),
+            nargs="?",
+            const=default_file,
+            default=argparse.SUPPRESS,
+            type=Path,
+            help=f"save the given options in a config file{default_help}",
+        )
+        return self
+
+    def activate(self, actions):
+        return actions[:-1] + [save, actions[-1]]  # Just before the last action
+
+
+def save(struct, opts):
+    """Save the given opts as preferences in a PyScaffold's config file."""
+    config = ConfigUpdater()
+
+    if not opts.get("save_config"):
+        file = info.config_file()
+    else:
+        file = Path(opts["save_config"])
+
+    if file.exists():
+        config.read(file, encoding="utf-8")
+    else:
+        config.read_string(
+            "# PyScaffold's configuration file, see:\n"
+            "# https://pyscaffold.org/en/latest/configuration.html\n#\n"
+            "# Accepted in `metadata`: author, author-email and license.\n"
+            "# Accepted in `pyscaffold`: extensions (and associated opts).\n"
+        )
+
+    if "metadata" not in config:
+        config.add_section("metadata")
+
+    # We will add metadata just if they are not the default ones
+    metadata = config["metadata"]
+    defaults = [
+        ("author", opts["author"], info.username()),
+        ("author-email", opts["email"], info.email()),
+        ("license", opts["license"], api.DEFAULT_OPTIONS["license"]),
+    ]
+
+    metadata.update({k: v for k, v, default in defaults if v != default})
+    templates.add_pyscaffold(config, opts)
+
+    operations.create(file, str(config), opts)  # operations provide logging and pretend
+
+    return struct, opts

--- a/src/pyscaffold/extensions/namespace.py
+++ b/src/pyscaffold/extensions/namespace.py
@@ -7,7 +7,6 @@ options **root_pkg** and **namespace_pkg** to the following functions in the
 action list.
 """
 
-import argparse
 import os
 from pathlib import Path
 
@@ -16,7 +15,7 @@ from ..file_system import chdir, move
 from ..identification import is_valid_identifier
 from ..log import logger
 from ..templates import get_template
-from . import Extension
+from . import Extension, store_with
 
 
 class Namespace(Extension):
@@ -32,7 +31,7 @@ class Namespace(Extension):
             self.flag,
             dest=self.name,
             default=None,
-            action=create_namespace_parser(self),
+            action=store_with(self),
             metavar="NS1[.NS2]",
             help="put your project inside a namespace package",
         )
@@ -53,33 +52,6 @@ class Namespace(Extension):
         actions = self.register(actions, add_namespace, before="version_migration")
 
         return self.register(actions, move_old_package, after="create_structure")
-
-
-def create_namespace_parser(obj_ref):
-    """Create a namespace parser.
-
-    Args:
-        obj_ref (Extension): object reference to the actual extension
-
-    Returns:
-        NamespaceParser: parser for namespace cli argument
-    """
-
-    class NamespaceParser(argparse.Action):
-        """Consumes the values provided, but also appends the extension
-           function to the extensions list.
-        """
-
-        def __call__(self, parser, namespace, values, option_string=None):
-            namespace.extensions.append(obj_ref)
-
-            # Now the extra parameters can be stored
-            setattr(namespace, self.dest, values)
-
-            # save the namespace cli argument for later
-            obj_ref.args = values
-
-    return NamespaceParser
 
 
 def prepare_namespace(namespace_str):

--- a/src/pyscaffold/extensions/namespace.py
+++ b/src/pyscaffold/extensions/namespace.py
@@ -35,6 +35,7 @@ class Namespace(Extension):
             metavar="NS1[.NS2]",
             help="put your project inside a namespace package",
         )
+        return self
 
     def activate(self, actions):
         """Register an action responsible for adding namespace to the package.

--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -159,7 +159,8 @@ def add_pyscaffold(config: ConfigUpdater, opts: ScaffoldOpts) -> ConfigUpdater:
 
     # Add the new extensions alongside the existing ones
     extensions = {ext.name for ext in opts.get("extensions", []) if ext.persist}
-    old = parse_extensions(pyscaffold.pop("extensions", ""))
+    old = pyscaffold.pop("extensions", "")
+    old = parse_extensions(getattr(old, "value", old))  # coerce configupdater return
     pyscaffold.set("extensions")
     pyscaffold["extensions"].set_values(sorted(old | extensions))
 

--- a/tests/extensions/helpers.py
+++ b/tests/extensions/helpers.py
@@ -1,0 +1,6 @@
+from pyscaffold import extensions
+
+
+def make_extension(name, **kwargs):
+    props = {"__doc__": f"activate {name}", **kwargs}
+    return type(name, (extensions.Extension,), props)()

--- a/tests/extensions/test_config.py
+++ b/tests/extensions/test_config.py
@@ -1,0 +1,187 @@
+import argparse
+from textwrap import dedent
+
+import pytest
+
+from pyscaffold import api, cli, info, templates, update
+from pyscaffold.extensions import config
+
+from .helpers import make_extension
+
+# ---- "Isolated" tests ----
+
+
+@pytest.fixture
+def default_file(fake_config_dir):
+    return fake_config_dir / "default.cfg"
+
+
+class ArgumentParser(argparse.ArgumentParser):
+    def exit(self, *_args, **_kwargs):
+        """Avoid argparse to exit on error"""
+
+
+def parse(*args, set_defaults={}):
+    parser = ArgumentParser()
+    parser.set_defaults(**set_defaults)
+    config.Config().augment_cli(parser)
+    return vars(parser.parse_args(args))
+
+
+def test_no_cli_opts(default_file):
+    # When no --config or --save-config is passed
+    cli_opts = parse()
+
+    # Then no save_config or config_files should be found in the opts
+    assert "save_files" not in cli_opts
+
+    # and config_files will be bootstraped with an empty list
+    # if the default file does not exist
+    opts = api.bootstrap_options(cli_opts)
+    assert opts["config_files"] == []
+
+    # or config_files will be bootstraped with the
+    # default file if it exists
+    default_file.write_text("[pyscaffold]\n")
+    opts = api.bootstrap_options(cli_opts)
+    assert opts["config_files"] == [default_file]
+
+
+def test_missing_config():
+    # When the --config opt is passed without a value, we have an error
+    with pytest.raises((argparse.ArgumentError, TypeError)):
+        # ^  TypeError happens because argparse tries to iterate over the --config opts
+        #    since it is marked with nargs='+'
+        parse("--config")
+
+
+def test_config_opts(default_file, fake_config_dir):
+    files = []
+    for j in range(3):
+        file = fake_config_dir / f"test{j}.cfg"
+        file.write_text("[pyscaffold]\n")
+        files.append(file)
+
+    # --config can be passed with 1 value
+    opts = parse("--config", str(files[0]))
+    assert opts["config_files"] == files[:1]
+
+    # --config can be passed with many
+    opts = parse("--config", *map(str, files))
+    assert opts["config_files"] == files
+
+    # after bootstrap_options, the given files are kept
+    # and the default is not included
+    opts = api.bootstrap_options(opts)
+    assert default_file not in opts["config_files"]
+    assert opts["config_files"] == files
+
+
+def test_no_config():
+    opts = parse("--no-config")
+    assert opts["config_files"] == api.NO_CONFIG
+
+    # Even after bootstrap_options
+    opts = api.bootstrap_options(opts)
+    assert opts["config_files"] == api.NO_CONFIG
+
+
+def test_save_config(default_file, fake_config_dir):
+    # With no value the default_file is used
+    opts = parse("--save-config")
+    opts["save_config"] == default_file
+
+    # With a value, the value is used
+    other_file = fake_config_dir / "other.cfg"
+    opts = parse("--save-config", str(other_file))
+    opts["save_config"] == other_file
+
+
+# ---- Integration tests ----
+
+
+def test_save_action(default_file):
+    # When the file does not exist
+    assert not default_file.exists()
+    opts = dict(author="author", email="email", license="mozilla")
+    config.save({}, {**opts, "save_config": default_file})
+    # it will create a valid file from the point of view of parsing
+    assert default_file.exists()
+    parsed = info.project({}, default_file)
+    assert all(parsed[k] == v for k, v in opts.items())
+    # and the file will contain instructions / references
+    assert "pyscaffold.org" in default_file.read_text()
+
+
+def existing_config(file):
+    text = dedent(
+        """\
+        [metadata]
+        author = John Doe
+        author-email = john.joe@fmail.com
+        license = gpl3
+
+        [pyscaffold]
+        # Comment
+        version = 3.78
+        extensions =
+            namespace
+            tox
+            travis
+        namespace = my_namespace.my_sub_namespace
+        """
+    )
+    file.write_text(text)
+    return file
+
+
+def test_save_action_existing_file(default_file, monkeypatch):
+    # Given default values that differ a bit from the given opts
+    monkeypatch.setattr(info, "username", lambda *_: "John Doe")
+    monkeypatch.setattr(info, "email", lambda *_: "email")
+    monkeypatch.setitem(api.DEFAULT_OPTIONS, "license", "mozilla")
+    opts = dict(author="author", email="email", license="mozilla")
+    # When the file exists and new config is saved
+    existing_config(default_file)
+    config.save({}, {**opts, "save_config": default_file})
+    # Then metadata that differs from default will change
+    expected = dict(author="author", email="john.joe@fmail.com", license="gpl3")
+    parsed = info.project({}, default_file)
+    assert all(parsed[k] == v for k, v in expected.items())
+
+
+def test_save_action_additional_extensions(default_file):
+    # Given the file exists
+    existing_config(default_file)
+    # When the new config is saved with new extensions
+    opts = dict(author="author", email="email", license="mozilla", my_extension1_opt=5)
+    extensions = [
+        make_extension("MyExtension1"),
+        make_extension("MyExtension2"),
+        make_extension("MyExtension3", persist=False),
+    ]
+    config.save({}, {**opts, "save_config": default_file, "extensions": extensions})
+    # The old ones are kept and the new ones are added,
+    # unless they specify persist=False
+    parsed = update.read_setupcfg(default_file).to_dict()["pyscaffold"]
+    print(default_file.read_text())
+    expected = {"namespace", "tox", "travis", "my_extension1", "my_extension2"}
+    assert templates.parse_extensions(parsed["extensions"]) == expected
+    assert parsed["namespace"] == "my_namespace.my_sub_namespace"
+    # Extension related opts are also saved
+    assert int(parsed["my_extension1_opt"]) == 5
+
+
+def test_cli_with_save_config(default_file, tmpfolder):
+    # Given a global config file does not exist
+    assert not default_file.exists()
+    # when the CLI is invoked with --save-config
+    cli.main("proj -l mozilla --namespace ns --travis --save-config".split())
+    # then the file will be created accordingly
+    assert default_file.exists()
+    parsed = update.read_setupcfg(default_file).to_dict()
+    assert parsed["metadata"]["license"] == "mozilla"
+    assert parsed["pyscaffold"]["namespace"] == "ns"
+    assert "travis" in parsed["pyscaffold"]["extensions"]
+    # and since the config extension has persist = False, it will not be stored
+    assert "config" not in parsed["pyscaffold"]["extensions"]

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,0 +1,50 @@
+import argparse
+
+from pyscaffold import extensions
+
+from .extensions.helpers import make_extension
+
+
+def test_extension():
+    parser = argparse.ArgumentParser()
+    extension = make_extension("MyExtension")
+    extension.augment_cli(parser)
+    opts = vars(parser.parse_args(["--my-extension"]))
+    assert opts["extensions"] == [extension]
+
+
+def test_extension_append():
+    parser = argparse.ArgumentParser()
+    extension1 = make_extension("MyExtension1")
+    extension2 = make_extension("MyExtension2")
+    parser.set_defaults(extensions=[extension1])
+
+    extension2.augment_cli(parser)
+    opts = vars(parser.parse_args(["--my-extension2"]))
+    assert opts["extensions"] == [extension1, extension2]
+
+
+def test_include():
+    parser = argparse.ArgumentParser()
+    my_extensions = [make_extension(f"MyExtension{n}") for n in range(7)]
+    parser.add_argument("--opt", nargs=0, action=extensions.include(*my_extensions))
+    opts = vars(parser.parse_args(["--opt"]))
+    assert opts["extensions"] == my_extensions
+
+
+def test_store_with():
+    parser = argparse.ArgumentParser()
+    my_extensions = [make_extension(f"MyExtension{n}") for n in range(7)]
+    parser.add_argument("--opt", action=extensions.store_with(*my_extensions))
+    opts = vars(parser.parse_args(["--opt", "42"]))
+    assert opts["extensions"] == my_extensions
+    assert opts["opt"] == "42"
+
+
+def test_store_with_type():
+    parser = argparse.ArgumentParser()
+    my_extensions = [make_extension(f"MyExtension{n}") for n in range(7)]
+    parser.add_argument("--opt", type=int, action=extensions.store_with(*my_extensions))
+    opts = vars(parser.parse_args(["--opt", "42"]))
+    assert opts["extensions"] == my_extensions
+    assert opts["opt"] == 42


### PR DESCRIPTION
Implements CLI options for managing config files and finally closes #236.

A bunch of re-usable code was extracted as well, specially in `pyscaffold.extensions`.
With the new functions the need for custom argparse actions becomes very small.

The system for persisting (or skipping persistence) extensions and extension options in the `setup.cfg` was also improved and documented.