### PR TITLE
Temporarily pin conda to 4.0.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Just pick your favourite installation method::
     pip install pyscaffold
 
     ## Conda for the datascience fans
-    conda install -c conda-forge pyscaffold
+    conda install -c conda-forge pyscaffold=4.0.0
 
     ## Or even pipx for the virtualenv aficionados
     pipx install pyscaffold


### PR DESCRIPTION
## Purpose
I accidentally published 4.0.1rc1 to the main index.

See https://github.com/conda-forge/pyscaffold-feedstock/issues/29