### PR TITLE
Specify virtualenv as extra dependency for build in tox.ini

### DIFF
--- a/src/pyscaffold/templates/tox_ini.template
+++ b/src/pyscaffold/templates/tox_ini.template
@@ -30,7 +30,7 @@ description =
 skip_install = True
 changedir = {toxinidir}
 deps =
-    build: build
+    build: build[virtualenv]
 commands =
     clean: python -c 'from shutil import rmtree; rmtree("build", True); rmtree("dist", True)'
     build: python -m build .

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ description =
 skip_install = True
 changedir = {toxinidir}
 deps =
-    build: build
+    build: build[virtualenv]
 commands =
     clean: python -c 'from shutil import rmtree; rmtree("build", True); rmtree("dist", True)'
     build: python -m build .


### PR DESCRIPTION
## Purpose
`build` seems to rely by default in the stdlib's implementation of `venv` and unfortunately for a specific combination of Windows + conda env + virtualenv (as used by tox), that might be problematic as identified in https://github.com/pyscaffold/pyscaffoldext-markdown/issues/10.

## Approach
According to the discussion in https://github.com/pypa/build/pull/253, specifying `virtualenv` as an extra dependency of `build` seems to be a good workaround. Moreover I would expect some kind speed improvements (virtualenv is reported to be faster than venv).

