### PR TITLE
Experiment: Change in the Sphinx Theme

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -3,12 +3,13 @@ article .align-center:not(table) {
 }
 
 .sidebar-logo {
-  background-color: var(--color-brand-primary);
+  background-color: var(--color-brand-logo-background);
   border-radius: 0.3rem;
 }
 
 main img[alt$="logo"] {
   margin-top: 3rem;
+  background-color: var(--color-brand-logo-background);
   border-radius: 0.5rem;
 }
 

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,69 @@
+article .align-center:not(table) {
+  display: block;
+}
+
+.sidebar-logo {
+  background-color: var(--color-brand-primary);
+  border-radius: 0.3rem;
+}
+
+main img[alt$="logo"] {
+  margin-top: 3rem;
+  border-radius: 0.5rem;
+}
+
+dl:not([class]) dt {
+  color: var(--color-brand-content);
+}
+
+ol > li::marker {
+  /* font-weight: bold; */
+  color: var(--color-foreground-muted);
+}
+
+blockquote {
+  background-color: var(--color-sidebar-background);
+  border-left: solid 0.2rem var(--color-foreground-border);
+  padding-left: 1rem;
+}
+
+blockquote p:first-child {
+  margin-top: 0.1rem;
+}
+
+blockquote p:last-child {
+  margin-bottom: 0.1rem;
+}
+
+.mobile-header,
+.mobile-header.scrolled {
+  border-bottom: solid 1px var(--color-background-border);
+  box-shadow: none;
+}
+
+.section[id$="package"] h1 {
+  color: var(--color-brand-content);
+}
+
+.section[id^="module"] h2 {
+  color: var(--color-brand-primary);
+  background-color: var(--color-brand-light);
+  border-left: solid 0.2rem var(--color-brand-primary);
+  padding: 0.2rem 0.5rem;
+  /* font-family: var(--font-stack--monospace); */
+}
+
+.section[id^="module"] h2:last-child {
+  display: none;
+}
+
+.sidebar-tree .current-page > .reference {
+    background: var(--color-brand-light);
+}
+
+.py.class,
+.py.exception,
+.py.function,
+.py.data {
+  border-top: solid 0.2rem var(--color-brand-light);
+}

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -47,8 +47,8 @@ blockquote p:last-child {
 
 .section[id^="module"] h2 {
   color: var(--color-brand-primary);
-  background-color: var(--color-brand-light);
-  border-left: solid 0.2rem var(--color-brand-primary);
+  background-color: var(--color-brand-muted);
+  border-top: solid 0.2rem var(--color-brand-primary);
   padding: 0.2rem 0.5rem;
   /* font-family: var(--font-stack--monospace); */
 }
@@ -58,12 +58,12 @@ blockquote p:last-child {
 }
 
 .sidebar-tree .current-page > .reference {
-    background: var(--color-brand-light);
+    background: var(--color-brand-muted);
 }
 
 .py.class,
 .py.exception,
 .py.function,
 .py.data {
-  border-top: solid 0.2rem var(--color-brand-light);
+  border-top: solid 0.2rem var(--color-brand-muted);
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,11 +168,11 @@ html_theme_options = {
         "color-brand-primary": "#2980B9",
         "color-brand-content": "#005CA0",
         "color-brand-muted": "#E7F2FA",
+        "color-brand-logo-background": "#156EAD",
     },
     "dark_css_variables": {
-        "color-brand-primary": "#007DDE",
         "color-brand-content": "#0A93FB",
-        "color-brand-muted": "#011A2D",
+        "color-brand-muted": "#00091A",
     },
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -142,6 +142,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".venv"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
+pygments_dark_style = "monokai"
 
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
@@ -154,12 +155,21 @@ pygments_style = "sphinx"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = "sphinx_rtd_theme"
+# html_theme = "sphinx_rtd_theme"
+html_theme = "furo"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-# html_theme_options = {}
+html_theme_options = {
+    "sidebar_hide_name": True,
+    "navigation_with_keys": True,
+    "light_css_variables": {
+        "color-brand-primary": "#2980B9",
+        "color-brand-content": "#005CA0",
+        "color-brand-light": "#E7F2FA",
+    }
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
@@ -190,6 +200,10 @@ html_favicon = "gfx/logo.ico"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+html_css_files = [
+    "custom.css",
+]
+
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
 # html_last_updated_fmt = '%b %d, %Y'
@@ -218,7 +232,7 @@ html_static_path = ["_static"]
 # html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-# html_show_sphinx = True
+html_show_sphinx = False
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 # html_show_copyright = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -167,8 +167,13 @@ html_theme_options = {
     "light_css_variables": {
         "color-brand-primary": "#2980B9",
         "color-brand-content": "#005CA0",
-        "color-brand-light": "#E7F2FA",
-    }
+        "color-brand-muted": "#E7F2FA",
+    },
+    "dark_css_variables": {
+        "color-brand-primary": "#007DDE",
+        "color-brand-content": "#0A93FB",
+        "color-brand-muted": "#011A2D",
+    },
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 # Requirements file for ReadTheDocs, check .readthedocs.yml
 appdirs
 configupdater
+furo
 packaging
 setuptools>=38.3
 setuptools_scm


### PR DESCRIPTION
Recently the RTD themes have been showing some incompatibilities with the latest versions of Sphinx and its dependencies (see #451).

Moreover, instead of centralising the main content in the window, the RTD theme compresses the entire page to the left, and fills the remaining space on the right with a gray background. In large monitors this empty area can have a size comparable (if not bigger) to the area in which the content is displayed, which I consider unpleasant to the reader.

This is an experiment with a new trending Sphinx theme: Furo. It is a minimal theme which prioritises readability and have been used lately in the documentation for the majority of the PyPA projects.

I did a series of customisations/improvements that I found suitable for the PyScaffold docs.

A preview of the changes can be seen [here](https://pyscaffold.org/en/change-docs-theme/).

What do you think @FlorianWilhelm, would that be a good idea?
I do like the original RTD typefaces, but the empty space on the right is a real shame... 


**Note**
I have mainly focusing on the `light` mode of the theme. Depending on the browser/operating system configuration, the `dark` version can be active. If we find this experiment interesting and we want to go forward with the new theme, I can spend some time also changing the `dark` mode.