### PR TITLE
Adopt wheel by default

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -90,8 +90,6 @@ testing =
     # arguments in the command-line.
 
 [options.entry_points]
-distutils.setup_keywords =
-    use_pyscaffold = pyscaffold.integration:pyscaffold_keyword
 console_scripts =
     putup = pyscaffold.cli:run
 pyscaffold.cli =
@@ -134,16 +132,11 @@ log_cli = True
 log_cli_level = CRITICAL
 junit_family = xunit2
 
-[aliases]
-dists = sdist bdist_wheel
-
 [devpi:upload]
 # Options for the devpi: PyPI server and packaging tool
 # VCS export must be deactivated since we are using setuptools-scm
 no-vcs = 1
-formats =
-    sdist
-    bdist_wheel
+formats = bdist_wheel
 
 [flake8]
 # Some sane defaults for the code style checker flake8

--- a/src/pyscaffold/templates/setup_cfg.template
+++ b/src/pyscaffold/templates/setup_cfg.template
@@ -92,9 +92,6 @@ testpaths = tests
 #     slow: mark tests as slow (deselect with '-m "not slow"')
 #     system: mark end-to-end system tests
 
-[aliases]
-dists = sdist bdist_wheel
-
 [bdist_wheel]
 # Use this option if your package is pure-python
 universal = 1

--- a/src/pyscaffold/templates/tox_ini.template
+++ b/src/pyscaffold/templates/tox_ini.template
@@ -6,6 +6,7 @@
 minversion = 3.15
 envlist = default
 
+
 [testenv]
 description = invoke pytest to run automated tests
 isolated_build = ${isolated_build}
@@ -34,6 +35,7 @@ deps =
 commands =
     clean: python -c 'from shutil import rmtree; rmtree("build", True); rmtree("dist", True)'
     build: python -m build .
+# By default `build` produces wheels, you can also explicitly use the flags `--sdist` and `--wheel`
 
 
 [testenv:{docs,doctests}]

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@
 minversion = 3.15
 envlist = default
 
+
 [testenv]
 description = Invoke pytest to run automated tests
 isolated_build = True
@@ -55,6 +56,7 @@ deps =
 commands =
     clean: python -c 'from shutil import rmtree; rmtree("build", True); rmtree("dist", True)'
     build: python -m build .
+# By default `build` produces wheels, you can also explicitly use the flags `--sdist` and `--wheel`
 
 
 [testenv:{docs,doctests}]


### PR DESCRIPTION
… now that we don't need PyScaffold to be a "setup-time" dependency, we
don't need sdists.

This PR also remove the old pyscaffold keyword argument from the
entrypoints (left behind in previous changes).

See discussion in #365.