### PR TITLE
Simplify/remove some things from setup.cfg

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -30,12 +30,8 @@ In case you have a general question that is not answered here, consider submitti
    But don't worry, if you distribute your project in the recommended `wheel format`_ those dependencies will not affect
    the final users, they are just required during development to assembling the package file.
 
-   That means if someone clones your repository and runs ``setup.py``, ``setuptools`` checks for the ``setup_requires``
-   argument and installs the dependencies automatically as `egg file`_ into ``.eggs`` if they are not yet
-   installed. This mechanism is provided by ``setuptools`` and definitely beyond the scope of this answer. The same
-   applies for the deprecated source distribution (``sdist``) but not for a binary distribution (``bdist``).
-   Anyways, the recommend way is nowadays a binary wheel distribution (``bdist_wheel``) which will not depend on the
-   other dependencies we include at all.
+   That means if someone clones your repository and tries to build it, the dependencies in ``pyproject.toml``
+   will be automatically pulled. This mechanism is described by `PEP 517`_/`PEP 518`_ and definitely beyond the scope of this answer.
 
 |
 
@@ -86,18 +82,29 @@ In case you have a general question that is not answered here, consider submitti
    * ``.gitignore`` with some nice defaults and other dot files depending on the flags used when running ``putup``,
    * some sane defaults for pytest.
 
-   For further cleanups, feel free to remove the dependencies from the ``setup_requires`` key in ``setup.cfg`` as well as
-   the complete ``[pyscaffold]`` section.
+   For further cleanups, feel free to remove the dependencies from the ``requires`` key in ``pyproject.toml`` as well as
+   the complete ``[pyscaffold]`` section in ``setup.cfg``.
 
 |
 
-6. **Can I modify** ``setup_requires`` **despite the warning in** ``setup.cfg`` **to avoid doing that?**
+6. **Can I modify** ``requires`` **despite the warning in** ``pyproject.toml`` **to avoid doing that?**
 
-   You can definitely modify ``setup_requires``, but it is good to understand how PyScaffold uses it.
+   You can definitely modify ``pyproject.toml``, but it is good to understand how PyScaffold uses it.
    If you are just adding a new build dependency (e.g. `Cython`_), there is nothing to worry.
    However, if you are trying to remove or change the version of a dependency PyScaffold included there,
    PyScaffold will overwrite that change if you ever run ``putup --update`` in the same project
    (in those cases ``git diff`` is your friend, and you should be able to manually reconcile the dependencies).
+
+|
+
+7. **What should I do if I am not using** ``pyproject.toml``?
+
+   If you prefer to have legacy builds, you can remove the ``pyproject.toml`` file and run
+   ``python setup.py bdist_wheel``, but we advise to install the build requirements (as the ones specified in the
+   ``requires`` field of ``pyproject.toml``) in an `isolated environment`_ and use it to run the ``setup.py`` commands
+   (`tox`_ can be really useful for that). Alternatively you can use the ``setup_requires`` field in `setup.cfg`_,
+   however, this method is discouraged and might be invalid in the future. To skip the generation of the
+   ``pyproject.toml`` file you can run ``putup`` with the ``--no-pyproject`` flag.
 
 |
 
@@ -112,3 +119,8 @@ In case you have a general question that is not answered here, consider submitti
 .. _Twitter: https://twitter.com/FlorianWilhelm
 .. _setuptools_scm: https://pypi.org/project/setuptools-scm/
 .. _Cython: https://cython.org
+.. _PEP 517: https://www.python.org/dev/peps/pep-0517/
+.. _PEP 518: https://www.python.org/dev/peps/pep-0518/
+.. _isolated environment: https://realpython.com/python-virtual-environments-a-primer/
+.. _setup.cfg: https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
+.. _tox: https://tox.readthedocs.org/

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -88,7 +88,7 @@ Your project is already an initialised Git repository and ``setup.py`` uses
 the information of tags to infer the version of your project with the help of `setuptools_scm`_.
 To use this feature you need to tag with the format ``MAJOR.MINOR[.PATCH]``
 , e.g. ``0.0.1`` or ``0.1``.
-Run ``python setup.py --version`` to retrieve the current `PEP440`_-compliant version.
+Run ``python setup.py --version`` to retrieve the current `PEP 440`_-compliant version.
 This version will be used when building a package and is also accessible through
 ``my_project.__version__``. If you want to upload to PyPI_ you have to tag the current commit
 before uploading since PyPI_ does not allow local versions, e.g. ``0.0.dev5+gc5da6ad``,
@@ -222,13 +222,13 @@ Run ``tox`` to generate test virtual environments for various python
 environments defined in the generated :file:`tox.ini`. Testing and building
 *sdists* for python 2.7 and python 3.6 is just as simple with tox as::
 
-        tox -e py27,py36
+    tox -e py27,py36
 
 Environments for tests with the the static code analyzers pyflakes and pep8
 which are bundled in `flake8`_ are included
 as well. Run it explicitly with::
 
-        tox -e flake8
+    tox -e flake8
 
 With tox, you can use the ``--recreate`` flag to force tox to create new
 environments. By default, PyScaffold's tox configuration will execute tests for
@@ -275,9 +275,6 @@ PyScaffold comes with several extensions:
 * Have a ``README.md`` based on MarkDown instead of ``README.rst`` by using
   ``--markdown`` after having installed `pyscaffoldext-markdown`_ with ``pip``.
 
-* Add a ``pyproject.toml`` file according to `PEP 518`_ to your template by using
-  ``--pyproject`` after having installed `pyscaffoldext-pyproject`_ with ``pip``.
-
 * With the help of `Cookiecutter`_ it is possible to further customize your project
   setup with a template tailored for PyScaffold.
   Just install `pyscaffoldext-cookiecutter`_ and add ``--cookiecutter TEMPLATE``
@@ -300,29 +297,8 @@ An update will only overwrite files that are not often altered by users like
 An existing project that was not setup with PyScaffold can be converted with
 ``putup --force existing_project``. The force option is completely safe to use
 since the git repository of the existing project is not touched!
-Also check out if :ref:`configuration options <configuration>` in
-``setup.cfg`` have changed.
-
-
-Updates from PyScaffold 2
--------------------------
-
-Since the overall structure of a project set up with PyScaffold 2 differs quite
-much from a project generated with PyScaffold 3 it is not possible to just use
-the ``--update`` parameter. Still with some manual efforts an update from
-a scaffold generated with PyScaffold 2 to PyScaffold 3's scaffold is quite easy.
-Assume the name of our project is ``old_project`` with a package called
-``old_package`` and no namespaces then just:
-
-1) make sure your worktree is not dirty, i.e. commit all your changes,
-2) run ``putup old_project --force --no-skeleton -p old_package`` to generate
-   the new structure inplace and ``cd`` into your project,
-3) move with ``git mv old_package/* src/old_package/ --force`` your old package
-   over to the new ``src`` directory,
-4) check ``git status`` and add untracked files from the new structure,
-5) use ``git difftool`` to check all overwritten files, especially ``setup.cfg``,
-   and transfer custom configurations from the old structure to the new,
-6) check if ``python setup.py test sdist`` works and commit your changes.
+Please check out the :ref:`updating` docs for more information on how to migrate
+from old versions and :ref:`configuration options <configuration>` in ``setup.cfg``.
 
 Adding features
 ---------------
@@ -366,7 +342,7 @@ Check out our :ref:`Configuration <default-cfg>` section to get started.
 .. _flake8: http://flake8.readthedocs.org/
 .. _GitLab: https://gitlab.com/
 .. _tox: https://tox.readthedocs.org/
-.. _PEP440: http://www.python.org/dev/peps/pep-0440/
+.. _PEP 440: http://www.python.org/dev/peps/pep-0440/
 .. _pre-commit hooks: http://pre-commit.com/
 .. _setuptools_scm: https://pypi.python.org/pypi/setuptools_scm/
 .. _pytest: http://pytest.org/
@@ -379,7 +355,6 @@ Check out our :ref:`Configuration <default-cfg>` section to get started.
 .. _pyscaffoldext-pyproject: https://github.com/pyscaffold/pyscaffoldext-pyproject
 .. _pyscaffoldext-django: https://github.com/pyscaffold/pyscaffoldext-django
 .. _pyscaffoldext-cookiecutter: https://github.com/pyscaffold/pyscaffoldext-cookiecutter
-.. _PEP 518: https://www.python.org/dev/peps/pep-0518/
 .. _PyScaffold organisation: https://github.com/pyscaffold/
 .. _Semantic Versioning: https://semver.org/
 .. _dependency hell: https://en.wikipedia.org/wiki/Dependency_hell

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,7 @@ Contents
 
    Features <features>
    Installation <install>
+   Updating <updating>
    Examples <examples>
    Configuration <configuration>
    Dependency Management <dependencies>

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -38,8 +38,8 @@ Let's start:
    In most cases you will not need to make changes to the new ``setup.py`` file provided by PyScaffold.
    The only exceptions are if your project uses compiled resources, e.g. Cython.
 
-#. In order to check that everything works, run ``python setup.py install`` and ``python setup.py sdist``.
-   If those two commands don't work, check ``setup.cfg``, ``setup.py`` as well as your package under ``src`` again.
+#. In order to check that everything works, run ``pip install .`` and ``python setup.py sdist``.
+   If those two commands don't work, check ``pyproject.toml``, ``setup.cfg``, ``setup.py`` as well as your package under ``src`` again.
    Were all modules moved correctly? Is there maybe some ``__init__.py`` file missing?
    After these basic commands, try also to run ``make -C docs html`` and ``pytest`` (or preferably their ``tox`` equivalents)
    to check that Sphinx and PyTest run correctly.

--- a/docs/updating.rst
+++ b/docs/updating.rst
@@ -1,0 +1,70 @@
+.. _updating:
+
+===============================
+Updating from Previous Versions
+===============================
+
+When updating a project generated with the same major version of PyScaffold
+[#up1]_, running ``putup --update`` should be enough to get you going.
+However updating from previous major versions of PyScaffold will probably
+require some manual adjustments. The following sections describe how to update
+from one major version into the following one.
+
+.. warning::
+   Before updating make sure to commit all the pending changes in your
+   repository. If something does not work exactly how you expected after the
+   update, please revise the changes using a ``diff`` and perform the necessary
+   corrections.
+
+
+Updates from PyScaffold 2 to PyScaffold 3
+-----------------------------------------
+
+Since the overall structure of a project set up with PyScaffold 2 differs quite
+much from a project generated with PyScaffold 3 it is not possible to just use
+the ``--update`` parameter. Still with some manual efforts an update from
+a scaffold generated with PyScaffold 2 to PyScaffold 3's scaffold is quite easy.
+Assume the name of our project is ``old_project`` with a package called
+``old_package`` and no namespaces then just:
+
+1) make sure your worktree is not dirty, i.e. commit all your changes,
+2) run ``putup old_project --force --no-skeleton -p old_package`` to generate
+   the new structure inplace and ``cd`` into your project,
+3) move with ``git mv old_package/* src/old_package/ --force`` your old package
+   over to the new ``src`` directory,
+4) check ``git status`` and add untracked files from the new structure,
+5) use ``git difftool`` to check all overwritten files, especially ``setup.cfg``,
+   and transfer custom configurations from the old structure to the new,
+6) check if ``python setup.py test sdist`` works and commit your changes.
+
+
+Updates from PyScaffold 3 to PyScaffold 4
+-----------------------------------------
+
+Most of the time, updating from PyScaffold 3 should be completely automatic.
+However, since in version 4 we have adopted Python's new standards for
+packaging (`PEP 517`_/`PEP 518`_), you might find the new build process incompatible.
+
+If that is the case, you can use the ``--no-pyproject`` flag to keep using the
+legacy behaviour. You will need, though, to manually remove PyScaffold from
+your build dependencies (``setup_requires`` in ``setup.cfg``) and add
+`setuptools_scm`_.
+
+Please note that the use of ``setup_requires`` is discouraged. If you are using
+``pyproject.toml``, PyScaffold will remove this field automatically and transfer
+the dependencies to the ``pyproject.toml :: build-system.requires`` field.
+However, if you are using legacy builds we will not remove it. You might be
+interested in doing that yourself and using other tools like `tox`_ to build
+your project with the correct dependencies in place. With `tox`_ you can specify a
+``build`` testenv with the `skip_install`_ option and the required build time
+dependencies in ``deps``.
+
+.. [#up1] PyScaffold uses 3 numbers for its version: ``MAJOR.MINOR.PATCH``
+   (when the numbers on the right are missing, just assume them as being 0),
+   so PyScaffold 3.1.2 has the same major version as PyScaffold 3.3.1, but not
+   PyScaffold 4.
+
+.. _PEP 517: https://www.python.org/dev/peps/pep-0517/
+.. _PEP 518: https://www.python.org/dev/peps/pep-0518/
+.. _tox: https://tox.readthedocs.org/
+.. _skip_install: https://tox.readthedocs.io/en/latest/config.html#conf-skip_install

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,9 +21,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Environment :: Console
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
@@ -39,9 +36,6 @@ python_requires = >=3.6
 include_package_data = True
 package_dir =
     =src
-setup_requires =
-    wheel
-    setuptools_scm>=4.1.2
 install_requires =
     appdirs>=1.4.4,<2
     configupdater>=1.0.1,<2
@@ -71,12 +65,14 @@ ds =
     pyscaffoldext-dsproject
 # Add here test dependencies (used by tox)
 testing =
+    tomlkit     # as dependency in `-e fast`
     certifi     # tries to prevent certificate problems on windows
     tox         # system tests use tox inside tox
     pep517      # system tests use pep517 to build projects
     pre-commit  # system tests run pre-commit
     sphinx      # system tests build docs
     flake8      # system tests run flake8
+    virtualenv  # virtualenv as dependency for the venv extension in `-e fast`
     pytest
     pytest-cov
     pytest-shutil
@@ -86,7 +82,6 @@ testing =
     # We keep pytest-xdist in the test dependencies, so the developer can
     # easily opt-in for distributed tests by adding, for example, the `-n 15`
     # arguments in the command-line.
-    virtualenv
 
 [options.entry_points]
 distutils.setup_keywords =

--- a/src/pyscaffold/api.py
+++ b/src/pyscaffold/api.py
@@ -137,8 +137,7 @@ def create_project(opts=None, **kwargs):
     pipeline = actions.discover(opts["extensions"])
 
     # call the actions to generate final struct and opts
-    struct, opts = reduce(actions.invoke, pipeline, ({}, opts))
-    return struct, opts
+    return reduce(actions.invoke, pipeline, ({}, opts))
 
 
 # -------- Auxiliary functions (Private) --------

--- a/src/pyscaffold/api.py
+++ b/src/pyscaffold/api.py
@@ -30,7 +30,6 @@ DEFAULT_OPTIONS = {
     "url": "https://github.com/pyscaffold/pyscaffold/",
     "license": "mit",
     "version": pyscaffold.__version__,
-    "classifiers": ["Development Status :: 4 - Beta", "Programming Language :: Python"],
     "extensions": [],
     "config_files": [],  # Overloaded in bootstrap_options for lazy evaluation
 }

--- a/src/pyscaffold/cli.py
+++ b/src/pyscaffold/cli.py
@@ -251,9 +251,9 @@ def main(args):
 
 @shell_command_error2exit_decorator
 @exceptions2exit([RuntimeError])
-def run():
+def run(args=None):
     """Entry point for console script"""
-    main(sys.argv[1:])
+    main(args or sys.argv[1:])
 
 
 if __name__ == "__main__":

--- a/src/pyscaffold/extensions/no_pyproject.py
+++ b/src/pyscaffold/extensions/no_pyproject.py
@@ -24,7 +24,13 @@ class NoPyProject(Extension):
     name = "no_pyproject"
 
     def activate(self, actions: List[Action]) -> List[Action]:
+        actions = self.register(actions, ensure_option, before="get_default_options")
         return self.register(actions, remove_files, after="define_structure")
+
+
+def ensure_option(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
+    """Make option available in non-CLI calls (used by other parts of PyScaffold)"""
+    return struct, {**opts, "pyproject": False, "isolated_build": False}
 
 
 def remove_files(struct: Structure, opts: ScaffoldOpts) -> ActionParams:

--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -203,15 +203,7 @@ def project(opts, config_path=None, config_file=None):
 
     # Overwrite only if user has not provided corresponding cli argument
     # Derived/computed parameters should be set by `get_default_options`
-    existing.update(opts)  # existing opts will be overwritten by cli given opts
-    opts = existing  # ^  equivalent of dict merge
-
-    # Merge classifiers
-    if "classifiers" in metadata:
-        classifiers = (c.strip() for c in metadata["classifiers"].strip().split("\n"))
-        classifiers = {c for c in classifiers if c}
-        existing_classifiers = {c for c in opts.get("classifiers", []) if c}
-        opts["classifiers"] = sorted(existing_classifiers | classifiers)
+    opts = {**existing, **opts}
 
     # Complement the cli extensions with the ones from configuration
     if "extensions" in pyscaffold:

--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -114,26 +114,16 @@ def setup_cfg(opts: ScaffoldOpts) -> str:
     cfg_str = template.substitute(opts)
 
     updater = ConfigUpdater()
-    updater.read_string(cfg_str)
 
-    # add `classifiers`
-    help = "Add here all kinds of additional classifiers as defined under"
-    ref = "https://pypi.python.org/pypi?%3Aaction=list_classifiers"
-    metadata = updater["metadata"]
-    metadata["platforms"].add_after.comment(help).comment(ref).option("classifiers")
-    metadata["classifiers"].set_values(opts["classifiers"])
-
-    # add `setup_requires` and `install_requires`
-    options = updater["options"]
-    setup_requires = options["setup_requires"]
-    setup_requires.set_values(list(deps.BUILD).copy())
-    if opts["requirements"]:
-        setup_requires.add_after.option("install_requires")
-        options["install_requires"].set_values(list(opts["requirements"]).copy())
+    if opts["requirements"]:  # uncomment/add install_requires
+        cfg_str = cfg_str.replace("# install_requires =", "install_requires =")
+        updater.read_string(cfg_str)
+        updater["options"]["install_requires"].set_values(list(opts["requirements"])[:])
     else:
-        help = "Add here dependencies of your project (semicolon/line-separated), e.g."
-        example = "install_requires = numpy; scipy"
-        setup_requires.add_after.comment(help).comment(example)
+        updater.read_string(cfg_str)
+
+    # add `setup_requires`
+    updater["options"]["setup_requires"].set_values(list(deps.BUILD)[:])
 
     # fill [pyscaffold] section used for later updates
     add_pyscaffold(updater, opts)

--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -122,9 +122,6 @@ def setup_cfg(opts: ScaffoldOpts) -> str:
     else:
         updater.read_string(cfg_str)
 
-    # add `setup_requires`
-    updater["options"]["setup_requires"].set_values(list(deps.BUILD)[:])
-
     # fill [pyscaffold] section used for later updates
     add_pyscaffold(updater, opts)
     pyscaffold = updater["pyscaffold"]

--- a/src/pyscaffold/templates/setup_cfg.template
+++ b/src/pyscaffold/templates/setup_cfg.template
@@ -37,9 +37,6 @@ include_package_data = True
 package_dir =
     =src
 
-# AVOID CHANGING SETUP_REQUIRES: IT WILL BE UPDATED BY PYSCAFFOLD!
-setup_requires =
-
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 # python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
 
@@ -55,6 +52,7 @@ exclude =
 # Add here additional requirements for extra features, to install with:
 # `pip install ${name}[PDF]` like:
 # PDF = ReportLab; RXP
+
 # Add here test requirements (semicolon/line-separated)
 testing =
     pytest
@@ -72,7 +70,6 @@ testing =
 #     awesome = pyscaffoldext.awesome.extension:AwesomeExtension
 
 [tool:pytest]
-# Options for pytest:
 # Specify command line options as you would do when invoking pytest directly.
 # e.g. --cov-report html (or xml) for html/xml output or --junitxml junit.xml
 # in order to write a coverage file that can be read by Jenkins.

--- a/src/pyscaffold/templates/setup_cfg.template
+++ b/src/pyscaffold/templates/setup_cfg.template
@@ -23,18 +23,28 @@ project-urls =
 # Change if running only on Windows, Mac or Linux (comma-separated)
 platforms = any
 
+# Add here all kinds of additional classifiers as defined under
+# https://pypi.python.org/pypi?%3Aaction=list_classifiers
+classifiers =
+    Development Status :: 4 - Beta
+    Programming Language :: Python
+
+
 [options]
 zip_safe = False
 packages = find:
 include_package_data = True
 package_dir =
     =src
+
 # AVOID CHANGING SETUP_REQUIRES: IT WILL BE UPDATED BY PYSCAFFOLD!
 setup_requires =
-# The usage of test_requires is discouraged, see `Dependency Management` docs
-# tests_require = pytest; pytest-cov
+
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4
 # python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+
+# Add here dependencies of your project (semicolon/line-separated), e.g.
+# install_requires = numpy; scipy
 
 [options.packages.find]
 where = src

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from os.path import isdir
 from os.path import join as path_join
 from pkg_resources import DistributionNotFound
 from shutil import rmtree
+from types import SimpleNamespace as Object
 
 import pytest
 
@@ -14,7 +15,6 @@ from .helpers import (
     command_exception,
     disable_import,
     nop,
-    obj,
     replace_import,
     set_writable,
     uniqstr,
@@ -329,7 +329,7 @@ def no_curses_mock():
 
 @pytest.fixture
 def curses_mock():
-    with replace_import("curses", obj()):
+    with replace_import("curses", Object()):
         yield
 
 
@@ -341,5 +341,5 @@ def no_colorama_mock():
 
 @pytest.fixture
 def colorama_mock():
-    with replace_import("colorama", obj(init=nop)):
+    with replace_import("colorama", Object(init=nop)):
         yield

--- a/tests/extensions/test_no_pyproject.py
+++ b/tests/extensions/test_no_pyproject.py
@@ -1,4 +1,3 @@
-import sys
 from pathlib import Path
 
 from pyscaffold.api import create_project
@@ -11,10 +10,12 @@ def test_create_project_wit_no_pyproject(tmpfolder):
     opts = dict(project_path="proj", extensions=[NoPyProject()])
 
     # when the project is created,
-    create_project(opts)
+    _, opts = create_project(opts)
 
     # then file should not exist
     assert not Path("proj/pyproject.toml").exists()
+
+    assert opts["isolated_build"] is False
 
 
 def test_create_project_without_no_skeleton(tmpfolder):
@@ -22,18 +23,18 @@ def test_create_project_without_no_skeleton(tmpfolder):
     opts = dict(project_path="proj")
 
     # when the project is created,
-    create_project(opts)
+    _, opts = create_project(opts)
 
     # then file should exist
     assert Path("proj/pyproject.toml").exists()
 
+    assert opts["isolated_build"] is True
+
 
 def test_cli_with_no_skeleton(tmpfolder):
     # Given the command line with the no-pyproject option,
-    sys.argv = ["pyscaffold", "--no-pyproject", "proj"]
-
     # when pyscaffold runs,
-    run()
+    run(["--no-pyproject", "proj"])
 
     # then file should not exist
     assert not Path("proj/pyproject.toml").exists()
@@ -41,10 +42,8 @@ def test_cli_with_no_skeleton(tmpfolder):
 
 def test_cli_without_no_skeleton(tmpfolder):
     # Given the command line without the no-pyproject option,
-    sys.argv = ["pyscaffold", "--no-pyproject", "proj"]
-
     # when pyscaffold runs,
-    run()
+    run(["--no-pyproject", "proj"])
 
     # then file should not exist
     assert not Path("proj/pyproject.toml").exists()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,7 +3,6 @@ import builtins
 import logging
 import os
 import stat
-from collections import namedtuple
 from contextlib import contextmanager
 from glob import glob
 from pathlib import Path
@@ -28,12 +27,6 @@ def uniqpath(nested=False):
 
 def nop(*args, **kwargs):
     """Function that does nothing"""
-
-
-def obj(**kwargs):
-    """Create a generic object with the given fields"""
-    constructor = namedtuple("GenericObject", kwargs.keys())
-    return constructor(**kwargs)
 
 
 def set_writable(func, path, exc_info):

--- a/tests/system/test_common.py
+++ b/tests/system/test_common.py
@@ -8,7 +8,7 @@ from subprocess import CalledProcessError
 import pytest
 
 from pyscaffold.file_system import chdir
-from pyscaffold.update import read_pyproject_toml, read_setupcfg
+from pyscaffold.update import read_pyproject
 
 from .helpers import run, run_common_tasks
 
@@ -48,14 +48,10 @@ def test_putup(cwd, putup):
     with cwd.join("myproj").as_cwd():
         # then the new version of PyScaffold should produce packages with
         # the correct build deps
-        setup_cfg = read_setupcfg(".")
-        _, pyproject_toml = read_pyproject_toml(".")
-        for stored_deps in (
-            setup_cfg["options"]["setup_requires"].value,
-            " ".join(pyproject_toml["build-system"]["requires"]),
-        ):
-            for dep in BUILD_DEPS:
-                assert dep in stored_deps
+        pyproject_toml = read_pyproject(".")
+        stored_deps = " ".join(pyproject_toml["build-system"]["requires"])
+        for dep in BUILD_DEPS:
+            assert dep in stored_deps
         # and no error should be raised when running the common tasks
         run_common_tasks()
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -78,7 +78,7 @@ def test_setup_cfg():
     setup_requires = deps.split(setup_cfg["options"]["setup_requires"])
     for dep in deps.BUILD:
         assert dep in setup_requires
-    # Assert setup_requires is correctly assigned
+    # Assert install_requires is correctly assigned
     install_requires = deps.split(setup_cfg["options"]["install_requires"])
     for dep in reqs:
         assert dep in install_requires

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -74,10 +74,6 @@ def test_setup_cfg():
     setup_cfg = ConfigParser()
     setup_cfg.read_string(text)
 
-    # Assert setup_requires is correctly assigned
-    setup_requires = deps.split(setup_cfg["options"]["setup_requires"])
-    for dep in deps.BUILD:
-        assert dep in setup_requires
     # Assert install_requires is correctly assigned
     install_requires = deps.split(setup_cfg["options"]["install_requires"])
     for dep in reqs:


### PR DESCRIPTION
This PR simplifies the setup.cfg generation by embedding the classifiers in the template itself, instead  of dynamically generating them from opts (since no other part of the code uses that) and attempts to remove `setup_requires` that is sort-of deprecated.

To remove `setup_requires` we have to migrate the dependencies over `pyproject.toml` which impacts `update.py`.

There is documentation added to deal with the edge cases and instructions for the migration.