### PR TITLE
Quote shell.get_executable to avoid errors with whitespace

### DIFF
--- a/src/pyscaffold/shell.py
+++ b/src/pyscaffold/shell.py
@@ -152,7 +152,7 @@ git = get_git_cmd()
 
 
 def get_executable(
-    name: str, prefix: PathLike = sys.prefix, include_path=True, quote: bool = True
+    name: str, prefix: PathLike = sys.prefix, include_path=True
 ) -> Optional[str]:
     """Find an executable in the system, if available.
 

--- a/src/pyscaffold/shell.py
+++ b/src/pyscaffold/shell.py
@@ -236,7 +236,8 @@ def join(parts: Iterable[Union[str, PathLike]]) -> str:
         # ^  CI setup does not aggregate Windows coverage
         return subprocess.list2cmdline(map(str, parts))
 
-    return shlex.join(map(str, parts))
+    return " ".join(shlex.quote(str(p)) for p in parts)
+    # ^  TODO: Replace with `shlex.join(map(str, parts))` when Python >= 3.8
 
 
 #: Command for git

--- a/src/pyscaffold/shell.py
+++ b/src/pyscaffold/shell.py
@@ -114,7 +114,9 @@ def get_git_cmd(**args):
     Args:
         **args: additional keyword arguments to :obj:`~.ShellCommand`
     """
-    if sys.platform == "win32":
+    if sys.platform == "win32":  # pragma: no cover
+        # in our current CI setup, Windows-specific code might run during tests
+        # but the coverage data is not submitted
         for cmd in ["git.cmd", "git.exe"]:
             git = ShellCommand(cmd, **args)
             try:
@@ -213,13 +215,16 @@ def get_editor(**kwargs):
 def edit(file: PathLike, *args, **kwargs) -> Path:
     """Open a text editor and returns back a :obj:`Path` to file, after user editing."""
     editor = ShellCommand(_quote(get_editor()))
-    # since we quote here we cannot pass flags in EDITOR environment variable
+    # ^  since we quote here we cannot pass flags in EDITOR environment variable
     editor(file, *args, **{"stdout": None, "stderr": None, **kwargs})
     # ^  stdout/stderr=None => required for a terminal editor to open properly
     return Path(file)
 
 
-def _has_whitespace(executable_path: str) -> bool:
+def _has_whitespace(executable_path: str) -> bool:  # pragma: no cover
+    # This helper function is only supposed to be used on Windows
+    # and in our current CI setup, even if it runs, the coverage data will not be
+    # submitted
     parts = executable_path.split()
     # by default split will consider all kinds of whitespace
     return len(parts) > 1
@@ -238,7 +243,9 @@ def _quote(executable_path: str) -> str:
     if os.name == "posix":
         return shlex.quote(executable_path)
         # shlex is supposed to not quote if not necessary
-    elif os.name == "nt" and _has_whitespace(executable_path):
+    elif os.name == "nt" and _has_whitespace(executable_path):  # pragma: no cover
+        # in our current CI setup, Windows-specific code might run during tests
+        # but the coverage data is not submitted
         return f'"{executable_path}"'
 
     return executable_path

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -76,6 +76,12 @@ def test_get_command():
         python("--" + uniqstr())
 
 
+def test_get_command_inexistent():
+    name = uniqstr()
+    inexistent = shell.get_command(name, prefix=sys.prefix, include_path=False)
+    assert inexistent is None
+
+
 def test_get_command_with_whitespace(tmpfolder):
     # Given an executable exists in a path with spaces
     prefix = Path(tmpfolder, "with spaces")

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -145,3 +145,20 @@ def test_edit(tmpfolder, monkeypatch):
     # ^ a bit of vim scripting so it does not wait for the user to type
 
     assert file.read_text("utf-8").strip() == "Hello PyScaffold"
+
+
+def test_join():
+    # Join should work with empty iterables
+    assert shell.join([]) == ""
+    assert shell.join({}) == ""
+    assert shell.join(()) == ""
+    assert shell.join(x for x in []) == ""
+
+    # Join should accept Path objects
+    p1 = Path("a", "b", "c")
+    p2 = Path("d", "f", "g")
+    assert shell.join([p1, p2]) == f"{p1} {p2}"
+
+    # Join should be the opposite of split
+    args = ["/my path/to exec", '"other args"', "asdf", "42", "'a b c'"]
+    assert shlex.split(shell.join(args)) == args

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,8 +1,12 @@
 import logging
+import os
 import re
+import shlex
 import shutil
+import stat
 import sys
 from pathlib import Path
+from pprint import pformat
 
 import pytest
 
@@ -70,6 +74,43 @@ def test_get_command():
     assert next(python("--version")).strip().startswith("Python 3")
     with pytest.raises(shell.ShellCommandException):
         python("--" + uniqstr())
+
+
+def test_get_command_with_whitespace(tmpfolder):
+    # Given an executable exists in a path with spaces
+    prefix = Path(tmpfolder, "with spaces")
+    if os.name == "posix":
+        executable = Path(prefix, "bin", "myexec")
+        executable.parent.mkdir(parents=True, exist_ok=True)
+        executable.write_text("#!/bin/sh\n\necho 42")
+        executable.chmod(stat.S_IMODE(stat.S_IREAD | stat.S_IEXEC))
+    elif os.name == "nt":  # Windows
+        executable = Path(prefix, "Script", "myexec.bat")
+        executable.parent.mkdir(parents=True, exist_ok=True)
+        executable.write_text("echo 42", encoding="ascii")
+        # ^  Let's use a basic encoding + CRLF for windows
+    else:
+        pytest.skip("Requires either POSIX-compliant OS or Windows")
+        return
+
+    # ----> helps when debugging
+    exec_path = shell.get_executable(
+        "myexec", prefix=prefix, include_path=False, quote=False
+    )
+    print("exec_path:", pformat(shlex.quote(exec_path)))
+    print("contents:\n", pformat(executable.read_text()))
+    assert exec_path is not None
+    assert Path(exec_path).exists()
+    # <----
+
+    # When we create a command with `get_command`
+    cmd = shell.get_command("myexec", prefix=prefix, include_path=False)
+    assert cmd is not None
+    # it should run without any problems
+    completed = cmd.run()
+    print("stdout:", completed.stdout)
+    assert int(completed.stdout) == 42
+    completed.check_returncode()
 
 
 def test_get_editor(monkeypatch):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -87,7 +87,7 @@ def test_get_command_with_whitespace(tmpfolder):
     elif os.name == "nt":  # Windows
         executable = Path(prefix, "Script", "myexec.bat")
         executable.parent.mkdir(parents=True, exist_ok=True)
-        executable.write_text("echo 42", encoding="ascii")
+        executable.write_text("@echo off\r\necho 42", encoding="ascii")
         # ^  Let's use a basic encoding + CRLF for windows
     else:
         pytest.skip("Requires either POSIX-compliant OS or Windows")

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -100,9 +100,7 @@ def test_get_command_with_whitespace(tmpfolder):
         return
 
     # ----> helps when debugging
-    exec_path = shell.get_executable(
-        "myexec", prefix=prefix, include_path=False, quote=False
-    )
+    exec_path = shell.get_executable("myexec", prefix=prefix, include_path=False)
     print("exec_path:", pformat(shlex.quote(exec_path)))
     print("contents:\n", pformat(executable.read_text()))
     assert exec_path is not None


### PR DESCRIPTION
Attempt to fix #430, by `shlex.quote`-ing the executable path.