### PR TITLE
Improve pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: '^(src/pyscaffold/contrib|docs/conf.py|docs/gfx)'
 
 repos:
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v3.1.0
+  rev: v3.2.0
   hooks:
   - id: trailing-whitespace
   - id: check-added-large-files
@@ -18,7 +18,7 @@ repos:
     args: ['--fix=no']
 
 - repo: http://github.com/timothycrosley/isort
-  rev: 5.0.9
+  rev: 5.2.2
   hooks:
   - id: isort
 

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -357,7 +357,7 @@ extension which defines the ``define_awesome_files`` action:
                     content="AWESOME!",
                     file_op=skip_on_update(create),
                     # The second argument is the file path, represented by a
-                    # os.PathLike object.
+                    # os.PathLike object or string.
                     # Alternatively in this example:
                     # Path("src", opts["package"], filename),
                 )

--- a/src/pyscaffold/actions.py
+++ b/src/pyscaffold/actions.py
@@ -36,19 +36,21 @@ from .structure import Structure, create_structure, define_structure
 from .update import version_migration
 
 if TYPE_CHECKING:
-    from .extensions import Extension
+    from .extensions import Extension  # avoid circular dependencies in runtime
 
 ScaffoldOpts = Dict[str, Any]
-"""Dictionary with PyScaffold's options, see :obj:`pyscaffold.api.create_project`.
-Should be treated as immutable (if required, copy before changing).
-"""
+"""Dictionary with PyScaffold's options, see :obj:`pyscaffold.api.create_project`."""
 
 Action = Callable[[Structure, ScaffoldOpts], Tuple[Structure, ScaffoldOpts]]
-"""Signature of a PyScaffold action"""
+"""Signature of a PyScaffold action, both arguments should be treated as immutable,
+but a copy of the arguments, modified by the extension might be returned.
+"""
 
 ActionParams = Tuple[Structure, ScaffoldOpts]
 """Both argument and return type of an action ``(struct, opts)``,
 so a sequence of actions work in pipeline.
+When actions run, they can return an updated copy of :obj:`Structure` and
+:obj:`ScaffoldOpts`.
 """
 
 

--- a/src/pyscaffold/api.py
+++ b/src/pyscaffold/api.py
@@ -85,7 +85,7 @@ def create_project(opts=None, **kwargs):
 
     Valid options include:
 
-    :Project Information:   - **project_path** (:class:`os.PathLike`)
+    :Project Information:   - **project_path** (:obj:`os.PathLike` or :obj:`str`)
 
     :Naming:                - **name** (*str*)
                             - **package** (*str*)

--- a/src/pyscaffold/extensions/pre_commit.py
+++ b/src/pyscaffold/extensions/pre_commit.py
@@ -3,18 +3,25 @@ Extension that generates configuration files for Yelp `pre-commit`_.
 
 .. _pre-commit: http://pre-commit.com
 """
+from typing import List
 
-from .. import structure
+from .. import shell, structure
+from ..actions import Action, ActionParams, ScaffoldOpts, Structure
+from ..exceptions import ShellCommandException
+from ..file_system import chdir
 from ..log import logger
 from ..operations import no_overwrite
 from ..templates import get_template
-from . import Extension
+from . import Extension, venv
+
+EXECUTABLE = "pre-commit"
+CMD_OPT = "____command-pre_commit"  # we don't want this to be persisted
 
 
 class PreCommit(Extension):
     """Generate pre-commit configuration file"""
 
-    def activate(self, actions):
+    def activate(self, actions: List[Action]) -> List[Action]:
         """Activate extension
 
         Args:
@@ -23,50 +30,70 @@ class PreCommit(Extension):
         Returns:
             list: updated list of actions
         """
-        actions = self.register(actions, self.add_files, after="define_structure")
-        return self.register(actions, self.instruct_user, before="report_done")
+        actions = self.register(actions, add_files, after="define_structure")
+        actions = self.register(actions, find_executable, after="define_structure")
+        return self.register(actions, install, before="report_done")
 
-    @staticmethod
-    def add_files(struct, opts):
-        """Add .pre-commit-config.yaml file to structure
 
-        Since the default template uses isort, this function also provides an
-        initial version of .isort.cfg that can be extended by the user
-        (it contains some useful skips, e.g. tox and venv)
+def add_files(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
+    """Add .pre-commit-config.yaml file to structure
 
-        Args:
-            struct (dict): project representation as (possibly) nested
-                :obj:`dict`.
-            opts (dict): given options, see :obj:`create_project` for
-                an extensive list.
+    Since the default template uses isort, this function also provides an
+    initial version of .isort.cfg that can be extended by the user
+    (it contains some useful skips, e.g. tox and venv)
+    """
+    files: Structure = {
+        ".pre-commit-config.yaml": (get_template("pre-commit-config"), no_overwrite()),
+        ".isort.cfg": (get_template("isort_cfg"), no_overwrite()),
+    }
 
-        Returns:
-            struct, opts: updated project representation and options
-        """
-        files = {
-            ".pre-commit-config.yaml": (
-                get_template("pre-commit-config"),
-                no_overwrite(),
-            ),
-            ".isort.cfg": (get_template("isort_cfg"), no_overwrite()),
-        }
+    return structure.merge(struct, files), opts
 
-        return structure.merge(struct, files), opts
 
-    @staticmethod
-    def instruct_user(struct, opts):
-        logger.warning(
-            "\nA `.pre-commit-config.yaml` file was generated inside your "
-            "project but in order to make sure the hooks will run, please "
-            "don't forget to install the `pre-commit` package:\n\n"
-            f"  cd {opts['project_path']}\n"
-            "  # it is a good idea to create and activate a virtualenv here\n"
-            "  pip install pre-commit\n"
-            "  pre-commit install\n"
-            "  # another good idea is update the hooks to the latest version\n"
-            "  # pre-commit autoupdate\n\n"
-            "You might also consider including similar instructions in your "
-            "docs, to remind the contributors to do the same.\n"
-        )
+def find_executable(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
+    """Find the pre-commit exectuable that should run later in the next action...
+    Or take advantage of the venv to install it...
+    """
+    pre_commit = shell.get_command(EXECUTABLE)
+    opts = opts.copy()
+    if pre_commit:
+        opts.setdefault(CMD_OPT, pre_commit)
+    else:
+        # We can try to add it for venv to install... it will only work if the user is
+        # already creating a venv anyway.
+        opts.setdefault("venv_install", []).extend(["pre-commit"])
 
-        return struct, opts
+    return struct, opts
+
+
+def install(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
+    """Attempts to install pre-commit in the project"""
+    pre_commit = opts.get(CMD_OPT, shell.get_command(EXECUTABLE, venv.get_path(opts)))
+    # ^  try again after venv, maybe it was installed
+    msg = (
+        "It is a good idea to update the hooks to the latest version:\n\n"
+        "  pre-commit autoupdate\n\n"
+        "Don't forget to tell your contributors to also install and use pre-commit.\n"
+    )
+    if pre_commit:
+        try:
+            with chdir(opts.get("project_path", ".")):
+                pre_commit("install")
+            logger.warning(f"\nA pre-commit hook was installed in your repo.\n{msg}")
+            return struct, opts
+        except ShellCommandException:
+            logger.error(
+                "\nImpossible to install pre-commit automatically, please open an "
+                "issue in https://github.com/pyscaffold/pyscaffold/issues.\n",
+                exc_info=True,
+            )
+
+    logger.warning(
+        "\nA `.pre-commit-config.yaml` file was generated inside your project but in "
+        "order to make sure the hooks will run, please install `pre-commit`:\n\n"
+        f"  cd {opts['project_path']}\n"
+        "  # it is a good idea to create and activate a virtualenv here\n"
+        "  pip install pre-commit\n"
+        f"  pre-commit install\n\n{msg}"
+    )
+    return struct, opts

--- a/src/pyscaffold/extensions/pre_commit.py
+++ b/src/pyscaffold/extensions/pre_commit.py
@@ -68,7 +68,8 @@ def find_executable(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
 
 def install(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
     """Attempts to install pre-commit in the project"""
-    pre_commit = opts.get(CMD_OPT, shell.get_command(EXECUTABLE, venv.get_path(opts)))
+    project_path = opts.get("project_path", "PROJECT_DIR")
+    pre_commit = opts.get(CMD_OPT) or shell.get_command(EXECUTABLE, venv.get_path(opts))
     # ^  try again after venv, maybe it was installed
     msg = (
         "It is a good idea to update the hooks to the latest version:\n\n"
@@ -91,7 +92,7 @@ def install(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
     logger.warning(
         "\nA `.pre-commit-config.yaml` file was generated inside your project but in "
         "order to make sure the hooks will run, please install `pre-commit`:\n\n"
-        f"  cd {opts['project_path']}\n"
+        f"  cd {project_path}\n"
         "  # it is a good idea to create and activate a virtualenv here\n"
         "  pip install pre-commit\n"
         f"  pre-commit install\n\n{msg}"

--- a/src/pyscaffold/extensions/venv.py
+++ b/src/pyscaffold/extensions/venv.py
@@ -1,19 +1,18 @@
 """Create a virtual environment for the project"""
 import argparse
-import os
 from contextlib import suppress
 from pathlib import Path
 from typing import List, Optional
 
 from .. import dependencies as deps
 from ..actions import Action, ActionParams, ScaffoldOpts, Structure
-from ..file_system import chdir
+from ..file_system import PathLike, chdir
 from ..identification import get_id
 from ..log import logger
 from ..shell import get_command, get_executable
 from . import Extension, store_with
 
-DEFAULT: os.PathLike = Path(".venv")
+DEFAULT: PathLike = ".venv"
 
 
 class Venv(Extension):

--- a/src/pyscaffold/shell.py
+++ b/src/pyscaffold/shell.py
@@ -8,10 +8,12 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 from .exceptions import ShellCommandException
 from .log import logger
+
+PathLike = Union[str, os.PathLike]
 
 
 class ShellCommand(object):
@@ -126,14 +128,16 @@ def command_exists(cmd):
 git = get_git_cmd()
 
 
-def get_executable(name: str, prefix=sys.prefix, include_path=True) -> Optional[str]:
+def get_executable(
+    name: str, prefix: PathLike = sys.prefix, include_path=True
+) -> Optional[str]:
     """Find an executable in the system, if available.
 
     Args:
         name: name of the executable
-        include_path (bool): when true the functions tries to look in the entire $PATH.
-        prefix (os.PathLike): look on this directory, exclusively or in additon to $PATH
+        prefix (PathLike): look on this directory, exclusively or in additon to $PATH
             depending on the value of ``include_path``.
+        include_path (bool): when true the functions tries to look in the entire $PATH.
     """
     executable = shutil.which(name)
     if include_path and executable:
@@ -150,7 +154,7 @@ def get_executable(name: str, prefix=sys.prefix, include_path=True) -> Optional[
 
 
 def get_command(
-    name: str, prefix=sys.prefix, include_path=True, **kwargs
+    name: str, prefix: PathLike = sys.prefix, include_path=True, **kwargs
 ) -> Optional[ShellCommand]:
     """Similar to :obj:`get_executable` but return an instance of :obj:`ShellCommand`
     if it is there to be found.

--- a/src/pyscaffold/structure.py
+++ b/src/pyscaffold/structure.py
@@ -6,13 +6,12 @@
    :obj:`~string.Template.safe_substitute`)
 """
 from copy import deepcopy
-from os import PathLike
 from pathlib import Path
 from string import Template
 from typing import Callable, Dict, Optional, Tuple, Union, cast
 
 from . import templates
-from .file_system import create_directory
+from .file_system import PathLike, create_directory
 from .operations import (
     FileContents,
     FileOp,
@@ -198,11 +197,10 @@ def modify(
     created.
 
     Args:
-        struct (Structure): project representation as (possibly) nested
-            :obj:`dict`. See :obj:`~.merge`.
+        struct: project representation as (possibly) nested dict. See :obj:`~.merge`.
 
-        path (os.PathLike): path-like string or object relative to the
-            structure root. The following examples are equivalent::
+        path: path-like string or object relative to the structure root.
+            The following examples are equivalent::
 
                 from pathlib import Path
 
@@ -230,7 +228,7 @@ def modify(
        handling the new :obj:`pyscaffold.operations` API.
 
     Returns:
-        Structure: updated project tree representation
+        Updated project tree representation
 
     Note:
         Use an empty string as content to ensure a file is created empty
@@ -267,15 +265,15 @@ def ensure(
     All the parent directories are automatically created.
 
     Args:
-        struct (Structure): project representation as (possibly) nested.
+        struct: project representation as (possibly) nested.
 
-        path (os.PathLike): path-like string or object relative to the
-            structure root. See :obj:`~.modify`.
+        path: path-like string or object relative to the structure root.
+            See :obj:`~.modify`.
 
             .. versionchanged:: 4.0
                The function no longer accepts a list of strings of path parts.
 
-        content (str): file text contents, ``None`` by default.
+        content: file text contents, ``None`` by default.
             The old content is preserved if ``None``.
 
         file_op: see :obj:`pyscaffold.operations`, :obj:`~.create`` by default.
@@ -285,7 +283,7 @@ def ensure(
        <pyscaffold.oprtations.FileOp>`.
 
     Returns:
-        Structure: updated project tree representation
+        Updated project tree representation
 
     Note:
         Use an empty string as content to ensure a file is created empty.
@@ -299,16 +297,16 @@ def reject(struct: Structure, path: PathLike) -> Structure:
     """Remove a file from the project tree representation if existent.
 
     Args:
-        struct (Structure): project representation as (possibly) nested.
+        struct: project representation as (possibly) nested.
 
-        path (os.PathLike): path-like string or object relative to the
-            structure root. See :obj:`~.modify`.
+        path: path-like string or object relative to the structure root.
+            See :obj:`~.modify`.
 
             .. versionchanged:: 4.0
                The function no longer accepts a list of strings of path parts.
 
     Returns:
-        Structure: modified project tree representation
+        Modified project tree representation
     """
     # Retrieve a list of parts from a path-like object
     path_parts = Path(path).parts
@@ -334,10 +332,8 @@ def merge(old: Structure, new: Structure) -> Structure:
     Basically a deep dictionary merge, except from the leaf update method.
 
     Args:
-        old (Structure): directory descriptor that takes low precedence
-                         during the merge
-        new (Structure): directory descriptor that takes high precedence
-                         during the merge
+        old: directory descriptor that takes low precedence during the merge.
+        new: directory descriptor that takes high precedence during the merge.
 
 
     .. versionchanged:: 4.0
@@ -345,7 +341,7 @@ def merge(old: Structure, new: Structure) -> Structure:
         top level project folder.
 
     Returns:
-        Structure: resulting merged directory representation
+        Resulting merged directory representation
 
     Note:
         Use an empty string as content to ensure a file is created empty.
@@ -382,17 +378,15 @@ def _merge_leaf(old_value: Leaf, new_value: Leaf) -> Leaf:
     ``None`` is used for the update rule.
 
     Args:
-        old_value (tuple or str): descriptor for the file that takes low
-                                  precedence during the merge
-        new_value (tuple or str): descriptor for the file that takes high
-                                  precedence during the merge
+        old_value: descriptor for the file that takes low precedence during the merge.
+        new_value: descriptor for the file that takes high precedence during the merge.
 
     Note:
         ``None`` contents are ignored, use and empty string to force empty
         contents.
 
     Returns:
-        tuple or str: resulting value for the merged leaf
+        Resulting value for the merged leaf
     """
     old = old_value if isinstance(old_value, (list, tuple)) else (old_value, None)
     new = new_value if isinstance(new_value, (list, tuple)) else (new_value, None)

--- a/src/pyscaffold/templates/pre-commit-config.template
+++ b/src/pyscaffold/templates/pre-commit-config.template
@@ -2,7 +2,7 @@ exclude: '^docs/conf.py'
 
 repos:
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v3.1.0
+  rev: v3.2.0
   hooks:
   - id: trailing-whitespace
   - id: check-added-large-files
@@ -18,7 +18,7 @@ repos:
     args: ['--fix=no']
 
 - repo: http://github.com/timothycrosley/isort
-  rev: 5.0.9
+  rev: 5.2.2
   hooks:
   - id: isort
 

--- a/src/pyscaffold/templates/readme.template
+++ b/src/pyscaffold/templates/readme.template
@@ -10,6 +10,8 @@ Description
 A longer description of your project goes here...
 
 
+.. pyscaffold-notes::
+
 Note
 ====
 

--- a/src/pyscaffold/update.py
+++ b/src/pyscaffold/update.py
@@ -1,8 +1,10 @@
 """
 Functionality to update one PyScaffold version to another
 """
+import os
 from functools import reduce
 from pathlib import Path
+from typing import TYPE_CHECKING, Optional, Union
 
 from pkg_resources import parse_version
 
@@ -12,16 +14,21 @@ from . import __version__ as pyscaffold_version
 from . import dependencies as deps
 from .log import logger
 
+PathLike = Union[str, os.PathLike]
 
-def read_setupcfg(path, filename=None):
+if TYPE_CHECKING:
+    # ^  avoid circular dependencies in runtime
+    from .actions import ActionParams, ScaffoldOpts, Structure
+
+
+def read_setupcfg(path: PathLike, filename: Optional[PathLike] = None) -> ConfigUpdater:
     """Reads-in a configuration file that follows a setup.cfg format.
     Useful for retrieving stored information (e.g. during updates)
 
     Args:
-        path (os.PathLike): path where to find the config file
-        filename (os.PathLike): if ``path`` is a directory,
-            ``name`` will be considered a file relative to ``path``
-            to read (default: setup.cfg)
+        path: path where to find the config file
+        filename: if ``path`` is a directory, ``name`` will be considered a file
+            relative to ``path`` to read (default: setup.cfg)
 
     Returns:
         ConfigUpdater: object that can be used to read/edit configuration
@@ -39,7 +46,7 @@ def read_setupcfg(path, filename=None):
     return updater
 
 
-def get_curr_version(project_path):
+def get_curr_version(project_path: PathLike):
     """Retrieves the PyScaffold version that put up the scaffold
 
     Args:
@@ -52,12 +59,12 @@ def get_curr_version(project_path):
     return parse_version(setupcfg["pyscaffold"]["version"])
 
 
-def version_migration(struct, opts):
+def version_migration(struct: "Structure", opts: "ScaffoldOpts") -> "ActionParams":
     """Migrations from one version to another
 
     Args:
-        struct (dict): previous directory structure (ignored)
-        opts (dict): options of the project
+        struct: previous directory structure (ignored)
+        opts: options of the project
 
     Returns:
         tuple(dict, dict):
@@ -85,16 +92,15 @@ def version_migration(struct, opts):
     return struct, opts
 
 
-def add_entrypoints(struct, opts):
+def add_entrypoints(struct: "Structure", opts: "ScaffoldOpts") -> "ActionParams":
     """Add [options.entry_points] to setup.cfg
 
     Args:
-        struct (dict): previous directory structure (ignored)
-        opts (dict): options of the project
+        struct: previous directory structure (ignored)
+        opts: options of the project
 
     Returns:
-        tuple(dict, dict):
-            structure as dictionary of dictionaries and input options
+        Structure as dictionary of dictionaries and input options
     """
     setupcfg = read_setupcfg(opts["project_path"])
     section_str = """[options.entry_points]
@@ -127,12 +133,12 @@ def add_entrypoints(struct, opts):
     return struct, opts
 
 
-def update_pyscaffold_version(project_path, pretend):
+def update_pyscaffold_version(project_path: PathLike, pretend: bool):
     """Update `setup_requires` in setup.cfg
 
     Args:
-        project_path (str): path to project
-        pretend (bool): only pretend to do something
+        project_path: path to project
+        pretend: only pretend to do something
     """
     setupcfg = read_setupcfg(project_path)
     comment = "# AVOID CHANGING SETUP_REQUIRES! IT WILL BE UPDATED BY PYSCAFFOLD!"

--- a/tests/extensions/test_pre_commit.py
+++ b/tests/extensions/test_pre_commit.py
@@ -2,10 +2,76 @@
 import logging
 import sys
 from pathlib import Path
+from unittest.mock import Mock
 
+from pyscaffold import shell
 from pyscaffold.api import create_project
 from pyscaffold.cli import run
 from pyscaffold.extensions import pre_commit
+
+
+def assert_in_logs(caplog, *expected):
+    log = caplog.text
+    for text in expected:
+        assert text in log
+
+
+# ---- "Isolated" tests ----
+
+
+def test_find_executable(monkeypatch):
+    # When an executable can be found
+    exec = Mock()
+    monkeypatch.setattr(shell, "get_command", Mock(return_value=exec))
+    _, opts = pre_commit.find_executable({}, {})
+    # then pre-commit should no be added to venv_install
+    assert "pre-commit" not in opts.get("venv_install", [])
+    # and the command should be stored in opts
+    assert opts[pre_commit.CMD_OPT] == exec
+
+    # When an executable can not be found
+    monkeypatch.setattr(shell, "get_command", Mock(return_value=None))
+    _, opts = pre_commit.find_executable({}, {})
+    # then pre-commit should be added to venv_install
+    assert "pre-commit" in opts.get("venv_install", [])
+    # and the command should not be stored in opts
+    assert pre_commit.CMD_OPT not in opts
+
+
+def test_install(monkeypatch, caplog):
+    caplog.set_level(logging.WARNING)
+    # When an executable can be found
+    exec = Mock()
+    monkeypatch.setattr(shell, "get_command", Mock(return_value=exec))
+    pre_commit.install({}, {})
+    # then `pre-commit` install should run
+    exec.assert_called_once_with("install")
+
+    # When no executable can be found
+    monkeypatch.setattr(shell, "get_command", Mock(return_value=None))
+    pre_commit.install({}, {})
+    # then the proper log message should be displayed
+    assert_in_logs(caplog, "please install", "pre-commit install")
+
+    # When an error occurs during installation
+    caplog.set_level(logging.ERROR)
+    exec = Mock(side_effect=shell.ShellCommandException)
+    monkeypatch.setattr(shell, "get_command", Mock(return_value=exec))
+    # then PyScaffold should not stop, only log the error.
+    pre_commit.install({}, {})
+    assert_in_logs(caplog, "pre-commit", "pyscaffold/issues")
+
+    # When a command is available in opts
+    cmd = Mock()
+    exec = Mock()
+    monkeypatch.setattr(shell, "get_command", Mock(return_value=exec))
+    # then it should be ussed, and get_command not called
+    pre_commit.install({}, {pre_commit.CMD_OPT: cmd})
+    cmd.assert_called_once_with("install")
+    exec.assert_not_called()
+
+
+# ---- Integration tests ----
 
 
 def test_create_project_with_pre_commit(tmpfolder, caplog):

--- a/tests/extensions/test_pre_commit.py
+++ b/tests/extensions/test_pre_commit.py
@@ -21,11 +21,7 @@ def test_create_project_with_pre_commit(tmpfolder, caplog):
     assert Path("proj/.isort.cfg").exists()
 
     # and the user should be instructed to install pre-commit
-    expected_warnings = (
-        "to make sure the hooks will run",
-        "cd proj",
-        "pre-commit install",
-    )
+    expected_warnings = ("pre-commit autoupdate",)
     log = caplog.text
     for text in expected_warnings:
         assert text in log

--- a/tests/extensions/test_pre_commit.py
+++ b/tests/extensions/test_pre_commit.py
@@ -8,6 +8,7 @@ from pyscaffold import shell
 from pyscaffold.api import create_project
 from pyscaffold.cli import run
 from pyscaffold.extensions import pre_commit
+from pyscaffold.templates import get_template
 
 
 def assert_in_logs(caplog, *expected):
@@ -51,7 +52,8 @@ def test_install(monkeypatch, caplog):
     monkeypatch.setattr(shell, "get_command", Mock(return_value=None))
     pre_commit.install({}, {})
     # then the proper log message should be displayed
-    assert_in_logs(caplog, "please install", "pre-commit install")
+    msg = pre_commit.INSTALL_MSG.format(project_path="PROJECT_DIR")
+    assert_in_logs(caplog, msg)
 
     # When an error occurs during installation
     caplog.set_level(logging.ERROR)
@@ -59,7 +61,7 @@ def test_install(monkeypatch, caplog):
     monkeypatch.setattr(shell, "get_command", Mock(return_value=exec))
     # then PyScaffold should not stop, only log the error.
     pre_commit.install({}, {})
-    assert_in_logs(caplog, "pre-commit", "pyscaffold/issues")
+    assert_in_logs(caplog, pre_commit.ERROR_MSG)
 
     # When a command is available in opts
     cmd = Mock()
@@ -69,6 +71,14 @@ def test_install(monkeypatch, caplog):
     pre_commit.install({}, {pre_commit.CMD_OPT: cmd})
     cmd.assert_called_once_with("install")
     exec.assert_not_called()
+
+
+def test_add_instructions():
+    old_text = get_template("readme")
+    opts = {"title": "proj", "name": "proj", "description": "desc", "version": "99.9"}
+    new_text, _ = pre_commit.add_instructions(opts, old_text, Mock())
+    note = pre_commit.README_NOTE.format(**opts)
+    assert note in new_text
 
 
 # ---- Integration tests ----
@@ -85,12 +95,11 @@ def test_create_project_with_pre_commit(tmpfolder, caplog):
     # then pre-commit files should exist
     assert Path("proj/.pre-commit-config.yaml").exists()
     assert Path("proj/.isort.cfg").exists()
+    note = pre_commit.README_NOTE.format(name="proj")
+    assert note in Path("proj/README.rst").read_text()
 
-    # and the user should be instructed to install pre-commit
-    expected_warnings = ("pre-commit autoupdate",)
-    log = caplog.text
-    for text in expected_warnings:
-        assert text in log
+    # and the user should be instructed to update pre-commit
+    assert_in_logs(caplog, pre_commit.UPDATE_MSG)
 
 
 def test_create_project_without_pre_commit(tmpfolder):


### PR DESCRIPTION
Everytime `--pre-commit` flag is used, the users are left with the task of manually installing it to the repo, and sometimes they forget.

This is an attempt to improve that workflow by automatically installing the hooks if possible.