### PR TITLE
Adopt no-guess-dev instead of post-release for setuptools_scm

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,8 @@ Version 4.0
 - Add an experimental ``--interactive`` *mode* (inspired by ``git rebase -i``),
   :issue:`191` (additional discussion: :pr:`333`, :pr:`325`, :pr:`362`)
 - Reorganise the **FAQ** (including version questions previously in **Features**).
+- Updated ``setuptools`` and ``setuptools_scm`` dependencies to minimal
+  versions 46.1 and 5, respectively.
 
 Current versions
 ================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Version 4.0
 - Removed ``contrib`` subpackage, vendorized packages are now runtime dependencies, :pr:`290`
 - ``setuptools_scm`` is included by default in ``setup.cfg``, ``setup.py`` and ``pyproject.toml``
 - API changed to use ``pyscaffold.operations`` instead of integer flags, :issue:`271`
-- Allow ``string.Template`` and ``callable`` as file contents in project structure, "proposal" :issue:`295`
+- Allow ``string.Template`` and ``callable`` as file contents in project structure, :pr:`295`
 - Extract file system functions from ``utils.py`` into ``file_system.py``
 - Extract identification/naming functions from ``utils.py`` into ``identification.py``
 - Extract action related functions from ``api/__init__.py`` to ``actions.py``
@@ -37,11 +37,12 @@ Version 4.0
 - Adopt SPDX identifiers for the license field in ``setup.cfg``, :issue:`319`
 - Removed deprecated ``log.configure_logger``
 - Add links to issues and pull requests to changelog, :pr:`363`
-- Add an experimental ``--interactive`` *mode* (inspired by ``git rebase -i``),
-  :issue:`191` (additional discussion: :pr:`333`, :pr:`325`, :pr:`362`)
-- Reorganise the **FAQ** (including version questions previously in **Features**).
-- Updated ``setuptools`` and ``setuptools_scm`` dependencies to minimal
-  versions 46.1 and 5, respectively.
+- Add an experimental ``--interactive`` *mode* (inspired by ``git rebase -i``), :issue:`191`
+  (additional discussion: :pr:`333`, :pr:`325`, :pr:`362`)
+- Reorganise the **FAQ** (including version questions previously in **Features**)
+- Updated ``setuptools`` and ``setuptools_scm`` dependencies to minimal versions 46.1 and 5, respectively
+- Adopted ``no-guess-dev`` version scheme from ``setuptools_scm`` (semantically all stays the same, but
+  non-tag commits are now versioned ``LAST_TAG.post1.devN`` instead of ``LAST_TAG.post0.devN``)
 
 Current versions
 ================

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -6,7 +6,7 @@ Requirements
 ============
 
 The installation of PyScaffold only requires a recent version of `setuptools`_,
-i.e. at least version 38.3, as well as a working installation of `Git`_.
+i.e. at least version 46.1, as well as a working installation of `Git`_.
 Especially Windows users should make sure that the command ``git`` is available on
 the command line. Otherwise, check and update your ``PATH`` environment
 variable or run PyScaffold from the *Git Bash*.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # AVOID CHANGING REQUIRES: IT WILL BE UPDATED BY PYSCAFFOLD!
-requires = ["setuptools>=46.1.0", "setuptools_scm[toml]>=4.1.2", "wheel"]
+requires = ["setuptools>=46.1.0", "setuptools_scm[toml]>=5", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-version_scheme = "post-release"
+version_scheme = "no-guess-dev"

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,8 @@ install_requires =
     importlib-metadata; python_version<"3.8"
     appdirs>=1.4.4,<2
     configupdater>=1.1.3,<2
-    setuptools>=38.3
-    setuptools_scm>=5,<6
+    setuptools>=46.1.0
+    setuptools_scm>=5
     tomlkit>=0.7.0,<2
     packaging>=20.7
 # packaging is versioned by year, not SemVer

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 if __name__ == "__main__":
     try:
-        setup(use_scm_version={"version_scheme": "post-release"})
+        setup(use_scm_version={"version_scheme": "no-guess-dev"})
     except:  # noqa
         print(
             "\n\nAn error occurred while building the project, "

--- a/src/pyscaffold/dependencies.py
+++ b/src/pyscaffold/dependencies.py
@@ -17,12 +17,12 @@ except ImportError:
 
 
 SETUPTOOLS_VERSION = parse_version("40.1")  # required for find_namespace
-BUILD = ("setuptools_scm>=4.1.2", "wheel")
+BUILD = ("setuptools_scm>=5", "wheel")
 """Dependencies that will be required to build the created project"""
 RUNTIME = ('importlib-metadata; python_version<"3.8"',)
 # TODO: Remove `importlib-metadata` when `python_requires = >= 3.8`
 """Dependencies that will be required at runtime by the created project"""
-ISOLATED = ("setuptools>=46.1.0", "setuptools_scm[toml]>=4.1.2", *BUILD[1:])
+ISOLATED = ("setuptools>=46.1.0", "setuptools_scm[toml]>=5", *BUILD[1:])
 """Dependencies for isolated builds (PEP517/518).
 - setuptools min version might be slightly higher then the version required at runtime.
 - setuptools_scm requires an optional dependency to work with pyproject.toml

--- a/src/pyscaffold/templates/pyproject_toml.template
+++ b/src/pyscaffold/templates/pyproject_toml.template
@@ -1,8 +1,8 @@
 [build-system]
 # AVOID CHANGING REQUIRES: IT WILL BE UPDATED BY PYSCAFFOLD!
-requires = ["setuptools>=46.1.0", "setuptools_scm[toml]>=4.1.2", "wheel"]
+requires = ["setuptools>=46.1.0", "setuptools_scm[toml]>=5", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 # See configuration details in https://github.com/pypa/setuptools_scm
-version_scheme = "post-release"
+version_scheme = "no-guess-dev"

--- a/src/pyscaffold/templates/setup_py.template
+++ b/src/pyscaffold/templates/setup_py.template
@@ -10,7 +10,7 @@ from setuptools import setup
 
 if __name__ == "__main__":
     try:
-        setup(use_scm_version={"version_scheme": "post-release"})
+        setup(use_scm_version={"version_scheme": "no-guess-dev"})
     except:  # noqa
         print(
             "\n\nAn error occurred while building the project, "

--- a/src/pyscaffold/update.py
+++ b/src/pyscaffold/update.py
@@ -176,7 +176,7 @@ def update_pyproject_toml(struct: Structure, opts: ScaffoldOpts) -> "ActionParam
     build["requires"] = deps.remove(deps.add(existing, deps.ISOLATED), ["pyscaffold"])
     # ^  PyScaffold is no longer a build dependency
     toml.setdefault(build, "build-backend", "setuptools.build_meta")
-    toml.setdefault(config, "tool.setuptools_scm.version_scheme", "post-release")
+    toml.setdefault(config, "tool.setuptools_scm.version_scheme", "no-guess-dev")
 
     (opts["project_path"] / PYPROJECT_TOML).write_text(toml.dumps(config), "utf-8")
     logger.report("updated", opts["project_path"] / PYPROJECT_TOML)

--- a/tests/demoapp/pyproject.toml
+++ b/tests/demoapp/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # AVOID CHANGING REQUIRES: IT WILL BE UPDATED BY PYSCAFFOLD!
-requires = ["setuptools>=46.1.0", "wheel", "setuptools_scm[toml]>=5,<6"]
+requires = ["setuptools>=46.1.0", "wheel", "setuptools_scm[toml]>=5"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-version_scheme = "post-release"
+version_scheme = "no-guess-dev"

--- a/tests/demoapp/setup.cfg
+++ b/tests/demoapp/setup.cfg
@@ -26,7 +26,7 @@ include_package_data = True
 package_dir =
     =src
 setup_requires =
-    setuptools_scm>=5,<6
+    setuptools_scm>=5
     wheel
 
 # TODO: Remove conditional requirements once `python_requires = >=3.8`

--- a/tests/demoapp/setup.py
+++ b/tests/demoapp/setup.py
@@ -4,4 +4,4 @@
 from setuptools import setup
 
 if __name__ == "__main__":
-    setup(use_scm_version={"version_scheme": "post-release"})
+    setup(use_scm_version={"version_scheme": "no-guess-dev"})

--- a/tests/demoapp_data/pyproject.toml
+++ b/tests/demoapp_data/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # AVOID CHANGING REQUIRES: IT WILL BE UPDATED BY PYSCAFFOLD!
-requires = ["setuptools>=46.1.0", "wheel", "setuptools_scm[toml]>=5,<6"]
+requires = ["setuptools>=46.1.0", "wheel", "setuptools_scm[toml]>=5"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-version_scheme = "post-release"
+version_scheme = "no-guess-dev"

--- a/tests/demoapp_data/setup.cfg
+++ b/tests/demoapp_data/setup.cfg
@@ -26,7 +26,7 @@ include_package_data = True
 package_dir =
     =src
 setup_requires =
-    setuptools_scm>=5,<6
+    setuptools_scm>=5
     wheel
 # TODO: Remove conditional requirements once `python_requires = >=3.8`
 install_requires =

--- a/tests/demoapp_data/setup.py
+++ b/tests/demoapp_data/setup.py
@@ -4,4 +4,4 @@
 from setuptools import setup
 
 if __name__ == "__main__":
-    setup(use_scm_version={"version_scheme": "post-release"})
+    setup(use_scm_version={"version_scheme": "no-guess-dev"})

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -236,7 +236,7 @@ def check_version(output, exp_version, dirty=False):
 def test_sdist_install(demoapp):
     (demoapp.build("sdist").install())
     out = demoapp.cli("--version")
-    exp = "0.0.post2"
+    exp = "0.0.post1.dev2"
     check_version(out, exp, dirty=False)
 
 
@@ -250,7 +250,7 @@ def test_sdist_install_dirty(demoapp):
         .install()
     )
     out = demoapp.cli("--version")
-    exp = "0.1.post1"
+    exp = "0.1.post1.dev1"
     check_version(out, exp, dirty=True)
 
 
@@ -270,7 +270,7 @@ def test_sdist_install_with_1_0_tag(demoapp):
 def test_sdist_install_with_1_0_tag_dirty(demoapp):
     demoapp.tag("v1.0", "final release").make_dirty_tree().build("sdist").install()
     out = demoapp.cli("--version")
-    exp = "1.0.post0"
+    exp = "1.0.post1.dev0"
     check_version(out, exp, dirty=True)
 
 
@@ -278,20 +278,20 @@ def test_sdist_install_with_1_0_tag_dirty(demoapp):
 def test_bdist_install(demoapp):
     demoapp.build("bdist").install()
     out = demoapp.cli("--version")
-    exp = "0.0.post2"
+    exp = "0.0.post1.dev2"
     check_version(out, exp, dirty=False)
 
 
 def test_bdist_wheel_install(demoapp):
     demoapp.build("bdist_wheel").install()
     out = demoapp.cli("--version")
-    exp = "0.0.post2"
+    exp = "0.0.post1.dev2"
     check_version(out, exp, dirty=False)
 
 
 def test_git_repo(demoapp):
     out = demoapp.setup_py("--version")
-    exp = "0.0.post2"
+    exp = "0.0.post1.dev2"
     check_version(out, exp, dirty=False)
 
 
@@ -303,7 +303,7 @@ def test_git_repo_dirty(demoapp):
         .make_dirty_tree()
     )
     out = demoapp.setup_py("--version")
-    exp = "0.1.post1"
+    exp = "0.1.post1.dev1"
     check_version(out, exp, dirty=True)
 
 
@@ -317,7 +317,7 @@ def test_git_repo_with_1_0_tag(demoapp):
 def test_git_repo_with_1_0_tag_dirty(demoapp):
     demoapp.tag("v1.0", "final release").make_dirty_tree()
     out = demoapp.setup_py("--version")
-    exp = "1.0.post0"
+    exp = "1.0.post1.dev0"
     check_version(out, exp, dirty=True)
 
 
@@ -360,7 +360,7 @@ def test_setup_py_install_with_data(demoapp_data):
     exp = "Hello World"
     assert out.startswith(exp)
     out = demoapp_data.cli("--version")
-    exp = "0.0.post2"
+    exp = "0.0.post1.dev2"
     check_version(out, exp, dirty=False)
 
 
@@ -370,5 +370,5 @@ def test_setup_py_develop_with_data(demoapp_data):
     exp = "Hello World"
     assert out.startswith(exp)
     out = demoapp_data.cli("--version")
-    exp = "0.0.post2"
+    exp = "0.0.post1.dev2"
     check_version(out, exp, dirty=False)


### PR DESCRIPTION
… this version scheme is closer to the one we were using in PyScaffold v3 (previously we were using the `.post0.devX`, `"no-guess-dev"` used `.post1.devX`, while the current master branch uses `.postX`).
It requires `setuptools_scm > 5` (since it is a new implementation).

Additionally this PR updates the `setuptools` dependency to match the one from `pyproject.toml` (always a good thing to ensure the user will have a version of `setuptools` that supports PEP 517, 518 and 420).