### PR TITLE
Improve tests and fixtures

### DIFF
--- a/.cirrus.yaml
+++ b/.cirrus.yaml
@@ -81,7 +81,7 @@ linux_mac_task:
       install_script: *debian-install
     - name: test (Linux - 3.9)
       allow_failures: true  # Python version is not stable
-      container: {image: "python:3.9-rc-buster"}
+      container: {image: "python:3.9-buster"}
       install_script: *debian-install
     - name: test (Linux - Anaconda)
       container: {image: "continuumio/anaconda3:2019.03"}

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -59,6 +59,9 @@ linux_mac_task:
     - name: test (Linux - 3.8)
       container: {image: "python:3.8-buster"}
       install_script: *debian-install
+    - name: test (Linux - 3.9)
+      container: {image: "python:3.9-buster"}
+      install_script: *debian-install
     - name: test (Linux - Anaconda)
       container: {image: "continuumio/anaconda3:2019.03"}
       install_script: *debian-install

--- a/src/pyscaffold/templates/gitlab_ci.template
+++ b/src/pyscaffold/templates/gitlab_ci.template
@@ -52,6 +52,10 @@ py38:
   image: "python:3.8"
   <<: *test_script
 
+py39:
+  image: "python:3.9"
+  <<: *test_script
+
 
 docs:
   script:

--- a/src/pyscaffold/templates/travis.template
+++ b/src/pyscaffold/templates/travis.template
@@ -18,6 +18,8 @@ jobs:
       env: DISTRIB="ubuntu" TOX_PYTHON_VERSION="py37" COVERAGE="false"
     - python: 3.8
       env: DISTRIB="ubuntu" TOX_PYTHON_VERSION="py38" COVERAGE="false"
+    - python: 3.9
+      env: DISTRIB="ubuntu" TOX_PYTHON_VERSION="py39" COVERAGE="false"
     - env: DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="false"
 install:
   - source tests/travis_install.sh


### PR DESCRIPTION
- Replace container for Python 3.9 with stable version in CIs
- Avoid nesting more then once the fake home fixture inside temp directories in tests.