### PR TITLE
[v4.0.x] Fix excluding options 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ tags
 # Unittest and coverage
 htmlcov/*
 .coverage
+.coverage.*.*
 .tox
 junit*.xml
 coverage.xml

--- a/src/pyscaffold/extensions/config.py
+++ b/src/pyscaffold/extensions/config.py
@@ -20,7 +20,8 @@ class Config(Extension):
     def augment_cli(self, parser: argparse.ArgumentParser):
         default_file = info.config_file(default=None)
         default_help = f" (defaults to: {default_file})" if default_file else ""
-        parser.add_argument(
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
             "--config",
             dest="config_files",
             metavar="CONFIG_FILE",
@@ -28,7 +29,7 @@ class Config(Extension):
             type=Path,
             help=f"config file to read PyScaffold's preferences{default_help}",
         )
-        parser.add_argument(
+        group.add_argument(
             "--no-config",
             dest="config_files",
             action="store_const",

--- a/src/pyscaffold/templates/gitignore.template
+++ b/src/pyscaffold/templates/gitignore.template
@@ -32,6 +32,7 @@ tags
 # Unittest and coverage
 htmlcov/*
 .coverage
+.coverage.*.*
 .tox
 junit*.xml
 coverage.xml

--- a/tests/extensions/test_config.py
+++ b/tests/extensions/test_config.py
@@ -85,7 +85,7 @@ def test_no_config():
 
 
 def test_no_config_conflict(fake_config_dir):
-    file = fake_config_dir / f"test_no_config.cfg"
+    file = fake_config_dir / "test_no_config.cfg"
     file.write_text("[pyscaffold]\n")
     with pytest.raises(SystemExit):
         parse("--no-config", "--config", str(file))

--- a/tests/extensions/test_config.py
+++ b/tests/extensions/test_config.py
@@ -84,6 +84,13 @@ def test_no_config():
     assert opts["config_files"] == api.NO_CONFIG
 
 
+def test_no_config_conflict(fake_config_dir):
+    file = fake_config_dir / f"test_no_config.cfg"
+    file.write_text("[pyscaffold]\n")
+    with pytest.raises(SystemExit):
+        parse("--no-config", "--config", str(file))
+
+
 def test_save_config(default_file, fake_config_dir):
     # With no value the default_file is used
     opts = parse("--save-config")


### PR DESCRIPTION
The options --config and --no-config should be exclusive.

For future interactive solutions this might be important, so this PR so early for so few changes.

Also note that if one is using tox -p more .coverage files are created (see git messages).