### PR TITLE
Fix generated __init__.py no cover pragma

### DIFF
--- a/src/pyscaffold/templates/__init__.template
+++ b/src/pyscaffold/templates/__init__.template
@@ -10,7 +10,7 @@ try:
     # Change here if project is renamed and does not equal the package name
     dist_name = ${distribution}
     __version__ = version(dist_name)
-except PackageNotFoundError:
-    __version__ = "unknown"  # pragma: no cover
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "unknown"
 finally:
     del version, PackageNotFoundError


### PR DESCRIPTION
The no cover pragma should apply to the entire except clause instead of
the statement in the clause.  Otherwise we get a coverage miss on the
"except" line.