### PR TITLE
Mark tests that should not run without PyScaffold's src

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -127,6 +127,7 @@ markers =
     system: mark system tests
     original_logger: do not isolate logger in specific tests
     no_fake_config_dir: avoid the autofixture fake_config_dir to take effect
+    requires_src: tests that require the raw source of PyScaffold and assume our default CI environment
 log_level = DEBUG
 log_cli = True
 log_cli_level = CRITICAL

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -13,6 +13,14 @@ from time import sleep
 from uuid import uuid4
 from warnings import warn
 
+import pytest
+
+skip_on_conda_build = pytest.mark.skipif(
+    os.getenv("CONDA_BUILD"),
+    reason="conda build does not run inside virtualenv/tox and "
+    "it does not have PyScaffold's source code available when running tests",
+)
+
 
 def uniqstr():
     """Generates a unique random long string every time it is called"""

--- a/tests/system/test_common.py
+++ b/tests/system/test_common.py
@@ -8,6 +8,7 @@ import pytest
 from pyscaffold.file_system import chdir
 from pyscaffold.info import read_pyproject
 
+from ..helpers import skip_on_conda_build
 from .helpers import run, run_common_tasks
 
 pytestmark = [pytest.mark.slow, pytest.mark.system]
@@ -27,6 +28,8 @@ def cwd(tmpdir):
         yield tmpdir
 
 
+@skip_on_conda_build
+@pytest.mark.requires_src
 def test_ensure_inside_test_venv(putup):
     # This is a METATEST
     # Here we ensure `putup` is installed inside tox so we know we are testing the

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -12,6 +12,8 @@ from pyscaffold import __path__ as pyscaffold_paths
 from pyscaffold import __version__, info, update
 from pyscaffold.file_system import chdir
 
+from .helpers import skip_on_conda_build
+
 EDITABLE_PYSCAFFOLD = re.compile(r"^-e.+pyscaffold.*$", re.M | re.I)
 
 
@@ -123,6 +125,8 @@ def venv_mgr(tmpdir, venv, pytestconfig):
 
 
 @pytest.mark.slow
+@pytest.mark.requires_src
+@skip_on_conda_build
 def test_update_version_3_0_to_3_1(with_coverage, venv_mgr):
     project = Path(venv_mgr.venv_path, "my_old_project")
     (
@@ -137,6 +141,8 @@ def test_update_version_3_0_to_3_1(with_coverage, venv_mgr):
 
 
 @pytest.mark.slow
+@pytest.mark.requires_src
+@skip_on_conda_build
 def test_update_version_3_0_to_3_1_pretend(with_coverage, venv_mgr):
     project = Path(venv_mgr.venv_path, "my_old_project")
     (
@@ -151,6 +157,8 @@ def test_update_version_3_0_to_3_1_pretend(with_coverage, venv_mgr):
 
 
 @pytest.mark.slow
+@pytest.mark.requires_src
+@skip_on_conda_build
 def test_inplace_update(with_coverage, venv_mgr):
     # Given an existing project
     project = Path(venv_mgr.tmpdir) / "my-ns-proj"


### PR DESCRIPTION
## Purpose
Some tests in our test suite assume specific conditions like having the source code available or running inside a virtual environment created by tox.
There are some circumstances though where users might want to obtain PyScaffold from a pre-packaged source and then just run the tests from a separated copy of the `tests` folder, specially when considering packaging forms other than wheels/pip.

## Approach
This PR adds pytest marks that can be de-selected, so the tests under the mentioned assumptions will not run.

## Resources & Links

See https://github.com/pyscaffold/pyscaffoldext-markdown/issues/10 for the context motivating this PR.