### PR TITLE
Remove duplicate spec of version_scheme

### DIFF
--- a/src/pyscaffold/templates/setup_py.template
+++ b/src/pyscaffold/templates/setup_py.template
@@ -10,7 +10,7 @@ from setuptools import setup
 
 if __name__ == "__main__":
     try:
-        setup(use_scm_version={"version_scheme": "no-guess-dev"})
+        setup()
     except:  # noqa
         print(
             "\n\nAn error occurred while building the project, "


### PR DESCRIPTION
The version scheme is already specified in pyproject.toml, is it really necessary to duplicate it in setup()?

