### PR TITLE
Merge main and run in a single function inside skeleton

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,8 +15,8 @@ env:
 .regular_task_template: &REGULAR_TASK_TEMPLATE
   pip_cache: &pip-cache
     folder: $PIP_CACHE
-  # pre_commit_cache: &pre-commit-cache
-  #   folder: $PRE_COMMIT_HOME
+  pre_commit_cache: &pre-commit-cache
+    folder: $PRE_COMMIT_HOME
   tox_install_script:
     - python -m pip install --upgrade pip setuptools tox
   prepare_script: &prepare
@@ -156,8 +156,8 @@ windows_task:
     # ^  deactivate SSL checking to avoid error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:661)
   pip_cache:
     folder: '%PIP_CACHE%'
-  # pre_commit_cache:
-  #   folder: '%PRE_COMMIT_HOME%'
+  pre_commit_cache:
+    folder: '%PRE_COMMIT_HOME%'
   install_script:
     # Activate long file paths to avoid some errors
     - REG ADD HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,8 +15,8 @@ env:
 .regular_task_template: &REGULAR_TASK_TEMPLATE
   pip_cache: &pip-cache
     folder: $PIP_CACHE
-  pre_commit_cache: &pre-commit-cache
-    folder: $PRE_COMMIT_HOME
+  # pre_commit_cache: &pre-commit-cache
+  #   folder: $PRE_COMMIT_HOME
   tox_install_script:
     - python -m pip install --upgrade pip setuptools tox
   prepare_script: &prepare
@@ -156,8 +156,8 @@ windows_task:
     # ^  deactivate SSL checking to avoid error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:661)
   pip_cache:
     folder: '%PIP_CACHE%'
-  pre_commit_cache:
-    folder: '%PRE_COMMIT_HOME%'
+  # pre_commit_cache:
+  #   folder: '%PRE_COMMIT_HOME%'
   install_script:
     # Activate long file paths to avoid some errors
     - REG ADD HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem /v LongPathsEnabled /t REG_DWORD /d 1 /f

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,12 +13,8 @@ env:
 
 # This template is used in most of the tasks
 .regular_task_template: &REGULAR_TASK_TEMPLATE
-  pip_cache: &pip-cache
-    folder: $PIP_CACHE
-  pre_commit_cache: &pre-commit-cache
-    folder: $PRE_COMMIT_HOME
   tox_install_script:
-    - python -m pip install --upgrade pip setuptools tox
+    - python -m pip install --upgrade pip setuptools tox pre-commit
   prepare_script: &prepare
     # This script is also used in Windows, so the shell is not POSIX
     - git config --global user.email "you@example.com"
@@ -37,6 +33,15 @@ env:
       path: junit-*.xml
       format: junit
       type: text/xml
+  pip_cache: &pip-cache
+    folder: $PIP_CACHE
+  pre_commit_cache: &pre-commit-cache
+    folder: $PRE_COMMIT_HOME
+    fingerprint_script:
+      - echo $CIRRUS_OS
+      - python --version
+      - pre-commit --version
+      - cat .pre-commit-config.yaml src/pyscaffold/templates/pre-commit-config.template
 
 
 # ---- Task definitions ----
@@ -164,7 +169,7 @@ windows_task:
     # Set Windows encoding to UTF-8
     - REG ADD "HKEY_CURRENT_USER\Software\Microsoft\Command Processor" /v Autorun /t REG_SZ /d "@chcp 65001>nul" /f
     - python -m ensurepip
-    - python -m pip install --upgrade --user pip setuptools certifi tox
+    - python -m pip install --upgrade --user pip setuptools certifi tox pre-commit
   prepare_script: *prepare
   clean_workspace_script:
     # Avoid information carried from one run to the other

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -163,8 +163,8 @@ coverage_task:
     - test (Linux - Anaconda)
     - test (OS X)
   install_script: *debian-install
-  pre_commit_cache: &pre-commit-cache
-    folder: $PRE_COMMIT_HOME
+  # pre_commit_cache: &pre-commit-cache
+  #   folder: $PRE_COMMIT_HOME
   pip_install_script:
     pip install --user --upgrade coverage coveralls pre-commit
   precommit_script:

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -163,8 +163,8 @@ coverage_task:
     - test (Linux - Anaconda)
     - test (OS X)
   install_script: *debian-install
-  # pre_commit_cache: &pre-commit-cache
-  #   folder: $PRE_COMMIT_HOME
+  pre_commit_cache: &pre-commit-cache
+    folder: $PRE_COMMIT_HOME
   pip_install_script:
     pip install --user --upgrade coverage coveralls pre-commit
   precommit_script:

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -163,8 +163,6 @@ coverage_task:
     - test (Linux - Anaconda)
     - test (OS X)
   install_script: *debian-install
-  pre_commit_cache: &pre-commit-cache
-    folder: $PRE_COMMIT_HOME
   pip_install_script:
     pip install --user --upgrade coverage coveralls pre-commit
   precommit_script:
@@ -173,3 +171,10 @@ coverage_task:
   <<: *REGULAR_TASK_TEMPLATE
   coverage_script:
     - coveralls
+  pre_commit_cache: &pre-commit-cache
+    folder: $PRE_COMMIT_HOME
+    fingerprint_script:
+      - echo $CIRRUS_OS
+      - python --version
+      - pre-commit --version
+      - cat .pre-commit-config.yaml

--- a/src/pyscaffold/templates/skeleton.template
+++ b/src/pyscaffold/templates/skeleton.template
@@ -67,6 +67,7 @@ def parse_args(args):
 
     Args:
       args (List[str]): command line parameters as list of strings
+          (for example  ``["--help"]``).
 
     Returns:
       :obj:`argparse.Namespace`: command line parameters namespace
@@ -109,22 +110,29 @@ def setup_logging(loglevel):
     )
 
 
-def run(args=None):
-    """Main entry point for console scripts
+def main(args):
+    """Wrapper allowing :func:`fib` to be called with string arguments in a CLI fashion
 
-    Calls :func:`fib` with the given command line arguments and prints the
-    result to the stdout in a nicely formated message.
+    Instead of returning the value from :func:`fib`, it prints the result to the
+    ``stdout`` in a nicely formated message.
 
     Args:
-      args (Optional[List[str]]): command line parameter list.
-        When ``args`` is not provided, it will be taken directly from the
-        command line (:obj:`sys.argv`).
+      args (List[str]): command line parameters as list of strings
+          (for example  ``["--verbose", "42"]``).
     """
-    args = parse_args(args or sys.argv[1:])
+    args = parse_args(args)
     setup_logging(args.loglevel)
     _logger.debug("Starting crazy calculations...")
     print("The {}-th Fibonacci number is {}".format(args.n, fib(args.n)))
     _logger.info("Script ends here")
+
+
+def run():
+    """Calls :func:`main` passing the CLI arguments extracted from :obj:`sys.argv`
+
+    This function can be used as entry point to create console scripts with setuptools.
+    """
+    main(sys.argv[1:])
 
 
 if __name__ == "__main__":

--- a/src/pyscaffold/templates/skeleton.template
+++ b/src/pyscaffold/templates/skeleton.template
@@ -1,17 +1,23 @@
 """
 This is a skeleton file that can serve as a starting point for a Python
 console script. To run this script uncomment the following lines in the
-[options.entry_points] section in setup.cfg:
+``[options.entry_points]`` section in ``setup.cfg``::
 
     console_scripts =
          fibonacci = ${package}.skeleton:run
 
-Then run `python setup.py install` which will install the command `fibonacci`
-inside your current environment.
-Besides console scripts, the header (i.e. until _logger...) of this file can
+Then run ``pip install .`` (or ``pip install -e .`` for editable mode)
+which will install the command ``fibonacci`` inside your current environment.
+
+Besides console scripts, the header (i.e. until ``_logger``...) of this file can
 also be used as template for Python modules.
 
-Note: This skeleton file can be safely removed if not needed!
+Note:
+    This skeleton file can be safely removed if not needed!
+
+References:
+    - https://setuptools.readthedocs.io/en/latest/userguide/entry_point.html
+    - https://pip.pypa.io/en/stable/reference/pip_install
 """
 
 import argparse
@@ -25,6 +31,13 @@ __copyright__ = "${author}"
 __license__ = "${license}"
 
 _logger = logging.getLogger(__name__)
+
+
+# ---- Python API ----
+# The functions defined in this section can be imported by users in their
+# Python scripts/interactive interpreter, e.g. via
+# `from ${qual_pkg}.skeleton import fib`,
+# when using this Python module as a library.
 
 
 def fib(n):
@@ -43,11 +56,17 @@ def fib(n):
     return a
 
 
+# ---- CLI ----
+# The functions defined in this section are wrappers around the main Python
+# API allowing them to be called directly from the terminal as a CLI
+# executable/script.
+
+
 def parse_args(args):
     """Parse command line parameters
 
     Args:
-      args ([str]): command line parameters as list of strings
+      args (List[str]): command line parameters as list of strings
 
     Returns:
       :obj:`argparse.Namespace`: command line parameters namespace
@@ -90,23 +109,33 @@ def setup_logging(loglevel):
     )
 
 
-def main(args):
-    """Main entry point allowing external calls
+def run(args=None):
+    """Main entry point for console scripts
+
+    Calls :func:`fib` with the given command line arguments and prints the
+    result to the stdout in a nicely formated message.
 
     Args:
-      args ([str]): command line parameter list
+      args (Optional[List[str]]): command line parameter list.
+        When ``args`` is not provided, it will be taken directly from the
+        command line (:obj:`sys.argv`).
     """
-    args = parse_args(args)
+    args = parse_args(args or sys.argv[1:])
     setup_logging(args.loglevel)
     _logger.debug("Starting crazy calculations...")
     print("The {}-th Fibonacci number is {}".format(args.n, fib(args.n)))
     _logger.info("Script ends here")
 
 
-def run():
-    """Entry point for console_scripts"""
-    main(sys.argv[1:])
-
-
 if __name__ == "__main__":
+    # ^  This is a guard statement that will prevent the following code from
+    #    being executed in the case someone imports this file instead of
+    #    executing it as a script.
+    #    https://docs.python.org/3/library/__main__.html
+
+    # After installing your project with pip, users can also run your Python
+    # modules as scripts via the ``-m`` flag, as defined in PEP 338::
+    #
+    #     python -m ${qual_pkg}.skeleton 42
+    #
     run()

--- a/src/pyscaffold/templates/test_skeleton.template
+++ b/src/pyscaffold/templates/test_skeleton.template
@@ -1,6 +1,6 @@
 import pytest
 
-from ${qual_pkg}.skeleton import fib, run
+from ${qual_pkg}.skeleton import fib, main
 
 __author__ = "${author}"
 __copyright__ = "${author}"
@@ -16,10 +16,10 @@ def test_fib():
         fib(-10)
 
 
-def test_run(capsys):
+def test_main(capsys):
     """CLI Tests"""
     # capsys is a pytest fixture that allows asserts agains stdout/stderr
     # https://docs.pytest.org/en/stable/capture.html
-    run(["7"])
+    main(["7"])
     captured = capsys.readouterr()
     assert "The 7-th Fibonacci number is 13" in captured.out

--- a/src/pyscaffold/templates/test_skeleton.template
+++ b/src/pyscaffold/templates/test_skeleton.template
@@ -1,6 +1,6 @@
 import pytest
 
-from ${qual_pkg}.skeleton import fib
+from ${qual_pkg}.skeleton import fib, run
 
 __author__ = "${author}"
 __copyright__ = "${author}"
@@ -8,8 +8,18 @@ __license__ = "${license}"
 
 
 def test_fib():
+    """API Tests"""
     assert fib(1) == 1
     assert fib(2) == 1
     assert fib(7) == 13
     with pytest.raises(AssertionError):
         fib(-10)
+
+
+def test_run(capsys):
+    """CLI Tests"""
+    # capsys is a pytest fixture that allows asserts agains stdout/stderr
+    # https://docs.pytest.org/en/stable/capture.html
+    run(["7"])
+    captured = capsys.readouterr()
+    assert "The 7-th Fibonacci number is 13" in captured.out


### PR DESCRIPTION
As I went through #397 I found it difficult to explain/understand why we
have 2 functions in skeleton doing the CLI wrapping...

The docstring in `main` was also a bit confusing since it said that `main`
was the entry point for external calls. Since external calls can also
be interpreted as API calls from other packages, it sounded to me a bit weird that
people using skeleton's Python API should prefer passing stringfied
arguments instead of calling `fib` directly...

This change is a proposal to have `args` as an optional argument, which
makes it possible to unify the two functions into a single one, making
it a bit easier to explain.

I also added another test function for the CLI to the generated tests,
since we want to incentivise people to test.