### PR TITLE
Remove checks for old setuptools installation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,14 @@ install_requires =
     setuptools_scm>=5
     tomlkit>=0.7.0,<2
     packaging>=20.7
+
 # packaging is versioned by year, not SemVer
+
+# Notes about setuptools versions:
+# - 40.1: required for `find_namespace`
+# - 45: required for `setuptools_scm` v6
+# However we specify a higher version so we encourage users to update the
+# version they have installed...
 
 [options.packages.find]
 where = src

--- a/src/pyscaffold/cli.py
+++ b/src/pyscaffold/cli.py
@@ -13,7 +13,6 @@ from . import __version__ as pyscaffold_version
 from . import api, templates
 from .actions import ScaffoldOpts
 from .actions import discover as discover_actions
-from .dependencies import check_setuptools_version
 from .exceptions import exceptions2exit
 from .extensions import list_from_entry_points as list_all_extensions
 from .identification import get_id
@@ -253,7 +252,6 @@ def main(args: List[str]):
     Args:
         args: command line arguments
     """
-    check_setuptools_version()
     opts = parse_args(args)
     opts["command"](opts)
 

--- a/src/pyscaffold/dependencies.py
+++ b/src/pyscaffold/dependencies.py
@@ -5,18 +5,9 @@ from itertools import chain
 from typing import Iterable, List
 
 from packaging.requirements import Requirement
-from packaging.version import parse as parse_version
-from setuptools_scm.version import VERSION_CLASS
 
-from .exceptions import OldSetuptools
+# setuptools version is now enforced via `install_requires`
 
-try:
-    from setuptools import __version__ as setuptools_ver
-except ImportError:
-    raise OldSetuptools
-
-
-SETUPTOOLS_VERSION = parse_version("40.1")  # required for find_namespace
 BUILD = ("setuptools_scm>=5", "wheel")
 """Dependencies that will be required to build the created project"""
 RUNTIME = ('importlib-metadata; python_version<"3.8"',)
@@ -42,21 +33,6 @@ REQ_SPLITTER = re.compile(r";(?!\s*(python|platform|implementation|os|sys)_)", r
 .. _setup.cfg specs: https://setuptools.readthedocs.io/en/latest/setuptools.html#options
 .. _PEP 508: https://www.python.org/dev/peps/pep-0508/
 """
-
-
-def check_setuptools_version():
-    """Check minimum required version of setuptools
-
-    Check that setuptools has all necessary capabilities for setuptools_scm
-    as well as support for configuration with the help of ``setup.cfg``.
-
-    Raises:
-          :obj:`OldSetuptools` : raised if necessary capabilities are not met
-    """
-    setuptools_too_old = parse_version(setuptools_ver) < SETUPTOOLS_VERSION
-    setuptools_scm_check_failed = VERSION_CLASS is None
-    if setuptools_too_old or setuptools_scm_check_failed:
-        raise OldSetuptools
 
 
 def split(requirements: str) -> List[str]:

--- a/src/pyscaffold/exceptions.py
+++ b/src/pyscaffold/exceptions.py
@@ -104,20 +104,6 @@ class InvalidIdentifier(RuntimeError):
     """
 
 
-class OldSetuptools(RuntimeError):
-    """PyScaffold requires a recent version of setuptools."""
-
-    DEFAULT_MESSAGE = (
-        "Your setuptools version is too old (<38.3). "
-        "Use `pip install -U setuptools` to upgrade.\n"
-        "If you have the deprecated `distribute` package installed "
-        "remove it or update to version 0.7.3."
-    )
-
-    def __init__(self, message=DEFAULT_MESSAGE, *args, **kwargs):
-        super().__init__(message, *args, **kwargs)
-
-
 class PyScaffoldTooOld(RuntimeError):
     """PyScaffold cannot update a pre 3.0 version"""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -300,13 +300,6 @@ def nodjango_admin_mock(monkeypatch):
 
 
 @pytest.fixture
-def old_setuptools_mock(monkeypatch):
-    monkeypatch.setattr("setuptools.__version__", "10.0.0")
-    monkeypatch.setattr("pyscaffold.dependencies.setuptools_ver", "10.0.0")
-    yield
-
-
-@pytest.fixture
 def nosphinx_mock():
     with disable_import("sphinx"):
         yield

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 import pytest
 
 from pyscaffold import cli
-from pyscaffold.exceptions import ErrorLoadingExtension, OldSetuptools
+from pyscaffold.exceptions import ErrorLoadingExtension
 from pyscaffold.file_system import localize_path as lp
 
 from .log_helpers import find_report
@@ -112,12 +112,6 @@ def test_main_when_updating(tmpfolder, capsys, git_mock):
     assert os.path.exists(args[1])
     out, _ = capsys.readouterr()
     assert "Update accomplished!" in out
-
-
-def test_main_with_old_setuptools(tmpfolder, old_setuptools_mock):
-    args = ["my-project"]
-    with pytest.raises(OldSetuptools):
-        cli.main(args)
 
 
 def test_main_with_list_actions(tmpfolder, capsys, isolated_logger):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -135,7 +135,8 @@ class DemoApp(object):
 
     def setup_py(self, *args, **kwargs):
         with chdir(self.pkg_path):
-            args = ["python", "setup.py"] + list(args)
+            args = ["python", "-Wignore", "setup.py"] + list(args)
+            # Avoid warnings since we are going to compare outputs
             return self.run(*args, **kwargs)
 
     def build(self, dist="bdist", cli_opts=()):


### PR DESCRIPTION
As discussed in #428, some checks we were making for the setuptools
version are incompatible with the latest version of setuptools_scm.

So one alternative (implemented in this PR) is to simply stop verifying
the versions and assume they are satisfied because they are correctly
declared as `install_requires` in `setup.cfg`.

The only doubt left is: what happens if the person is building a
generated project with `--no-pyproject`?

(In `pyproject.toml` we do have a minimum requirement for setuptools,
which is more than enough, but in `setup.py` that is omitted... Should we
add one? Is that a good practice? Or are we just being optimistic and
relying on the error message asking the user to update?)