### PR TITLE
Remove mutually exclusive argparse group for extensions

### DIFF
--- a/src/pyscaffold/cli.py
+++ b/src/pyscaffold/cli.py
@@ -5,8 +5,6 @@ Command-Line-Interface of PyScaffold
 import argparse
 import logging
 import sys
-from itertools import filterfalse
-from operator import attrgetter
 from pkg_resources import parse_version
 from typing import List, Optional
 
@@ -161,20 +159,7 @@ def parse_args(args: List[str]) -> ScaffoldOpts:
         for extension in iter_entry_points("pyscaffold.cli")
     )
 
-    # find out if any of the extensions are mutually exclusive
-    is_mutex = attrgetter("mutually_exclusive")
-    mutex_ext = filter(is_mutex, cli_extensions)
-    coexisting_ext = filterfalse(is_mutex, cli_extensions)
-
-    # since argparse breaks if mutually exclusive groups are empty
-    # we need to check first
-    mutex_list = list(mutex_ext)
-    if mutex_list:
-        mutex_group = parser.add_mutually_exclusive_group()
-        for extension in mutex_list:
-            extension.augment_cli(mutex_group)
-
-    for extension in coexisting_ext:
+    for extension in cli_extensions:
         extension.augment_cli(parser)
 
     # Parse options and transform argparse Namespace object into common dict

--- a/src/pyscaffold/extensions/__init__.py
+++ b/src/pyscaffold/extensions/__init__.py
@@ -29,7 +29,6 @@ class Extension:
         property to match the entrypoint name).
     """
 
-    mutually_exclusive = False
     persist = True
     """When ``True`` PyScaffold will store the extension in the PyScaffold's section of
     ``setup.cfg``. Useful for updates. Set to ``False`` if the extension should not be


### PR DESCRIPTION
This feature was never really used anyway (it existed for a particular pair of extensions that now is outside the core - django and cookiecutter), and particularly tricky to generalise for other use
cases... I am not even sure if it wouldn't be possible to use them at the same time nowadays since the mutually exclusive group was implemented a while ago and a lot have changed.

If an extension is really incompatible with other, maybe it is better to add an action that verifies that and throw an error than during CLI args parser (so it would also be available for raw Python API calls).