### PR TITLE
PoC/WIP: Extension to provide an "editable" interface to putup (in opposition to "interactive")

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -496,6 +496,27 @@ serialisation mechanism and supported data types to avoid errors (it should be
 safe to use string values without line breaks).
 
 
+Extra Configurations
+--------------------
+
+Similarly to ``persist = False``, some existing extensions might accept some sort
+of metadata to be defined by new extensions.
+
+This is the case of the :obj:`pyscaffold.extension.edit`, that generates
+editable examples for command line usages of PyScaffold. It accepts a
+``on_edit`` attribute defined by any extension instance or class. This attribute
+might define a dictionary with keys: ``"ignore"`` and ``"comment"``.  The value
+associated with the key ``"ignore"`` should be a list of CLI options that
+should be simply ignored when creating examples (e.g. ``["--help"]``). The
+value associated with the key ``"comment"`` should be a list of CLI options
+that should be commented in the created examples, even if they appear in the
+original ``sys.argv``.
+
+If your extension accepts metadata and interact with other extensions, you can
+also rely in informative attributes, but please be sure to make these optional
+with good fallback values and a comprehensive documentation.
+
+
 Examples
 ========
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,6 +94,7 @@ console_scripts =
     putup = pyscaffold.cli:run
 pyscaffold.cli =
     config = pyscaffold.extensions.config:Config
+    edit = pyscaffold.extensions.edit:Edit
     venv = pyscaffold.extensions.venv:Venv
     namespace = pyscaffold.extensions.namespace:Namespace
     no_skeleton = pyscaffold.extensions.no_skeleton:NoSkeleton

--- a/src/pyscaffold/extensions/config.py
+++ b/src/pyscaffold/extensions/config.py
@@ -16,6 +16,7 @@ class Config(Extension):
     """Add a few useful options for creating/using PyScaffold config files."""
 
     persist = False
+    on_edit = {"comment": ["--no-config"]}
 
     def augment_cli(self, parser: argparse.ArgumentParser):
         default_file = info.config_file(default=None)

--- a/src/pyscaffold/extensions/edit.py
+++ b/src/pyscaffold/extensions/edit.py
@@ -1,0 +1,113 @@
+"""Extension that generates configuration for Cirrus CI."""
+import os
+import textwrap
+from argparse import Action, ArgumentParser
+from typing import List, Optional
+
+from ..actions import ScaffoldOpts as Opts
+from . import Extension
+
+INDENT_LEVEL = 4
+SKIP = ["help"]
+
+
+class Edit(Extension):
+    """Add configuration file for Cirrus CI (includes `--pre-commit`)"""
+
+    parser: ArgumentParser
+
+    def augment_cli(self, parser: ArgumentParser):
+        """Augments the command-line interface parser.
+        See :obj:`~pyscaffold.extension.Extension.augment_cli`.
+        """
+        self.parser = parser
+
+        parser.add_argument(
+            self.flag,
+            dest="command",
+            action="store_const",
+            const=self.command,
+            help=self.help_text,
+        )
+        return self
+
+    def command(self, opts: Opts):
+        """This method replace the regular call to PyScaffold with some intermediate
+        steps:
+
+        1. First it uses the already parsed arguments (first pass) to generate an
+           ``arguments file`` (in a similar fashion the popular program Astyle uses
+           ``.astylerc`` files)
+        2. Let the user edit the file
+        3. When the user close the file it parses its contents again,
+           using the same CLI methods
+        4. Finally putup is called again with contents of the given file
+        """
+        # file = self.generate_file(opts)
+        # if not edit(file): error
+        # new_opts = cli.parse_args(args_from_file)
+        # return cli.run_scaffold(new_opts)
+
+
+def wrap(text: Optional[str], width=70, **kwargs) -> str:
+    return os.linesep.join(textwrap.wrap(text or "", width, **kwargs))
+
+
+def comment(text: str, comment_mark="#", indent_level=0):
+    return textwrap.indent(text, (" " * indent_level) + comment_mark + " ")
+
+
+def join_block(*parts: str, sep=os.linesep):
+    return sep.join(p for p in parts if p)
+
+
+def long_option(action: Action):
+    return sorted(action.option_strings or [""], key=len)[-1]
+
+
+def alternative_flags(action: Action):
+    opts = sorted(action.option_strings, key=len)[:-1]
+    return f"(or alternatively: {' '.join(opts)})" if opts else ""
+
+
+def has_active_extension(action: Action, opts: Opts) -> bool:
+    ext_flags = [getattr(ext, "flag", None) for ext in opts.get("extensions", [])]
+    return any(f in ext_flags for f in action.option_strings)
+
+
+def example_no_value(parser: ArgumentParser, action: Action, opts: Opts) -> str:
+    option_line = long_option(action)
+    if opts.get(action.dest) or has_active_extension(action, opts):
+        return option_line
+
+    return comment(option_line)
+
+
+def example_with_value(parser: ArgumentParser, action: Action, opts: Opts) -> str:
+    long = long_option(action)
+
+    arg = opts.get(action.dest)
+    if arg is None:
+        formatter = parser._get_formatter()
+        return comment(f"{long} {formatter._format_args(action, action.dest)}".strip())
+
+    args = arg if isinstance(arg, (list, tuple)) else [arg]
+    return (long_option(action) + " " + " ".join(f"{a}" for a in args)).strip()
+
+
+def example(parser: ArgumentParser, action: Action, opts: Opts) -> str:
+    fn = example_no_value if action.nargs == 0 else example_with_value
+    return fn(parser, action, opts)
+
+
+def example_with_help(parser: ArgumentParser, action: Action, opts: Opts) -> str:
+    return join_block(
+        example(parser, action, opts),
+        comment(alternative_flags(action), indent_level=INDENT_LEVEL),
+        comment(wrap(action.help), indent_level=INDENT_LEVEL),
+    )
+
+
+def all_examples(parser: ArgumentParser, actions: List[Action], opts: Opts) -> str:
+    parts = (example_with_help(parser, a, opts) for a in actions if a.dest not in SKIP)
+    return join_block(*parts, sep=os.linesep * 3)

--- a/src/pyscaffold/extensions/edit.py
+++ b/src/pyscaffold/extensions/edit.py
@@ -125,14 +125,15 @@ def example_no_value(parser: ArgumentParser, action: Action, opts: Opts) -> str:
 
 def example_with_value(parser: ArgumentParser, action: Action, opts: Opts) -> str:
     long = long_option(action)
-
     arg = opts.get(action.dest)
-    if arg is None or long in get_config("comment"):
+    args = arg if isinstance(arg, (list, tuple)) else [arg]
+    value = " ".join(shlex.quote(f"{a}") for a in args).strip()
+
+    if arg is None or long in get_config("comment") or value == "":
         formatter = parser._get_formatter()
         return comment(f"{long} {formatter._format_args(action, action.dest)}".strip())
 
-    args = arg if isinstance(arg, (list, tuple)) else [arg]
-    return (f" {long} " + " ".join(shlex.quote(f"{a}") for a in args)).rstrip()
+    return f" {long} {value}"
 
 
 def example(parser: ArgumentParser, action: Action, opts: Opts) -> str:

--- a/src/pyscaffold/extensions/edit.py
+++ b/src/pyscaffold/extensions/edit.py
@@ -16,8 +16,8 @@ HEADER = templates.get_template("header_edit")
 
 
 CONFIG = {
-    "ignore": ["--help"],
-    "comment": ["--version", "--verbose", "--very-verbose"],
+    "ignore": ["--help", "--version"],
+    "comment": ["--verbose", "--very-verbose"],
 }
 """Configuration for the options that are not associated with an extension class.
 

--- a/src/pyscaffold/file_system.py
+++ b/src/pyscaffold/file_system.py
@@ -15,11 +15,24 @@ import sys
 from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
+from tempfile import mkstemp
 from typing import Callable, Optional, Union
 
 from .log import logger
 
 PathLike = Union[str, os.PathLike]
+
+
+@contextmanager
+def tmpfile(**kwargs):
+    """Context manager that yields a temporary :obj:`Path`"""
+    fp, path = mkstemp(**kwargs)
+    os.close(fp)  # we don't need the low level file handler
+    file = Path(path)
+    try:
+        yield file
+    finally:
+        file.unlink()
 
 
 @contextmanager

--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -172,7 +172,8 @@ def project(
     # Lazily load the following function to avoid circular dependencies
     from .extensions import list_from_entry_points as list_extensions
 
-    opts = copy.deepcopy(opts)
+    opts = copy.deepcopy({k: v for k, v in opts.items() if not callable(v)})
+    # ^  functions/lambdas are not deepcopy-able
 
     path = config_path or cast(PathLike, opts.get("project_path", "."))
 

--- a/src/pyscaffold/templates/header_edit.template
+++ b/src/pyscaffold/templates/header_edit.template
@@ -5,8 +5,8 @@
 # together with a brief description of what each option can do for you, and    #
 # their default values.                                                        #
 #                                                                              #
-# The best part is that you can edit it! And after you close the file, all the #
-# options that are left, will be used to generate your project.                #
+# The best part is that you can edit it! And after you save and close the file #
+# all the options that are left will be used to generate your project.         #
 #                                                                              #
 # A line that starts with a `#` (sharp) sign (preceded or not by white spaces) #
 # is considered a comment, and will be ignored. In-line comments are not       #

--- a/src/pyscaffold/templates/header_edit.template
+++ b/src/pyscaffold/templates/header_edit.template
@@ -1,0 +1,14 @@
+################################################################################
+#                        *** Welcome to PyScaffold! ***                        #
+#                                                                              #
+# This file contains a series of examples on how to use the PyScaffold CLI,    #
+# together with a brief description of what each option can do for you, and    #
+# their default values.                                                        #
+#                                                                              #
+# The best part is that you can edit it! And after you close the file, all the #
+# options that are left, will be used to generate your project.                #
+#                                                                              #
+# A line that starts with a `#` (sharp) sign (preceded or not by white spaces) #
+# is considered a comment, and will be ignored. In-line comments are not       #
+# supported.                                                                   #
+################################################################################

--- a/tests/extensions/test_edit.py
+++ b/tests/extensions/test_edit.py
@@ -116,9 +116,9 @@ def test_example():
     )
 
     action = make_action(nargs="*")
-    assert (
-        edit.example(parser, action, {}).strip() == "# --option [OPTION [OPTION ...]]"
-    )
+    example = edit.example(parser, action, {}).strip()
+    expected = ("# --option [OPTION [OPTION ...]]", "# --option [OPTION ...]")
+    assert example in expected
 
     action = make_action(nargs="+")
     assert edit.example(parser, action, {}).strip() == "# --option OPTION [OPTION ...]"

--- a/tests/extensions/test_edit.py
+++ b/tests/extensions/test_edit.py
@@ -1,0 +1,146 @@
+import argparse
+from os import linesep
+from textwrap import dedent
+from unittest.mock import Mock
+
+from pyscaffold.extensions import edit
+
+from ..helpers import ArgumentParser
+
+
+def normalise(text: str) -> str:
+    return text.strip().replace(linesep, "\n")
+
+
+def test_wrap():
+    text = "as eireir tueroue asdiuodsi usaoifdu asdouusa doudas"
+    assert (
+        normalise(edit.wrap(text, 20))
+        == "as eireir tueroue\nasdiuodsi usaoifdu\nasdouusa doudas"
+    )
+
+
+def test_comment():
+    assert edit.comment("a") == "# a"
+    assert edit.comment("a\nb") == "# a\n# b"
+    assert edit.comment("a\nb", indent_level=4) == "    # a\n    # b"
+    assert edit.comment("a\nb", comment_mark=";") == "; a\n; b"
+
+
+def test_join_block():
+    assert edit.join_block("a", "", "") == "a"
+    assert edit.join_block("", "", "c") == "c"
+    assert normalise(edit.join_block("a", "", "c")) == "a\nc"
+    assert normalise(edit.join_block("", "b", "c")) == "b\nc"
+    assert normalise(edit.join_block("a", "b", "c")) == "a\nb\nc"
+
+
+def test_long_option():
+    for flags in (["-o", "--option"], ["--option", "-o"]):
+        action = argparse.Action(flags, "dest")
+        assert edit.long_option(action) == "--option"
+
+
+def test_alternative_flags():
+    for flags in (["-o", "--option", "-b"], ["--option", "-b", "-o"]):
+        action = argparse.Action(flags, "dest")
+        text = edit.alternative_flags(action)
+        assert "--option" not in text
+        assert all([flag in text for flag in ("-o", "-b")])
+
+
+def test_example_no_value():
+    action = argparse.Action(["--option", "-o"], "option", nargs=0)
+    parser = ArgumentParser()
+    # When no value is available in opts, then it should be commented
+    option_line = edit.example_no_value(parser, action, {})
+    assert option_line == "# --option"
+    # When option value is True, then it should not be commented
+    option_line = edit.example_no_value(parser, action, {"option": True})
+    assert option_line == "--option"
+    # When an extension is available, then it should not be commented
+    option_line = edit.example_no_value(
+        parser, action, {"extensions": [Mock(flag="--option")]}
+    )
+    assert option_line == "--option"
+
+
+def test_example_noargs_action():
+    action = argparse.Action(["--option", "-o"], "option", nargs=0, help="do 42 things")
+    parser = ArgumentParser()
+    # When no value is available in opts, then it should be commented
+    text = dedent(
+        """\
+        # --option
+            # (or alternatively: -o)
+            # do 42 things
+        """
+    )
+    assert normalise(text) == edit.example_with_help(parser, action, {})
+
+    # When option value is True, then it should not be commented
+    text = dedent(
+        """\
+        --option
+            # (or alternatively: -o)
+            # do 42 things
+        """
+    )
+    assert normalise(text) == edit.example_with_help(parser, action, {"option": True})
+
+
+def make_action(
+    flags=("--option", "-o"),
+    dest="option",
+    nargs=None,
+    help="do 42 things",
+    metavar="OPTION",
+):
+    return argparse.Action(flags, dest, nargs=nargs, help=help, metavar=metavar)
+
+
+def test_example():
+    parser = ArgumentParser()
+
+    # Options with variable nargs
+    action = make_action(nargs=1)
+    assert edit.example(parser, action, {}) == "# --option OPTION"
+    assert edit.example(parser, action, {"option": 32}) == "--option 32"
+
+    action = make_action(nargs=3)
+    assert edit.example(parser, action, {}) == "# --option OPTION OPTION OPTION"
+    assert edit.example(parser, action, {"option": [32, 21, 5]}) == "--option 32 21 5"
+
+    action = make_action(nargs="*")
+    assert edit.example(parser, action, {}) == "# --option [OPTION [OPTION ...]]"
+
+    action = make_action(nargs="+")
+    assert edit.example(parser, action, {}) == "# --option OPTION [OPTION ...]"
+
+    action = make_action(nargs="?")
+    assert edit.example(parser, action, {}) == "# --option [OPTION]"
+
+    # Positional argument:
+    action = argparse.Action([], "arg", nargs=1, metavar="ARGUMENT")
+    assert edit.example(parser, action, {}) == "# ARGUMENT"
+    assert edit.example(parser, action, {"arg": "value"}) == "value"
+
+
+def test_all_examples():
+    parser = ArgumentParser()
+    actions = [
+        make_action(nargs=1),
+        make_action(["--abc"], "abc", metavar="ABC", help="Abc-foobarize your project"),
+    ]
+    text = dedent(
+        """\
+        --option 23
+            # (or alternatively: -o)
+            # do 42 things
+
+
+        # --abc ABC
+            # Abc-foobarize your project
+        """
+    )
+    assert normalise(text) == edit.all_examples(parser, actions, {"option": 23})

--- a/tests/test_file_system.py
+++ b/tests/test_file_system.py
@@ -8,6 +8,15 @@ from pyscaffold import file_system as fs
 from .helpers import temp_umask, uniqpath, uniqstr
 
 
+def test_tmpfile(tmpfolder):
+    with fs.tmpfile(suffix=".foo.bar", dir=str(tmpfolder)) as tmp:
+        path = str(tmp)
+        assert path.endswith(".foo.bar")
+        assert tmp.exists()
+
+    assert not tmp.exists()
+
+
 def test_chdir(caplog, tmpdir, isolated_logger):
     caplog.set_level(logging.INFO)
     curr_dir = os.getcwd()


### PR DESCRIPTION
In #325 I mentioned that an alternative to "interactive" could be done via a simple text file + an editor:

> Imagine that instead of an CLI constantly querying the user, we spawn $EDITOR with an text file with contents similar to putup -h, where users can uncomment flags / review the parameters that they might have already typed directly as arguments. When the file is closed putup runs with it's contents (a kind of 2 passes system, first we preprocess things with cli.parse_args, then we compose the file based on [(a.option_strings, a.help) for a in parser._actions] and leverage argparse's fromfile_prefix_chars and convert_arg_line_to_args to parse the tempfile a second time?).
>
> I wonder how these ergonomics/UX would compare to the interactive mode and how much we can reduce in terms of complexity (e.g. do we even need to overload ArgumentParser this way?)

This PR is a proof of concept in that direction... (more improvement can be done if the extension brings interest)