### PR TITLE
Add max version to extensions in v3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,14 +51,14 @@ exclude =
 all =
     django
     cookiecutter
-    pyscaffoldext-markdown
-    pyscaffoldext-pyproject
-    pyscaffoldext-custom-extension
-    pyscaffoldext-dsproject
+    pyscaffoldext-markdown<0.4a0
+    pyscaffoldext-pyproject<0.3a0
+    pyscaffoldext-custom-extension<0.6a0
+    pyscaffoldext-dsproject<0.5a0
 md =
-    pyscaffoldext-markdown
+    pyscaffoldext-markdown<0.4a0
 ds =
-    pyscaffoldext-dsproject
+    pyscaffoldext-dsproject<0.5a0
 # Add here test dependencies (used by tox)
 testing =
     django


### PR DESCRIPTION
Now that v4 compatible versions for the extensions are out, adding a max is an insurance policy to avoid errors...

Let's see if the CI is happy before merging.