### PR TITLE
ignore coverage files generated by tox -p

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ tags
 # Unittest and coverage
 htmlcov/*
 .coverage
+.coverage.*.*
 .tox
 junit*.xml
 coverage.xml

--- a/src/pyscaffold/templates/gitignore.template
+++ b/src/pyscaffold/templates/gitignore.template
@@ -32,6 +32,7 @@ tags
 # Unittest and coverage
 htmlcov/*
 .coverage
+.coverage.*.*
 .tox
 junit*.xml
 coverage.xml


### PR DESCRIPTION
Following up the discussion from [PR357](https://github.com/pyscaffold/pyscaffold/pull/357#issuecomment-754266600).

Answer to @abravalheri 

> Hi @CarliJoy please feel free to open a new issue/discussion/PR or keep it here. I am trying to understand your use case/tox workflow (so if you could expand a bit more the rationale behind the change, it would help a lot)...
> 
> If I am not wrong tox -p runs tox'es test environments in parallel. That was very useful in the past (for example for running tox -p -e py27,py36), however the default tox.ini file generated by PyScaffold was not really designed for it (in my opinion it makes little sense to run tox -p -e py,clean,build,docs). What PyScaffold adopts instead is pytest-xdist to run the tests in parallel inside a single tox testenv (activated by tox -- -n auto [opt-in feature, but that the user can easily change to be the default behaviour]).
> 
> With this option, the extra coverage files are still generated, but after pytest finishes running, the configuration that ships with PyScaffold make sure that they are combined in a single file and all the other ones are automatically deleted. They will not be deleted in the case the tox/pytest process is killed (e.g. CTRL+C).
> 
> I can see that sometimes someone might be surprised by a bunch of coverage files when they run git status, however in my mind they are a nice reminder that the tests did not finish running well and therefore you need to delete the files if you want to have your working directory clean. Ignoring the files will not make them go away... so if someone do a ls they would ending-up being surprised anyway... (That is why, with my current understanding of the situation, I opted by not merging this part of the PR)
> 

My use case is i.e. a [Django Plugin](https://github.com/CarliJoy/django-pint) I am developing.
For this I require that tox test all different combination of Django versions with Python Version (sums up to >10 combinations).

Often I have to cancel test manually (as you can imagine they take quite long to finish) if I see there is an error.
Therefore I would need to to modify the default `tox.ini`.
IMO the `tox.ini`  is probably edited quite often by different users as they might require different kind of test i.e. integration test with ssh or what ever....
So relying on the default pyscaffold configuration to proper clean up seems not very reliable.

Also I don't need a reminder that the test didn't run properly - I know that I killed them :wink:.
For me as an end user the `.gitignore` should be consistent. So for me it make no sense why the combined `.converage` file is treated different as the one generated by `tox -p`.
It looks also strange in PyCharm 😛
![image](https://user-images.githubusercontent.com/7687556/103641473-17caa080-4f52-11eb-8750-8d6158a006ec.png)

Of course they still there when using `ls -al` but more annoyingly is that adding the fix that caused me to cancel the test using `git add .` won't work.

