### PR TITLE
Attempt to implement merge_user_input using parser

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -460,8 +460,11 @@ above, the automatically generated option will be ``--awesome-files``.
 
 For more sophisticated extensions which need to read and parse their
 own command line arguments it is necessary to override
-:obj:`~pyscaffold.extensions.Extension.augment_cli` that receives an
-:class:`argparse.ArgumentParser` argument. This object can then be modified
+:obj:`~pyscaffold.extensions.Extension.augment_cli` that receives as argument
+an object that implements a customised version of
+:obj:`~argparse.ArgumentParser.add_argument`.
+You can call :obj:`~pyscaffold.cli_parser.ArgumentParser.add_argument` on this
+object, as if you were working directly with :class:`argparse.ArgumentParser`
 in order to add custom command line arguments that will later be stored in the
 ``opts`` dictionary.
 Just remember the convention that after the command line arguments parsing,
@@ -472,6 +475,17 @@ as well as the `pyproject extension`_ which serves as a blueprint for new
 extensions. Another convention is to avoid storing state/parameters inside the
 extension class, instead store them as you would do regularly with
 :mod:`argparse` (inside the :obj:`argparse.Namespace` object).
+
+In interactive mode (when ``-i`` or ``--interactive`` is given to ``putup``),
+PyScaffold will attempt to generate a suitable question for any CLI arguments
+your extension may define and parse the given input automatically via
+:obj:`~pyscaffold.cli_parser.default_prompt`.
+If you require customisation, please create a suitable alternative function and
+pass it via the ``prompt`` keyword argument to our customised
+:obj:`~pyscaffold.cli_parser.ArgumentParser.add_argument` method.
+If you want to completely avoid asking the user in interactive mode for a
+specific CLI argument, just pass ``prompt=False`` when defining it via
+:obj:`~pyscaffold.cli_parser.ArgumentParser.add_argument` method.
 
 
 Persisting Extensions for Future Updates

--- a/src/pyscaffold/cli_parser.py
+++ b/src/pyscaffold/cli_parser.py
@@ -133,7 +133,7 @@ class ArgumentParser(OriginalParser):
         """Parse user input and augment the existing options with the corresponding
         values.
         """
-        # Create a temporary parse to parse a single option corresponding to `action`
+        # Create a temporary parser to parse a single option corresponding to `action`
         tmp_parser = OriginalParser()
         args, kwargs = self._added_arguments[action]
         tmp_parser.add_argument(*args, **kwargs)

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -31,7 +31,8 @@ def test_merge_user_input_flag():
     assert merged == {"name": "proj", "force": True}
 
     merged = merge_user_input(parser, existing_opts, False, action)
-    assert merged == {"name": "proj", "force": False}
+    assert merged["name"] == "proj"
+    assert not merged.get("force")
 
 
 def test_merge_user_input_choices():
@@ -54,7 +55,7 @@ def test_merge_user_input_choices():
     )
 
     # Coercion with type should work
-    merged = merge_user_input(parser, existing_opts, "mit", action)
+    merged = merge_user_input(existing_opts, "-l", "mit", action)
     assert merged == {"name": "proj", "license": "gpl"}
 
 
@@ -66,14 +67,14 @@ def test_merge_user_input_list():
         "-x", "--X", dest="x", type=int, choices=range(10), nargs="+"
     )
 
-    merged = merge_user_input(parser, existing_opts, [1, 2], action)
+    merged = merge_user_input(existing_opts, "-x", [1, 2], action)
     assert merged == {"name": "proj", "x": [1, 2]}
 
     action = parser.add_argument(
         "-y", "--Y", dest="y", type=int, choices=range(10), nargs="*"
     )
 
-    merged = merge_user_input(parser, existing_opts, [], action)
+    merged = merge_user_input(existing_opts, "-y", [], action)
     assert merged == {"name": "proj", "y": []}
 
 
@@ -83,14 +84,12 @@ def test_merge_user_input_include():
     included_extensions = [Cirrus(), Travis()]
     parser = ArgumentParser()
     action = parser.add_argument(
-        "-x",
-        "--X",
-        action=include(*included_extensions),
-        required=False,
+        "-x", "--X", action=include(*included_extensions), required=False, nargs=0
     )
 
-    merged = merge_user_input(parser, existing_opts, True, action)
-    assert merged == {"name": "proj", "extensions": included_extensions}
+    merged = merge_user_input(existing_opts, "-x", None, action)
+    assert merged["extensions"] == included_extensions
+    assert merged["name"] == "proj"
 
 
 def test_merge_user_input_store_with():
@@ -106,5 +105,5 @@ def test_merge_user_input_store_with():
         required=False,
     )
 
-    merged = merge_user_input(parser, existing_opts, "value", action)
+    merged = merge_user_input(existing_opts, "-x", "value", action)
     assert merged == {"name": "proj", "extensions": included_extensions, "x": "value"}

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -1,0 +1,110 @@
+import argparse
+
+from pyscaffold.cli_parser import ArgumentParser, is_included, merge_user_input
+from pyscaffold.extensions import include, store_with
+from pyscaffold.extensions.cirrus import Cirrus
+from pyscaffold.extensions.travis import Travis
+
+
+def test_is_included():
+    extensions = [Cirrus(), Travis()]
+    cirrus_fake_action = argparse.Action(["--cirrus"], "option", nargs=0)
+    namespace_fake_action = argparse.Action(["--namespace"], "option", nargs=0)
+
+    assert is_included(cirrus_fake_action, extensions)
+    assert not is_included(namespace_fake_action, extensions)
+
+
+def test_merge_user_input_flag():
+    existing_opts = {"name": "proj"}
+
+    parser = ArgumentParser()
+    action = parser.add_argument(
+        "-f",
+        "--force",
+        dest="force",
+        action="store_true",
+        required=False,
+    )
+
+    merged = merge_user_input(parser, existing_opts, True, action)
+    assert merged == {"name": "proj", "force": True}
+
+    merged = merge_user_input(parser, existing_opts, False, action)
+    assert merged == {"name": "proj", "force": False}
+
+
+def test_merge_user_input_choices():
+    existing_opts = {"name": "proj"}
+
+    parser = ArgumentParser()
+    license_choices = ["mit", "gpl"]
+
+    def _best_fit_license(_):
+        return "gpl"
+
+    action = parser.add_argument(
+        "-l",
+        "--license",
+        dest="license",
+        choices=license_choices,
+        type=_best_fit_license,
+        required=False,
+        metavar="LICENSE",
+    )
+
+    # Coercion with type should work
+    merged = merge_user_input(parser, existing_opts, "mit", action)
+    assert merged == {"name": "proj", "license": "gpl"}
+
+
+def test_merge_user_input_list():
+    existing_opts = {"name": "proj"}
+
+    parser = ArgumentParser()
+    action = parser.add_argument(
+        "-x", "--X", dest="x", type=int, choices=range(10), nargs="+"
+    )
+
+    merged = merge_user_input(parser, existing_opts, [1, 2], action)
+    assert merged == {"name": "proj", "x": [1, 2]}
+
+    action = parser.add_argument(
+        "-y", "--Y", dest="y", type=int, choices=range(10), nargs="*"
+    )
+
+    merged = merge_user_input(parser, existing_opts, [], action)
+    assert merged == {"name": "proj", "y": []}
+
+
+def test_merge_user_input_include():
+    existing_opts = {"name": "proj"}
+
+    included_extensions = [Cirrus(), Travis()]
+    parser = ArgumentParser()
+    action = parser.add_argument(
+        "-x",
+        "--X",
+        action=include(*included_extensions),
+        required=False,
+    )
+
+    merged = merge_user_input(parser, existing_opts, True, action)
+    assert merged == {"name": "proj", "extensions": included_extensions}
+
+
+def test_merge_user_input_store_with():
+    existing_opts = {"name": "proj"}
+
+    included_extensions = [Cirrus(), Travis()]
+    parser = ArgumentParser()
+    action = parser.add_argument(
+        "-x",
+        "--X",
+        dest="x",
+        action=store_with(*included_extensions),
+        required=False,
+    )
+
+    merged = merge_user_input(parser, existing_opts, "value", action)
+    assert merged == {"name": "proj", "extensions": included_extensions, "x": "value"}


### PR DESCRIPTION
Apparently not all validations from argparse happen when we call directly `Action.__call__`, as illustrated by some of the new tests that are failing.

Something that is also interesting to notice is that flag actions (`store_true` or `store_false`) seem to not be called at all when not present in argv, so calling `Action.__call__` with the other value does not yield the expected outcome.