### PR TITLE
Attempt to simplify complexity on #325

### DIFF
--- a/src/pyscaffold/cli.py
+++ b/src/pyscaffold/cli.py
@@ -42,9 +42,9 @@ def add_default_args(parser: ArgumentParser):
     parser.add_argument(
         "-i",
         "--interactive",
-        dest="interactive",
-        action="store_true",
-        default=False,
+        dest="command",
+        action="store_const",
+        const=lambda opts: run_scaffold(parser.prompt_user(opts)),
         help="prompt for all missing arguments",
     )
     parser.add_argument(
@@ -116,7 +116,7 @@ def add_default_args(parser: ArgumentParser):
         "-V",
         "--version",
         action="version",
-        noprompt=True,
+        prompt=False,
         version=f"PyScaffold {pyscaffold_version}",
     )
     parser.add_argument(
@@ -125,7 +125,7 @@ def add_default_args(parser: ArgumentParser):
         action="store_const",
         const=logging.INFO,
         dest="log_level",
-        noprompt=True,
+        prompt=False,
         help="show additional information about current actions",
     )
     parser.add_argument(
@@ -134,27 +134,26 @@ def add_default_args(parser: ArgumentParser):
         action="store_const",
         const=logging.DEBUG,
         dest="log_level",
-        noprompt=True,
+        prompt=False,
         help="show all available information about current actions",
     )
 
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument(
+    parser.add_argument(
         "-P",
         "--pretend",
         dest="pretend",
         action="store_true",
         default=False,
-        noprompt=True,
+        prompt=False,
         help="do not create project, but displays the log of all operations"
         " as if it had been created.",
     )
-    group.add_argument(
+    parser.add_argument(
         "--list-actions",
         dest="command",
         action="store_const",
         const=list_actions,
-        noprompt=True,
+        prompt=False,
         help="do not create project, but show a list of planned actions",
     )
 
@@ -185,11 +184,7 @@ def parse_args(args: List[str]) -> ScaffoldOpts:
         extension.augment_cli(parser)
 
     # Parse options and transform argparse Namespace object into common dict
-    opts = vars(parser.parse_args(args))
-    if opts["interactive"]:
-        opts = parser.prompt_user(opts)
-
-    return _process_opts(opts)
+    return _process_opts(vars(parser.parse_args(args)))
 
 
 def _process_opts(opts: ScaffoldOpts) -> ScaffoldOpts:

--- a/src/pyscaffold/cli.py
+++ b/src/pyscaffold/cli.py
@@ -45,6 +45,7 @@ def add_default_args(parser: ArgumentParser):
         dest="command",
         action="store_const",
         const=lambda opts: run_scaffold(parser.prompt_user(opts)),
+        prompt=False,
         help="prompt for all missing arguments",
     )
     parser.add_argument(
@@ -138,22 +139,21 @@ def add_default_args(parser: ArgumentParser):
         help="show all available information about current actions",
     )
 
-    parser.add_argument(
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
         "-P",
         "--pretend",
         dest="pretend",
         action="store_true",
         default=False,
-        prompt=False,
         help="do not create project, but displays the log of all operations"
         " as if it had been created.",
     )
-    parser.add_argument(
+    group.add_argument(
         "--list-actions",
         dest="command",
         action="store_const",
         const=list_actions,
-        prompt=False,
         help="do not create project, but show a list of planned actions",
     )
 

--- a/src/pyscaffold/cli_parser.py
+++ b/src/pyscaffold/cli_parser.py
@@ -5,24 +5,23 @@ The main idea is to use Python's :obj:`argparse.ArgumentParser` and extend it:
  * to support `noprompt` in `add_argument` if an argument should never be prompted for
  * to track easily which command line options of all possible ones were specified
    and prompt only for the remaining ones if `nopromot` = False
-
-Since the authors of ArgumentParser did *NOT* favor Composition over Inheritance
-a lot of MixedIns had to be used.
 """
 
 from argparse import Action
 from argparse import ArgumentParser as OriginalParser
-from functools import reduce
-from typing import Any, Callable, Dict, List, Union
+from functools import partial, reduce
+from typing import Any, Callable, Dict, Iterator, List, Union
 
 import inquirer
 
 from .actions import ScaffoldOpts
 from .extensions import Extension
 
+PartialPrompt = Callable[[ScaffoldOpts], ScaffoldOpts]
 PromptFn = Callable[["ArgumentParser", Action, ScaffoldOpts], ScaffoldOpts]
-PromptMap = Dict[Action, Union[bool, PromptFn]]
+Prompt = Union[bool, PromptFn]
 # ^  TODO: Use Literal[False] instead of bool when `python_requires = >= 3.8`
+PromptMap = Dict[Action, Prompt]
 
 
 ARGUMENT_MSG = "Arguments of [{}] (enter for default)"
@@ -32,9 +31,7 @@ INCOMPAT_MSG = "argparse {} is incompatible with PyScaffold's interactive mode"
 
 
 def default_prompt(
-    parser: "ArgumentParser",
-    action: Action,
-    opts: ScaffoldOpts,
+    parser: "ArgumentParser", action: Action, opts: ScaffoldOpts
 ) -> ScaffoldOpts:
     """Interacts with user to obtain values for the given :obj:`Action`"""
     if is_included(action, opts["extensions"]):
@@ -62,30 +59,27 @@ def default_prompt(
 
 
 class ArgumentParser(OriginalParser):
-    """Extends ArgumentParser to allow any interactive prompts"""
+    """Extends ArgumentParser to allow any interactive prompts.
+
+    .. warning:: ``add_mutually_exclusive_group``, ``add_argument_group`` and
+        ``add_subparsers`` are not supported in PyScaffold's interactive mode.
+    """
 
     def __init__(self, *args, **kwargs):
+        self.hidden = ["help"]
         self._action_prompt: PromptMap = {}
         self.orig_args: List[str] = []
         super().__init__(*args, **kwargs)
 
-    def add_argument_group(self, *args, **kwargs):
-        raise NotImplementedError(INCOMPAT_MSG.format("add_argument_group"))
-
-    def add_mutually_exclusive_group(self, *args, **kwargs):
-        raise NotImplementedError(INCOMPAT_MSG.format("add_mutually_exclusive_group"))
-
-    def add_argument(
-        self, *args, prompt: Union[bool, PromptFn] = default_prompt, **kwargs
-    ) -> Action:
+    def add_argument(self, *args, prompt: Prompt = default_prompt, **kwargs) -> Action:
         """Adds `prompt` to the kwargs of obj:`argparse.ArgumentParser`.
 
-        By default :obj:`default_prompt` is used in interactive mode, but
-        when `prompt` is False, PyScaffold will skip the option. A custom
-        :obj:`PromptFn` callable can also be passed.
+        By default :obj:`default_prompt` is used to ask the user in interactive mode,
+        unless `prompt=False`. A custom :obj:`PromptFn` callable can also be passed.
         """
         action = super().add_argument(*args, **kwargs)
-        self._action_prompt[action] = prompt
+        if action.option_strings:
+            self._action_prompt[action] = prompt
         return action
 
     def parse_args(self, args=None, namespace=None):
@@ -95,16 +89,17 @@ class ArgumentParser(OriginalParser):
     def was_action_called(self, action):
         return any(s in self.orig_args for s in action.option_strings)
 
-    def _filter_prompts(self, extensions: List[Extension]) -> Dict[Action, PromptFn]:
-        return {
-            action: prompt
+    def _filter_prompts(self, extensions: List[Extension]) -> Iterator[PartialPrompt]:
+        return (
+            partial(prompt, self, action)
             for action, prompt in self._action_prompt.items()
             if (
                 callable(prompt)
+                and action.dest not in self.hidden
                 and not self.was_action_called(action)
                 and not is_included(action, extensions)
             )
-        }
+        )
 
     def format_flag(self, action: Action) -> str:
         flag = action.option_strings[-1]
@@ -119,8 +114,8 @@ class ArgumentParser(OriginalParser):
         ToDo: Show the user the defaults from `actions.get_default_options` by
          extracting this functionality into smaller functions that can be applied here
         """
-        prompts = self._filter_prompts(opts["extensions"])  # maps Action to PromptFn
-        return reduce(lambda opts, act: prompts[act](self, act, opts), prompts, opts)
+        prompts = self._filter_prompts(opts["extensions"])
+        return reduce(lambda acc, question: question(acc), prompts, opts)
 
 
 def is_included(action: Action, extensions: List[Extension]):
@@ -135,6 +130,6 @@ def is_included(action: Action, extensions: List[Extension]):
 def merge_user_input(opts: ScaffoldOpts, input: Any, action: Action) -> ScaffoldOpts:
     # ToDo: use the parser of action to parse the user's input
     if action.dest == "extensions":
-        return {**opts, "extensions": opts["extensions"] + action.const}
+        return {**opts, "extensions": opts["extensions"] + [action.const]}
 
     return {**opts, action.dest: input}

--- a/src/pyscaffold/cli_parser.py
+++ b/src/pyscaffold/cli_parser.py
@@ -27,7 +27,6 @@ PromptMap = Dict[Action, Prompt]
 ARGUMENT_MSG = "Arguments of [{}] (enter for default)"
 ACTIVATE_MSG = "Activate"
 CHOICES_MSG = "Choices"
-INCOMPAT_MSG = "argparse {} is incompatible with PyScaffold's interactive mode"
 
 
 def default_prompt(

--- a/src/pyscaffold/extensions/__init__.py
+++ b/src/pyscaffold/extensions/__init__.py
@@ -2,10 +2,13 @@
 Built-in extensions for PyScaffold.
 """
 import argparse
-from typing import List, Optional, Type
+from typing import TYPE_CHECKING, List, Optional, Type
 
 from ..actions import Action, register, unregister
 from ..identification import dasherize, underscore
+
+if TYPE_CHECKING:
+    from ..cli_parser import ArgumentParser
 
 
 class Extension:
@@ -53,7 +56,7 @@ class Extension:
         doc = " ".join([line.strip() for line in self.__doc__.split("\n")])
         return doc[0].lower() + doc[1:]
 
-    def augment_cli(self, parser: argparse.ArgumentParser):
+    def augment_cli(self, parser: "ArgumentParser"):
         """Augments the command-line interface parser.
 
         A command line argument ``--FLAG`` where FLAG=``self.name`` is added

--- a/src/pyscaffold/extensions/config.py
+++ b/src/pyscaffold/extensions/config.py
@@ -27,7 +27,7 @@ class Config(Extension):
             metavar="CONFIG_FILE",
             nargs="+",
             type=Path,
-            noprompt=True,
+            prompt=False,
             help=f"config file to read PyScaffold's preferences{default_help}",
         )
         parser.add_argument(
@@ -35,7 +35,7 @@ class Config(Extension):
             dest="config_files",
             action="store_const",
             const=api.NO_CONFIG,
-            noprompt=True,
+            prompt=False,
             help="prevent PyScaffold from reading its default config file",
         )
         parser.add_argument(
@@ -46,7 +46,7 @@ class Config(Extension):
             const=default_file,
             default=argparse.SUPPRESS,
             type=Path,
-            noprompt=True,
+            prompt=False,
             help=f"save the given options in a config file{default_help}",
         )
         return self

--- a/src/pyscaffold/log.py
+++ b/src/pyscaffold/log.py
@@ -5,6 +5,7 @@ import logging
 from collections import defaultdict
 from contextlib import contextmanager
 from logging import INFO, Formatter, LoggerAdapter, StreamHandler, getLogger
+from os import environ
 from os.path import realpath, relpath
 from os.path import sep as pathsep
 from typing import DefaultDict, Optional, Sequence
@@ -195,6 +196,10 @@ class ReportLogger(LoggerAdapter):
         self.handler = handler or StreamHandler()
         self.formatter = formatter or ReportFormatter()
         super(ReportLogger, self).__init__(self._wrapped, self.extra)
+
+        level = environ.get("PYSCAFFOLD_LOG_LEVEL")
+        if level and hasattr(logging, level):
+            self.level = getattr(logging, level.upper())
 
     @property
     def propagate(self) -> bool:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,3 @@
-import argparse
 import builtins
 import logging
 import os
@@ -12,6 +11,8 @@ from shutil import rmtree
 from time import sleep
 from uuid import uuid4
 from warnings import warn
+
+from pyscaffold import cli_parser
 
 
 def uniqstr():
@@ -146,7 +147,7 @@ def replace_import(prefix, new_module):
         builtins.__import__ = realimport
 
 
-class ArgumentParser(argparse.ArgumentParser):
+class ArgumentParser(cli_parser.ArgumentParser):
     def exit(self, status=0, message=None):
         """Avoid argparse to exit on error"""
         if status:


### PR DESCRIPTION
As discussed in #325, trying to extend `argparse` is difficult and increases the complexity of the code, specially due to the "mixin" approach used in the original implementation.

This PR is an attempt to concretely show some of the ideas I mentioned in my review. 

(I suppose some of the errors in the CI will be solved once the interactive branch is rebased on v4.0.x)