### PR TITLE
Fix broken links in the docs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -205,7 +205,7 @@ coverage_task:
 
 linkcheck_task:
   name: linkcheck (Linux)
-  only_if: $CIRRUS_BRANCH == 'master'
+  # only_if: $CIRRUS_BRANCH == 'master'
   allow_failures: true
   clone_script: *clone
   container: {image: "python:3.8-buster"}

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -201,3 +201,19 @@ coverage_task:
   <<: *REGULAR_TASK_TEMPLATE
   coverage_script:
     - coveralls
+
+
+linkcheck_task:
+  name: linkcheck (Linux)
+  only_if: $CIRRUS_TAG =~ '^v.*'
+  allow_failures: true
+  clone_script: *clone
+  container: {image: "python:3.8-buster"}
+  depends_on:
+    - test (Linux - 3.8)
+  pip_cache: *pip-cache
+  tox_install_script:
+    - python -m pip install --upgrade pip setuptools tox
+  prepare_script: *prepare
+  linkcheck_script:
+    - python -m tox -e linkcheck -- -q

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -205,7 +205,7 @@ coverage_task:
 
 linkcheck_task:
   name: linkcheck (Linux)
-  only_if: $CIRRUS_TAG =~ '^v.*'
+  only_if: $CIRRUS_BRANCH == 'master'
   allow_failures: true
   clone_script: *clone
   container: {image: "python:3.8-buster"}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -332,7 +332,7 @@ Version 2.3, 2015-08-26
 
 .. note::
 
-    Due to the switch to `pbr <http://docs.openstack.org/developer/pbr/>`_, it
+    Due to the switch to `pbr <https://docs.openstack.org/pbr/latest/>`_, it
     is necessary to update ``setup.cfg`` according to the new syntax.
 
 Version 2.2.1, 2015-06-18
@@ -344,7 +344,7 @@ Version 2.2, 2015-06-01
 -----------------------
 
 - Allow recursive inclusion of data files in setup.cfg, :issue:`49`
-- Replaced hand-written PyTest runner by `pytest-runner <https://pypi.python.org/pypi/pytest-runner>`_, :issue:`47`
+- Replaced hand-written PyTest runner by `pytest-runner <https://pypi.org/project/pytest-runner>`_, :issue:`47`
 - Improved default README.rst, :issue:`51`
 - Use tests/conftest.py instead of tests/__init__.py, :issue:`52`
 - Use setuptools_scm for versioning, :issue:`43`
@@ -429,7 +429,7 @@ Version 1.3.1, 2014-11-24
 Version 1.3, 2014-11-17
 -----------------------
 
-- Support for Tox (https://tox.readthedocs.org/)
+- Support for Tox (https://tox.readthedocs.io/en/stable/)
 - flake8: exclude some files
 - Usage of UTF8 as file encoding
 - Fix: create non-existent files during update

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,14 +17,6 @@ Version 4.0.2, 2021-05-26
 - Fix WSL2 installation problem, :issue:`440`
 - Fix for interactive mode under Windows, :issue:`430`
 
-Version 4.0.1, 2021-03-17
--------------------------
-
-- Fix ``tox -e build`` issue when running on Conda, :pr:`417`
-- Ensure ``snake_case`` for keys in ``setup.cfg``, :issue:`418`
-- Update dependencies on ``configupdater`` and ``pyscaffoldext-django``
-- Remove broken checks for old ``setuptools``, :issue:`428`
-
 Version 3.3, 2020-12-24
 -----------------------
 
@@ -49,6 +41,14 @@ Version 3.3, 2020-12-24
 Older versions
 ==============
 
+Version 4.0.1, 2021-03-17
+-------------------------
+
+- Fix ``tox -e build`` issue when running on Conda, :pr:`417`
+- Ensure ``snake_case`` for keys in ``setup.cfg``, :issue:`418`
+- Update dependencies on ``configupdater`` and ``pyscaffoldext-django``
+- Remove broken checks for old ``setuptools``, :issue:`428`
+
 Version 4.0, 2021-03-04
 -----------------------
 
@@ -59,7 +59,7 @@ Version 4.0, 2021-03-04
 - PyScaffold is no longer a build-time dependency, it just generates the project structure
 - Removed ``contrib`` subpackage, vendorized packages are now runtime dependencies, :pr:`290`
 - ``setuptools_scm`` is included by default in ``setup.cfg``, ``setup.py`` and ``pyproject.toml``
-- API changed to use ``pyscaffold.operations`` instead of integer flags, :issue:`271`
+- API changed to use ``pyscaffold.operations`` instead of integer flags, :pr:`271`
 - Allow ``string.Template`` and ``callable`` as file contents in project structure, :pr:`295`
 - Extract file system functions from ``utils.py`` into ``file_system.py``
 - Extract identification/naming functions from ``utils.py`` into ``identification.py``
@@ -424,7 +424,7 @@ Version 1.3.2, 2014-12-02
 Version 1.3.1, 2014-11-24
 -------------------------
 
-- Fix: --with-tox tuple bug, :issue:`28`
+- Fix: --with-tox tuple bug, :pr:`28`
 
 Version 1.3, 2014-11-17
 -----------------------
@@ -440,13 +440,13 @@ Version 1.3, 2014-11-17
 Version 1.2, 2014-10-13
 -----------------------
 
-- Support pre-commit hooks (http://pre-commit.com/)
+- Support pre-commit hooks (https://pre-commit.com/)
 
 Version 1.1, 2014-09-29
 -----------------------
 
 - Changed COPYING to LICENSE
-- Support for all licenses from http://choosealicense.com/
+- Support for all licenses from https://choosealicense.com/
 - Fix: Allow update of license again
 - Update to Versioneer 0.12
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,15 @@
 Changelog
 =========
 
-..
-    Development version
-    ===================
+
+Development version
+===================
+
+Version 4.X.X, 2021-XX-XX
+-------------------------
+
+- Added *linkcheck* task to ``tox.ini``, :pr:`456`
+- Updated configuration for Sphinx and ReadTheDocs, :pr:`455`
 
 
 Current versions

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -198,7 +198,7 @@ You can also setup breakpoints manually instead of using the ``--pdb`` option.
 .. _Travis: https://travis-ci.org/pyscaffold/pyscaffold
 .. _Cirrus-CI: https://cirrus-ci.com/github/pyscaffold/pyscaffold
 .. _PyPI: https://pypi.python.org/
-.. _Blue Yonder: https://www.blue-yonder.com
+.. _Blue Yonder: https://blueyonder.com/
 .. _project repository: https://github.com/pyscaffold/pyscaffold
 .. _Git: https://git-scm.com/
 .. _Miniconda: https://conda.io/miniconda.html

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -198,15 +198,15 @@ You can also setup breakpoints manually instead of using the ``--pdb`` option.
 .. _Travis: https://travis-ci.org/pyscaffold/pyscaffold
 .. _Cirrus-CI: https://cirrus-ci.com/github/pyscaffold/pyscaffold
 .. _PyPI: https://pypi.python.org/
-.. _Blue Yonder: http://www.blue-yonder.com/en/
-.. _project repository: https://github.com/pyscaffold/pyscaffold/
-.. _Git: http://git-scm.com/
+.. _Blue Yonder: https://www.blue-yonder.com
+.. _project repository: https://github.com/pyscaffold/pyscaffold
+.. _Git: https://git-scm.com/
 .. _Miniconda: https://conda.io/miniconda.html
-.. _issue tracker: http://github.com/pyscaffold/pyscaffold/issues
-.. _Create a Gitub account: https://github.com/signup/free
+.. _issue tracker: https://github.com/pyscaffold/pyscaffold/issues
+.. _Create a Gitub account: https://github.com/join
 .. _creating a PR: https://help.github.com/articles/creating-a-pull-request/
 .. _tox: https://tox.readthedocs.io/
-.. _flake8: http://flake8.pycqa.org/
+.. _flake8: https://flake8.pycqa.org/en/stable
 .. _ci-tester: https://github.com/pyscaffold/ci-tester
 .. _Pytest can drop you: https://docs.pytest.org/en/stable/usage.html#dropping-to-pdb-python-debugger-at-the-start-of-a-test
 .. _ptpdb: https://pypi.org/project/ptpdb/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -197,16 +197,16 @@ You can also setup breakpoints manually instead of using the ``--pdb`` option.
 
 .. _Travis: https://travis-ci.org/pyscaffold/pyscaffold
 .. _Cirrus-CI: https://cirrus-ci.com/github/pyscaffold/pyscaffold
-.. _PyPI: https://pypi.python.org/
+.. _PyPI: https://pypi.org/
 .. _Blue Yonder: https://blueyonder.com/
 .. _project repository: https://github.com/pyscaffold/pyscaffold
 .. _Git: https://git-scm.com/
-.. _Miniconda: https://conda.io/miniconda.html
+.. _Miniconda: https://docs.conda.io/en/latest/miniconda.html
 .. _issue tracker: https://github.com/pyscaffold/pyscaffold/issues
 .. _Create a Gitub account: https://github.com/join
-.. _creating a PR: https://help.github.com/articles/creating-a-pull-request/
-.. _tox: https://tox.readthedocs.io/
-.. _flake8: https://flake8.pycqa.org/en/stable
+.. _creating a PR: https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
+.. _tox: https://tox.readthedocs.io/en/stable/
+.. _flake8: https://flake8.pycqa.org/en/stable/
 .. _ci-tester: https://github.com/pyscaffold/ci-tester
 .. _Pytest can drop you: https://docs.pytest.org/en/stable/usage.html#dropping-to-pdb-python-debugger-at-the-start-of-a-test
 .. _ptpdb: https://pypi.org/project/ptpdb/

--- a/README.rst
+++ b/README.rst
@@ -250,17 +250,17 @@ since the git repository of the existing project is not touched!
 
 .. _v3.3: https://pyscaffold.org/en/v3.3.x/
 .. _PyPI: https://pypi.org/
-.. _pip: https://pip.pypa.io/
+.. _pip: https://pip.pypa.io/en/stable/
 .. _this demo project: https://github.com/pyscaffold/pyscaffold-demo
 .. _reasons to use PyScaffold: https://pyscaffold.org/en/latest/reasons.html
 .. _installation docs: https://pyscaffold.org/en/latest/install.html
 .. _isolated development environment: https://realpython.com/python-virtual-environments-a-primer/
 .. also good, but sometimes medium can get on the way: https://towardsdatascience.com/virtual-environments-104c62d48c54
-.. _virtualenv: https://virtualenv.pypa.io
-.. _conda: https://conda.io
-.. _editable install: https://pip.pypa.io/en/stable/reference/pip_install/#install-editable
-.. _setuptools: https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
-.. _setuptools_scm: https://pypi.python.org/pypi/setuptools_scm/
+.. _virtualenv: https://virtualenv.pypa.io/en/stable/
+.. _conda: https://docs.conda.io/en/latest/
+.. _editable install: https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs
+.. _setuptools: https://setuptools.readthedocs.io/en/stable/userguide/declarative_config.html
+.. _setuptools_scm: https://pypi.org/project/setuptools-scm/
 .. _semantic versioning: https://semver.org
 .. _Git: https://git-scm.com/
 .. _PEP440: https://www.python.org/dev/peps/pep-0440/
@@ -270,8 +270,8 @@ since the git repository of the existing project is not touched!
 .. _Read the Docs: https://readthedocs.org/
 .. _Numpy and Google style docstrings: https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
 .. _pytest: https://docs.pytest.org/en/stable/
-.. _pytest-cov: https://github.com/schlamar/pytest-cov
-.. _Cirrus CI: https://cirrus-ci.org
+.. _pytest-cov: https://github.com/pytest-dev/pytest-cov
+.. _Cirrus CI: https://cirrus-ci.org/
 .. _Travis CI: https://travis-ci.org/
 .. _Coveralls: https://coveralls.io/
 .. _tox: https://tox.readthedocs.io/en/stable/

--- a/README.rst
+++ b/README.rst
@@ -259,26 +259,25 @@ since the git repository of the existing project is not touched!
 .. _virtualenv: https://virtualenv.pypa.io
 .. _conda: https://conda.io
 .. _editable install: https://pip.pypa.io/en/stable/reference/pip_install/#install-editable
-.. _setuptools: http://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
+.. _setuptools: https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
 .. _setuptools_scm: https://pypi.python.org/pypi/setuptools_scm/
 .. _semantic versioning: https://semver.org
-.. _Git: http://git-scm.com/
-.. _PEP440: http://www.python.org/dev/peps/pep-0440/
-.. _pre-commit hooks: http://pre-commit.com/
-.. _py.test: http://pytest.org/
+.. _Git: https://git-scm.com/
+.. _PEP440: https://www.python.org/dev/peps/pep-0440/
+.. _pre-commit hooks: https://pre-commit.com/
 .. _make: https://www.gnu.org/software/make/
-.. _Sphinx: http://www.sphinx-doc.org/
+.. _Sphinx: https://www.sphinx-doc.org/en/master/
 .. _Read the Docs: https://readthedocs.org/
-.. _Numpy and Google style docstrings: http://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
-.. _pytest: http://pytest.org/
+.. _Numpy and Google style docstrings: https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
+.. _pytest: https://docs.pytest.org/en/stable/
 .. _pytest-cov: https://github.com/schlamar/pytest-cov
 .. _Cirrus CI: https://cirrus-ci.org
 .. _Travis CI: https://travis-ci.org/
 .. _Coveralls: https://coveralls.io/
-.. _tox: https://tox.readthedocs.org/
-.. _choosealicense.com: http://choosealicense.com/
+.. _tox: https://tox.readthedocs.io/en/stable/
+.. _choosealicense.com: https://choosealicense.com/
 .. _Django project: https://www.djangoproject.com/
-.. _Cookiecutter: https://cookiecutter.readthedocs.org/
+.. _Cookiecutter: https://cookiecutter.readthedocs.io/en/stable/
 .. _GitLab: https://about.gitlab.com/
 .. _pip-tools: https://github.com/jazzband/pip-tools/
 .. _pyscaffoldext-dsproject: https://github.com/pyscaffold/pyscaffoldext-dsproject

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,7 +11,7 @@ AUTODOCDIR    = api
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $?), 1)
-$(error "The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/")
+$(error "The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from https://sphinx-doc.org/")
 endif
 
 .PHONY: help clean Makefile

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ sys.path.insert(0, os.path.join(__location__, "../src"))
 # -- Run sphinx-apidoc -------------------------------------------------------
 # This hack is necessary since RTD does not issue `sphinx-apidoc` before running
 # `sphinx-build -b html . _build/html`. See Issue:
-# https://github.com/rtfd/readthedocs.org/issues/1139
+# https://github.com/readthedocs/readthedocs.org/issues/1139
 # DON'T FORGET: Check the box "Install your project inside a virtualenv using
 # setup.py install" in the RTD Advanced Settings.
 # Additionally it helps us to avoid running apidoc manually

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -198,9 +198,6 @@ add them to your virtual environment.
     very fast. Changes in the way developers can use it are expected in the
     near future, and therefore PyScaffold support might change as well.
 
-.. _Pipenv: https://pipenv.pypa.io/
-
-
 ..
     TODO: As reported in issue https://github.com/jazzband/pip-tools/issues/204,
     pip-tools is generating absolute file paths inside ``requirements.txt``
@@ -427,14 +424,15 @@ checkout `conda-build tutorials`_ for further information.
 .. _virtual environment: https://towardsdatascience.com/virtual-environments-104c62d48c54
 .. _virtual environments: https://realpython.com/python-virtual-environments-a-primer/
 .. _venv: https://docs.python.org/3/library/venv.html
-.. _virtualenv: https://virtualenv.pypa.io/
+.. _virtualenv: https://virtualenv.pypa.io/en/stable/
+.. _Pipenv: https://pipenv.pypa.io/en/stable/
 .. _pip-tools: https://github.com/jazzband/pip-tools
-.. _pip: https://pip.pypa.io/
+.. _pip: https://pip.pypa.io/en/stable/
 .. _PyPI: https://pypi.org/
-.. _conda: https://conda.io
+.. _conda: https://docs.conda.io/en/latest/
 .. _Anaconda: https://anaconda.org
-.. _channels: https://conda.io/projects/conda/en/latest/user-guide/concepts/channels.html
-.. _custom channels: https://conda.io/projects/conda/en/latest/user-guide/tasks/create-custom-channels.html
+.. _channels: https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/channels.html
+.. _custom channels: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/create-custom-channels.html
 .. _conda-forge: https://conda-forge.org
 .. _bioconda: https://bioconda.github.io
 .. _publishing your package on conda-forge: https://conda-forge.org/docs/maintainer/adding_pkgs.html
@@ -442,7 +440,7 @@ checkout `conda-build tutorials`_ for further information.
 .. _instructions: https://conda-forge.org/docs/maintainer/adding_pkgs.html#step-by-step-instructions
 .. _conda-build tutorials: https://docs.conda.io/projects/conda-build/en/latest/user-guide/tutorials/index.html
 .. _conda environment: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#using-pip-in-an-environment
-.. _PyScaffold's dsproject extension: https://pyscaffold.org/projects/dsproject/
+.. _PyScaffold's dsproject extension: https://pyscaffold.org/projects/dsproject/en/stable/
 .. _mamba: https://github.com/mamba-org/mamba
 .. _pyenv: https://github.com/pyenv/pyenv
 .. _example for data science projects: https://github.com/pyscaffold/dsproject-demo/blob/master/environment.yml

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -422,8 +422,8 @@ checkout `conda-build tutorials`_ for further information.
 .. |venv| replace:: ``venv``
 
 .. _Donald Stufft: https://caremad.io/posts/2013/07/setup-vs-requirement/
-.. _install_requires: https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-dependencies
-.. _extras: http://tox.readthedocs.io/en/latest/config.html#confval-extras=MULTI-LINE-LIST
+.. _install_requires: https://setuptools.readthedocs.io/en/stable/userguide/dependency_management.html
+.. _extras: https://tox.readthedocs.io/en/stable/config.html#conf-extras
 .. _virtual environment: https://towardsdatascience.com/virtual-environments-104c62d48c54
 .. _virtual environments: https://realpython.com/python-virtual-environments-a-primer/
 .. _venv: https://docs.python.org/3/library/venv.html

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -430,7 +430,7 @@ checkout `conda-build tutorials`_ for further information.
 .. _pip: https://pip.pypa.io/en/stable/
 .. _PyPI: https://pypi.org/
 .. _conda: https://docs.conda.io/en/latest/
-.. _Anaconda: https://anaconda.org
+.. _Anaconda: https://anaconda.org/about
 .. _channels: https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/channels.html
 .. _custom channels: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/create-custom-channels.html
 .. _conda-forge: https://conda-forge.org

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -654,13 +654,13 @@ Final Considerations
 
 
 .. _PEP423: https://www.python.org/dev/peps/pep-0423/#use-standard-pattern-for-community-contributions
-.. _setuptools entry point: http://setuptools.readthedocs.io/en/latest/setuptools.html?highlight=dynamic#dynamic-discovery-of-services-and-plugins
+.. _setuptools entry point: https://setuptools.readthedocs.io/en/latest/userguide/entry_point.html
 .. _custom_extension: https://github.com/pyscaffold/pyscaffoldext-custom-extension
 .. _Cookiecutter templates: https://github.com/pyscaffold/pyscaffoldext-cookiecutter
 .. _pyscaffoldext-cookiecutter: https://github.com/pyscaffold/pyscaffoldext-cookiecutter
 .. _Python decorators: https://en.wikipedia.org/wiki/Python_syntax_and_semantics#Decorators
 .. _semantic versioning: https://semver.org
 .. _pull request: https://github.com/pyscaffold/pyscaffold/pulls
-.. _issue: https://github.com/pyscaffold/pyscaffold/issues/new
-.. _discussion: https://github.com/pyscaffold/pyscaffold/discussion/new
+.. _issue: https://github.com/pyscaffold/pyscaffold/issues
+.. _discussion: https://github.com/pyscaffold/pyscaffold/discussions
 .. _explicit relative import statements: https://pep8.org/#imports

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -654,7 +654,7 @@ Final Considerations
 
 
 .. _PEP423: https://www.python.org/dev/peps/pep-0423/#use-standard-pattern-for-community-contributions
-.. _setuptools entry point: https://setuptools.readthedocs.io/en/latest/userguide/entry_point.html
+.. _setuptools entry point: https://setuptools.readthedocs.io/en/stable/userguide/entry_point.html
 .. _custom_extension: https://github.com/pyscaffold/pyscaffoldext-custom-extension
 .. _Cookiecutter templates: https://github.com/pyscaffold/pyscaffoldext-cookiecutter
 .. _pyscaffoldext-cookiecutter: https://github.com/pyscaffold/pyscaffoldext-cookiecutter

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -359,15 +359,15 @@ How can I build a distribution if I have only the source code without a proper g
 .. _PEP 420: https://www.python.org/dev/peps/pep-0420/
 .. _isolated environment: https://realpython.com/python-virtual-environments-a-primer/
 .. _setup.cfg: https://setuptools.readthedocs.io/en/stable/userguide/declarative_config.html
-.. _tox: https://tox.readthedocs.org/
+.. _tox: https://tox.readthedocs.io/en/stable/
 .. _packaging namespace packages official guide: https://packaging.python.org/guides/packaging-namespace-packages
 .. _pkg_resources: https://setuptools.readthedocs.io/en/stable/pkg_resources.html
-.. _Sphinx: https://www.sphinx-doc.org/
+.. _Sphinx: https://www.sphinx-doc.org/en/master/
 .. _pyscaffoldext-cookiecutter: https://github.com/pyscaffold/pyscaffoldext-cookiecutter
 .. _pyscaffoldext-dsproject: https://github.com/pyscaffold/pyscaffoldext-dsproject
 .. _Semantic Versioning: https://semver.org/
 .. _dependency hell: https://en.wikipedia.org/wiki/Dependency_hell
-.. _devpi: https://devpi.net/
-.. _Nexus: https://www.sonatype.com/product-nexus-repository
+.. _devpi: https://www.devpi.net
+.. _Nexus: https://www.sonatype.com/products/repository-oss
 .. _packaging, versioning and continuous integration: https://florianwilhelm.info/2018/01/ds_in_prod_packaging_ci
 .. _PyPI: https://pypi.org/

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -52,7 +52,7 @@ How can I get rid of PyScaffold when my project was set up using it?
    That's already everything you gonna lose. Not that much. You will still benefit from:
 
    * the smart project layout,
-   * the declarative configuration with ``setup.cfg`` which comes from ``setuptools``,
+   * the declarative configuration with ``setup.cfg`` which comes from `setuptools`_,
    * some sane defaults in Sphinx' ``conf.py``,
    * ``.gitignore`` with some nice defaults and other dot files depending on the flags used when running ``putup``,
    * some sane defaults for pytest.
@@ -345,30 +345,29 @@ How can I build a distribution if I have only the source code without a proper g
 .. _src layout: https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure
 .. _discussions: https://github.com/pyscaffold/pyscaffold/discussions
 .. _Q&A: https://github.com/pyscaffold/pyscaffold/discussions/categories/q-a
-.. _egg file: http://setuptools.readthedocs.io/en/latest/formats.html#eggs-and-their-formats
-.. _wheel format: https://pythonwheels.com/
-.. _Cargo: https://crates.io/
-.. _Rust: https://www.rust-lang.org/
-.. _Zen of Python: https://www.python.org/dev/peps/pep-0020/
-.. _six: https://six.readthedocs.io/
+.. _wheel format: https://pythonwheels.com
+.. _Cargo: https://crates.io
+.. _Rust: https://www.rust-lang.org
+.. _Zen of Python: https://www.python.org/dev/peps/pep-0020
+.. _six: https://six.readthedocs.io
 .. _Twitter: https://twitter.com/FlorianWilhelm
-.. _setuptools: https://setuptools.readthedocs.io/en/latest/setuptools.html#options
-.. _setuptools_scm: https://pypi.org/project/setuptools-scm/
+.. _setuptools: https://setuptools.readthedocs.io/en/stable/userguide/declarative_config.html
+.. _setuptools_scm: https://pypi.org/project/setuptools-scm
 .. _Cython: https://cython.org
 .. _PEP 517: https://www.python.org/dev/peps/pep-0517/
 .. _PEP 518: https://www.python.org/dev/peps/pep-0518/
 .. _PEP 420: https://www.python.org/dev/peps/pep-0420/
 .. _isolated environment: https://realpython.com/python-virtual-environments-a-primer/
-.. _setup.cfg: https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
+.. _setup.cfg: https://setuptools.readthedocs.io/en/stable/userguide/declarative_config.html
 .. _tox: https://tox.readthedocs.org/
-.. _packaging namespace packages official guide: https://packaging.python.org/guides/packaging-namespace-packages/
-.. _pkg_resources: https://setuptools.readthedocs.io/en/latest/pkg_resources.html
-.. _Sphinx: http://www.sphinx-doc.org/
+.. _packaging namespace packages official guide: https://packaging.python.org/guides/packaging-namespace-packages
+.. _pkg_resources: https://setuptools.readthedocs.io/en/stable/pkg_resources.html
+.. _Sphinx: https://www.sphinx-doc.org/
 .. _pyscaffoldext-cookiecutter: https://github.com/pyscaffold/pyscaffoldext-cookiecutter
 .. _pyscaffoldext-dsproject: https://github.com/pyscaffold/pyscaffoldext-dsproject
 .. _Semantic Versioning: https://semver.org/
 .. _dependency hell: https://en.wikipedia.org/wiki/Dependency_hell
 .. _devpi: https://devpi.net/
 .. _Nexus: https://www.sonatype.com/product-nexus-repository
-.. _packaging, versioning and continuous integration: https://florianwilhelm.info/2018/01/ds_in_prod_packaging_ci/
+.. _packaging, versioning and continuous integration: https://florianwilhelm.info/2018/01/ds_in_prod_packaging_ci
 .. _PyPI: https://pypi.org/

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -346,7 +346,7 @@ How can I build a distribution if I have only the source code without a proper g
 .. _discussions: https://github.com/pyscaffold/pyscaffold/discussions
 .. _Q&A: https://github.com/pyscaffold/pyscaffold/discussions/categories/q-a
 .. _wheel format: https://pythonwheels.com
-.. _Cargo: https://crates.io
+.. _Cargo: https://doc.rust-lang.org/stable/cargo/
 .. _Rust: https://www.rust-lang.org
 .. _Zen of Python: https://www.python.org/dev/peps/pep-0020
 .. _six: https://six.readthedocs.io

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -427,6 +427,6 @@ Check out our :ref:`Configuration <default-cfg>` section to get started.
 .. _wheels: https://realpython.com/python-wheels/
 .. _SPDX index: https://spdx.org/licenses/
 .. _Mozilla Public License 2.0: https://choosealicense.com/licenses/mpl-2.0/
-.. _editable installs: https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs
+.. _editable installs: https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs
 .. _virtual environment: https://towardsdatascience.com/virtual-environments-104c62d48c54
 .. _Travis CI: https://travis-ci.com

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -381,35 +381,35 @@ Check out our :ref:`Configuration <default-cfg>` section to get started.
 .. _setuptools: https://setuptools.readthedocs.io/en/stable/setuptools.html
 .. _setuptools' documentation: https://setuptools.readthedocs.io/en/stable/userguide/declarative_config.html
 .. _namespace packages: https://packaging.python.org/guides/packaging-namespace-packages/
-.. _Sphinx: https://www.sphinx-doc.org/
+.. _Sphinx: https://www.sphinx-doc.org/en/master/
 .. _Read the Docs: https://readthedocs.org/
 .. _RTD guides: https://docs.readthedocs.io/en/stable/intro/import-guide.html
-.. _tox: https://tox.readthedocs.org/
-.. _tox documentation: https://tox.readthedocs.org/en/stable/
-.. _tox examples: https://tox.readthedocs.io/en/latest/examples.html
+.. _tox: https://tox.readthedocs.io/en/stable/
+.. _tox documentation: https://tox.readthedocs.io/en/stable/
+.. _tox examples: https://tox.readthedocs.io/en/stable/examples.html
 .. _tox tutorial: https://www.seanh.cc/2018/09/01/tox-tutorial/
 .. _semantic versioning: https://semver.org
 .. _Numpy and Google style docstrings: https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
 .. _choosealicense.com: https://choosealicense.com/appendix/
 .. _Django project: https://www.djangoproject.com/
-.. _Cookiecutter: https://cookiecutter.readthedocs.org/
+.. _Cookiecutter: https://cookiecutter.readthedocs.io/en/stable/
 .. _pip-tools: https://github.com/jazzband/pip-tools/
 .. _Pipenv: https://docs.pipenv.org
 .. _PyPI: https://pypi.org/
 .. _TestPyPI: https://test.pypi.org/
-.. _twine: https://twine.readthedocs.io/
+.. _twine: https://twine.readthedocs.io/en/stable/
 .. _using TestPyPI: https://packaging.python.org/guides/using-testpypi/
 .. _importlib.resources: https://docs.python.org/3/library/importlib.html#module-importlib.resources
-.. _importlib_resources: https://importlib-resources.readthedocs.io/
+.. _importlib_resources: https://importlib-resources.readthedocs.io/en/stable/
 .. _flake8: https://flake8.pycqa.org/en/stable/
-.. _GitLab: https://gitlab.com/
+.. _GitLab: https://about.gitlab.com/
 .. _PEP 420: https://www.python.org/dev/peps/pep-0420/
 .. _PEP 440: https://www.python.org/dev/peps/pep-0440/
 .. _PEP 517: https://www.python.org/dev/peps/pep-0517/
 .. _PEP 518: https://www.python.org/dev/peps/pep-0518/
 .. _pre-commit hooks: https://pre-commit.com/
-.. _setuptools_scm: https://pypi.python.org/pypi/setuptools_scm/
-.. _pytest: https://pytest.org/
+.. _setuptools_scm: https://pypi.org/project/setuptools-scm/
+.. _pytest: https://docs.pytest.org/en/stable/
 .. _Cirrus CI: https://cirrus-ci.org/
 .. _pytest-cov: https://github.com/pytest-dev/pytest-cov
 .. _Coveralls: https://coveralls.io/

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -378,18 +378,18 @@ Check out our :ref:`Configuration <default-cfg>` section to get started.
    between any releases. If you are scripting with PyScaffold, please avoid using them.
 
 
-.. _setuptools: http://setuptools.readthedocs.io/en/latest/setuptools.html
-.. _setuptools' documentation: http://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
+.. _setuptools: https://setuptools.readthedocs.io/en/stable/setuptools.html
+.. _setuptools' documentation: https://setuptools.readthedocs.io/en/stable/userguide/declarative_config.html
 .. _namespace packages: https://packaging.python.org/guides/packaging-namespace-packages/
-.. _Sphinx: http://www.sphinx-doc.org/
+.. _Sphinx: https://www.sphinx-doc.org/
 .. _Read the Docs: https://readthedocs.org/
 .. _RTD guides: https://docs.readthedocs.io/en/stable/intro/import-guide.html
 .. _tox: https://tox.readthedocs.org/
-.. _tox documentation: http://tox.readthedocs.org/en/latest/
+.. _tox documentation: https://tox.readthedocs.org/en/stable/
 .. _tox examples: https://tox.readthedocs.io/en/latest/examples.html
 .. _tox tutorial: https://www.seanh.cc/2018/09/01/tox-tutorial/
 .. _semantic versioning: https://semver.org
-.. _Numpy and Google style docstrings: http://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
+.. _Numpy and Google style docstrings: https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
 .. _choosealicense.com: https://choosealicense.com/appendix/
 .. _Django project: https://www.djangoproject.com/
 .. _Cookiecutter: https://cookiecutter.readthedocs.org/
@@ -401,17 +401,17 @@ Check out our :ref:`Configuration <default-cfg>` section to get started.
 .. _using TestPyPI: https://packaging.python.org/guides/using-testpypi/
 .. _importlib.resources: https://docs.python.org/3/library/importlib.html#module-importlib.resources
 .. _importlib_resources: https://importlib-resources.readthedocs.io/
-.. _flake8: http://flake8.readthedocs.org/
+.. _flake8: https://flake8.pycqa.org/en/stable/
 .. _GitLab: https://gitlab.com/
 .. _PEP 420: https://www.python.org/dev/peps/pep-0420/
 .. _PEP 440: https://www.python.org/dev/peps/pep-0440/
 .. _PEP 517: https://www.python.org/dev/peps/pep-0517/
 .. _PEP 518: https://www.python.org/dev/peps/pep-0518/
-.. _pre-commit hooks: http://pre-commit.com/
+.. _pre-commit hooks: https://pre-commit.com/
 .. _setuptools_scm: https://pypi.python.org/pypi/setuptools_scm/
-.. _pytest: http://pytest.org/
+.. _pytest: https://pytest.org/
 .. _Cirrus CI: https://cirrus-ci.org/
-.. _pytest-cov: https://github.com/schlamar/pytest-cov
+.. _pytest-cov: https://github.com/pytest-dev/pytest-cov
 .. _Coveralls: https://coveralls.io/
 .. _pyscaffoldext-dsproject: https://github.com/pyscaffold/pyscaffoldext-dsproject
 .. _pyscaffoldext-custom-extension: https://github.com/pyscaffold/pyscaffoldext-custom-extension
@@ -421,7 +421,7 @@ Check out our :ref:`Configuration <default-cfg>` section to get started.
 .. _pyscaffoldext-cookiecutter: https://github.com/pyscaffold/pyscaffoldext-cookiecutter
 .. _PyScaffold organisation: https://github.com/pyscaffold/
 .. _dependency hell: https://en.wikipedia.org/wiki/Dependency_hell
-.. _pkg_resources: https://setuptools.readthedocs.io/en/latest/pkg_resources.html
+.. _pkg_resources: https://setuptools.readthedocs.io/en/stable/pkg_resources.html
 .. _make: https://en.wikipedia.org/wiki/Make_(software)
 .. _appdirs: https://pypi.org/project/appdirs/
 .. _wheels: https://realpython.com/python-wheels/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,5 +51,5 @@ Indices and tables
 
 
 .. _PyPI: https://pypi.org/
-.. _pip: https://pip.pypa.io/
+.. _pip: https://pip.pypa.io/en/stable/
 .. _v3.3: https://pyscaffold.org/en/v3.3.x/

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -119,4 +119,4 @@ development:
 .. _conda-forge: https://anaconda.org/conda-forge/pyscaffold
 .. _pipx: https://pipxproject.github.io/pipx/
 .. _Django: https://pypi.org/project/Django/
-.. _Cookiecutter: https://cookiecutter.readthedocs.org/
+.. _Cookiecutter: https://cookiecutter.readthedocs.io/en/stable/

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -86,9 +86,9 @@ packages when you use a virtual environment. If that is the case,
 just install following packages inside the environment you are using for
 development:
 
-* `Sphinx <http://sphinx-doc.org/>`_
-* `pytest <http://pytest.org/>`_
-* `pytest-cov <https://pypi.python.org/pypi/pytest-cov>`_
+* `Sphinx <https://www.sphinx-doc.org/en/master/>`_
+* `pytest <https://docs.pytest.org/en/stable/>`_
+* `pytest-cov <https://pypi.org/project/pytest-cov>`_
 
 
 .. note::
@@ -107,16 +107,16 @@ development:
 
 .. _working installation of Git: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
 .. _git setup: https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup
-.. _setuptools: https://pypi.python.org/pypi/setuptools/
+.. _setuptools: https://pypi.org/project/setuptools/
 .. _pip: https://pip.pypa.io/en/stable/
-.. _tox: https://tox.readthedocs.org/
+.. _tox: https://tox.readthedocs.io/en/stable/
 .. _Git: https://git-scm.com/
 .. _isolated development environment: https://realpython.com/python-virtual-environments-a-primer/
 .. also good, but sometimes medium can get on the way: https://towardsdatascience.com/virtual-environments-104c62d48c54
-.. _virtualenv: https://virtualenv.pypa.io
+.. _virtualenv: https://virtualenv.pypa.io/en/stable/
 .. _pip: https://pip.pypa.io/en/stable/
-.. _conda: https://conda.io
+.. _conda: https://docs.conda.io/en/latest/
 .. _conda-forge: https://anaconda.org/conda-forge/pyscaffold
 .. _pipx: https://pipxproject.github.io/pipx/
-.. _Django: https://pypi.python.org/pypi/Django/
+.. _Django: https://pypi.org/project/Django/
 .. _Cookiecutter: https://cookiecutter.readthedocs.org/

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -52,5 +52,5 @@ Let's start:
    to check that Sphinx and PyTest run correctly.
 
 
-.. _documentation of setuptools: https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
+.. _documentation of setuptools: https://setuptools.readthedocs.io/en/stable/userguide/declarative_config.html
 .. _src layout: https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure

--- a/docs/reasons.rst
+++ b/docs/reasons.rst
@@ -111,11 +111,11 @@ Batteries included
 Curious? Checkout out our `demo project`_, or :ref:`install <installation>`
 PyScaffold and type ``putup -h`` to :ref:`get started <quickstart>`.
 
-.. _setuptools: http://setuptools.readthedocs.io/en/latest/setuptools.html
+.. _setuptools: https://setuptools.readthedocs.io/en/latest/setuptools.html
 .. _tox: https://tox.readthedocs.org/
-.. _Sphinx: http://www.sphinx-doc.org/
-.. _pytest: http://pytest.org/
-.. _pre-commit: http://pre-commit.com/
+.. _Sphinx: https://www.sphinx-doc.org/
+.. _pytest: https://pytest.org/
+.. _pre-commit: https://pre-commit.com/
 .. _demo project: https://github.com/pyscaffold/pyscaffold-demo
-.. _pep8: https://www.python.or
-.. _black: https://black.readthedocs.io/
+.. _pep8: https://www.python.org/dev/peps/pep-0008/
+.. _black: https://black.readthedocs.io/en/stable/

--- a/docs/reasons.rst
+++ b/docs/reasons.rst
@@ -111,10 +111,10 @@ Batteries included
 Curious? Checkout out our `demo project`_, or :ref:`install <installation>`
 PyScaffold and type ``putup -h`` to :ref:`get started <quickstart>`.
 
-.. _setuptools: https://setuptools.readthedocs.io/en/latest/setuptools.html
-.. _tox: https://tox.readthedocs.org/
-.. _Sphinx: https://www.sphinx-doc.org/
-.. _pytest: https://pytest.org/
+.. _setuptools: https://setuptools.readthedocs.io/en/stable/
+.. _tox: https://tox.readthedocs.io/en/stable/
+.. _Sphinx: https://www.sphinx-doc.org/en/master/
+.. _pytest: https://docs.pytest.org/en/stable/
 .. _pre-commit: https://pre-commit.com/
 .. _demo project: https://github.com/pyscaffold/pyscaffold-demo
 .. _pep8: https://www.python.org/dev/peps/pep-0008/

--- a/docs/updating.rst
+++ b/docs/updating.rst
@@ -56,7 +56,7 @@ You will need, though, to manually follow a few extra steps to make sure
 everything works:
 
 1) Remove PyScaffold from your build dependencies (``setup_requires`` in ``setup.cfg``)
-   and add `setuptools_scm`_.
+   and add `setuptools-scm`_.
 
    .. note::
       The use of ``setup_requires`` is discouraged. When updating to v4
@@ -128,13 +128,13 @@ If using `Sphinx`_ for the documentation, you can also remove the
 .. _PEP 420: https://www.python.org/dev/peps/pep-0420/
 .. _PEP 517: https://www.python.org/dev/peps/pep-0517/
 .. _PEP 518: https://www.python.org/dev/peps/pep-0518/
-.. _setuptools_scm: https://pypi.python.org/pypi/setuptools_scm/
-.. _tox: https://tox.readthedocs.org/
+.. _setuptools-scm: https://pypi.org/project/setuptools-scm/
+.. _tox: https://tox.readthedocs.io/en/stable/
 .. _make: https://www.gnu.org/software/make/manual/html_node/index.html
-.. _skip_install: https://tox.readthedocs.io/en/latest/config.html#conf-skip_install
+.. _skip_install: https://tox.readthedocs.io/en/stable/config.html#conf-skip_install
 .. _official packaging namespace packages guides: https://packaging.python.org/guides/packaging-namespace-packages/
-.. _pkg_resources: https://setuptools.readthedocs.io/en/latest/pkg_resources.html
-.. _Sphinx: http://www.sphinx-doc.org/
+.. _pkg_resources: https://setuptools.readthedocs.io/en/stable/pkg_resources.html
+.. _Sphinx: https://www.sphinx-doc.org/en/master/
 .. _isortcfg: https://pycqa.github.io/isort/docs/configuration/config_files
 .. _coveragerc: https://coverage.readthedocs.io/en/coverage-5.1/config.html
 .. _issue: https://github.com/pyscaffold/pyscaffold/issues

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -102,10 +102,10 @@ Just a few examples to get you an idea of how easy PyScaffold is to use:
   different text editor by setting the ``EDITOR`` (or ``VISUAL``) environment
   variable in your terminal.
 
-``putup skynet -l GPL-3.0-only -d "Finally, the ultimate AI!" -u http://sky.net``
+``putup skynet -l GPL-3.0-only -d "Finally, the ultimate AI!" -u https://sky.net``
   This will create a project and package named *skynet* licensed under the GPL3.
   The *description* inside ``setup.cfg`` is directly set to "Finally, the ultimate AI!"
-  and the homepage to http://sky.net.
+  and the homepage to ``https://sky.net``.
 
 ``putup Scikit-Gravity -p skgravity -l BSD-3-Clause``
   This will create a project named *Scikit-Gravity* but the package will be
@@ -116,7 +116,7 @@ Just a few examples to get you an idea of how easy PyScaffold is to use:
   the files created by `Django's <https://www.djangoproject.com/>`_
   ``django-admin`` [#ex2]_. The *description* in ``setup.cfg`` will be set and
   a file ``.pre-commit-config.yaml`` is created with a default setup for
-  `pre-commit <http://pre-commit.com/>`_.
+  `pre-commit <https://pre-commit.com/>`_.
 
 ``putup thoroughly_tested --cirrus``
   This will create a project and package *thoroughly_tested* with files ``tox.ini``
@@ -131,7 +131,7 @@ Just a few examples to get you an idea of how easy PyScaffold is to use:
     from zope import subpackage
     # zope is the namespace and subpackage is the package name
 
-  To be honest, there is really only the `Zope project <http://www.zope.org/>`_
+  To be honest, there is really only the `Zope project <https://www.zope.org/>`_
   that comes to my mind which is using this exotic feature of Python's packaging system.
   Chances are high, that you will never ever need a namespace package in your life.
   To learn more about namespaces in the Python ecosystem, check `PEP 420`_.
@@ -240,8 +240,8 @@ option. See ``putup --help`` for more details.
     and extension might change).
 
 
-.. _setuptools: https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html
-.. _pyproject.toml: https://setuptools.readthedocs.io/en/latest/build_meta.html
+.. _setuptools: https://setuptools.readthedocs.io/en/stable/userguide/declarative_config.html
+.. _pyproject.toml: https://setuptools.readthedocs.io/en/stable/build_meta.html
 .. _PEP 621: https://www.python.org/dev/peps/pep-0621/
 .. _SPDX identifiers: https://spdx.org/licenses/
 .. _pyscaffoldext-django: https://pyscaffold.org/projects/django
@@ -250,7 +250,7 @@ option. See ``putup --help`` for more details.
 .. _PEP 420: https://www.python.org/dev/peps/pep-0420/
 .. _video tutorial: https://www.youtube.com/watch?v=JwwlRkLKj7o
 .. _this demo project: https://github.com/pyscaffold/pyscaffold-demo
-.. _editable: https://pip.pypa.io/en/stable/reference/pip_install/#install-editable
+.. _editable: https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs
 .. _isolated development environment: https://realpython.com/python-virtual-environments-a-primer/
 .. also good, but sometimes medium can get on the way: https://towardsdatascience.com/virtual-environments-104c62d48c54
 .. _virtualenv: https://virtualenv.pypa.io

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -244,8 +244,8 @@ option. See ``putup --help`` for more details.
 .. _pyproject.toml: https://setuptools.readthedocs.io/en/stable/build_meta.html
 .. _PEP 621: https://www.python.org/dev/peps/pep-0621/
 .. _SPDX identifiers: https://spdx.org/licenses/
-.. _pyscaffoldext-django: https://pyscaffold.org/projects/django
-.. _pip: https://pip.pypa.io
+.. _pyscaffoldext-django: https://pyscaffold.org/projects/django/en/stable/
+.. _pip: https://pip.pypa.io/en/stable/
 .. _PyPI: https://pypi.org
 .. _PEP 420: https://www.python.org/dev/peps/pep-0420/
 .. _video tutorial: https://www.youtube.com/watch?v=JwwlRkLKj7o
@@ -253,8 +253,8 @@ option. See ``putup --help`` for more details.
 .. _editable: https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs
 .. _isolated development environment: https://realpython.com/python-virtual-environments-a-primer/
 .. also good, but sometimes medium can get on the way: https://towardsdatascience.com/virtual-environments-104c62d48c54
-.. _virtualenv: https://virtualenv.pypa.io
-.. _conda: https://conda.io
+.. _virtualenv: https://virtualenv.pypa.io/en/stable/
+.. _conda: https://docs.conda.io/en/latest/
 .. _REPL: https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop
 .. _virtual environment: https://realpython.com/python-virtual-environments-a-primer/
-.. _tox: https://tox.readthedocs.org/
+.. _tox: https://tox.readthedocs.io/en/stable/

--- a/src/pyscaffold/api.py
+++ b/src/pyscaffold/api.py
@@ -131,7 +131,7 @@ def create_project(opts=None, **kwargs):
     created/updated, but the expected outcome will be logged.
 
     The **extensions** list may contain any object that follows the
-    `extension API <../extensions>`_. Note that some PyScaffold features, such
+    :ref:`extension API <extensions>`. Note that some PyScaffold features, such
     as cirrus, tox and pre-commit support, are implemented as built-in
     extensions. In order to use these features it is necessary to include the
     respective objects in the extension list. All built-in extensions are
@@ -141,7 +141,7 @@ def create_project(opts=None, **kwargs):
     PyScaffold will read it's options from there in addition to the ones already passed.
     If the list is empty, the default configuration file is used. To avoid reading any
     existing configuration, please pass ``config_file=NO_CONFIG``.
-    See https://pyscaffold.org/en/latest/configuration.html for more details.
+    See :doc:`usage </usage>` for more details.
 
     Note that extensions may define extra options. For example, the
     cookiecutter extension define a ``cookiecutter`` option that

--- a/src/pyscaffold/dependencies.py
+++ b/src/pyscaffold/dependencies.py
@@ -30,9 +30,9 @@ REQ_SPLITTER = re.compile(r";(?!\s*(python|platform|implementation|os|sys)_)", r
 """Regex to split requirements that considers both `setup.cfg specs`_ and `PEP 508`_
 (in a *good enough* simplified fashion).
 
-.. _setup.cfg specs: https://setuptools.readthedocs.io/en/latest/setuptools.html#options
+.. _setup.cfg specs: https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html
 .. _PEP 508: https://www.python.org/dev/peps/pep-0508/
-"""
+"""  # noqa
 
 
 def split(requirements: str) -> List[str]:

--- a/src/pyscaffold/extensions/pre_commit.py
+++ b/src/pyscaffold/extensions/pre_commit.py
@@ -1,7 +1,7 @@
 """
 Extension that generates configuration files for Yelp `pre-commit`_.
 
-.. _pre-commit: http://pre-commit.com
+.. _pre-commit: https://pre-commit.com
 """
 from functools import partial
 from typing import List
@@ -56,7 +56,7 @@ changes::
     cd {{name}}
     pre-commit install
 {UPDATE_MSG.replace(':', '::')}
-.. _pre-commit: http://pre-commit.com/
+.. _pre-commit: https://pre-commit.com/
 """
 
 

--- a/src/pyscaffold/identification.py
+++ b/src/pyscaffold/identification.py
@@ -50,7 +50,7 @@ def make_valid_identifier(string: str) -> str:
     raise InvalidIdentifier("String cannot be converted to a valid identifier.")
 
 
-# from http://en.wikibooks.org/, Creative Commons Attribution-ShareAlike 3.0
+# from https://en.wikibooks.org/, Creative Commons Attribution-ShareAlike 3.0
 def levenshtein(s1: str, s2: str) -> int:
     """Calculate the Levenshtein distance between two strings
 

--- a/src/pyscaffold/templates/gitlab_ci.template
+++ b/src/pyscaffold/templates/gitlab_ci.template
@@ -6,7 +6,7 @@
 
 # Pick zero or more services to be used on all builds.
 # Only needed when using a docker container to run your tests in.
-# Check out: http://docs.gitlab.com/ce/ci/docker/using_docker_images.html#what-is-service
+# Check out: https://docs.gitlab.com/ce/ci/docker/using_docker_images.html#what-is-service
 
 # services:
 #   - mysql:latest

--- a/src/pyscaffold/templates/license_affero_3.0.template
+++ b/src/pyscaffold/templates/license_affero_3.0.template
@@ -1,7 +1,7 @@
                     GNU AFFERO GENERAL PUBLIC LICENSE
                        Version 3, 19 November 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/src/pyscaffold/templates/license_cc0_1.0.template
+++ b/src/pyscaffold/templates/license_cc0_1.0.template
@@ -113,4 +113,4 @@ Affirmer's express Statement of Purpose.
   CC0 or use of the Work.
 
 For more information, please see
-<http://creativecommons.org/publicdomain/zero/1.0/>
+<https://creativecommons.org/publicdomain/zero/1.0/>

--- a/src/pyscaffold/templates/license_gpl_2.0.template
+++ b/src/pyscaffold/templates/license_gpl_2.0.template
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 2, June 1991
 
- Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc., <https://fsf.org/>
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.

--- a/src/pyscaffold/templates/license_gpl_3.0.template
+++ b/src/pyscaffold/templates/license_gpl_3.0.template
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/src/pyscaffold/templates/license_lgpl_3.0.template
+++ b/src/pyscaffold/templates/license_lgpl_3.0.template
@@ -1,7 +1,7 @@
                    GNU LESSER GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/src/pyscaffold/templates/license_mozilla.template
+++ b/src/pyscaffold/templates/license_mozilla.template
@@ -346,7 +346,7 @@ Exhibit A - Source Code Form License Notice
       2.0. If a copy of the MPL was not
       distributed with this file, You can
       obtain one at
-      http://mozilla.org/MPL/2.0/.
+      https://mozilla.org/MPL/2.0/.
 
 If it is not possible or desirable to put the notice in a particular file,
 then You may include the notice in a location (such as a LICENSE file in a

--- a/src/pyscaffold/templates/setup_cfg.template
+++ b/src/pyscaffold/templates/setup_cfg.template
@@ -1,6 +1,6 @@
 # This file is used to configure your project.
 # Read more about the various options under:
-# http://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
+# https://setuptools.readthedocs.io/en/stable/userguide/declarative_config.html
 
 [metadata]
 name = ${name}

--- a/src/pyscaffold/templates/setup_cfg.template
+++ b/src/pyscaffold/templates/setup_cfg.template
@@ -25,7 +25,7 @@ project_urls =
 platforms = any
 
 # Add here all kinds of additional classifiers as defined under
-# https://pypi.python.org/pypi?%3Aaction=list_classifiers
+# https://pypi.org/classifiers/
 classifiers =
     Development Status :: 4 - Beta
     Programming Language :: Python

--- a/src/pyscaffold/templates/sphinx_conf.template
+++ b/src/pyscaffold/templates/sphinx_conf.template
@@ -23,7 +23,7 @@ sys.path.insert(0, os.path.join(__location__, "../src"))
 # -- Run sphinx-apidoc -------------------------------------------------------
 # This hack is necessary since RTD does not issue `sphinx-apidoc` before running
 # `sphinx-build -b html . _build/html`. See Issue:
-# https://github.com/rtfd/readthedocs.org/issues/1139
+# https://github.com/readthedocs/readthedocs.org/issues/1139
 # DON'T FORGET: Check the box "Install your project inside a virtualenv using
 # setup.py install" in the RTD Advanced Settings.
 # Additionally it helps us to avoid running apidoc manually

--- a/src/pyscaffold/templates/sphinx_index.template
+++ b/src/pyscaffold/templates/sphinx_index.template
@@ -41,18 +41,18 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
-.. _toctree: http://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html
-.. _reStructuredText: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
-.. _references: http://www.sphinx-doc.org/en/stable/markup/inline.html
-.. _Python domain syntax: http://sphinx-doc.org/domains.html#the-python-domain
-.. _Sphinx: http://www.sphinx-doc.org/
-.. _Python: http://docs.python.org/
-.. _Numpy: http://docs.scipy.org/doc/numpy
-.. _SciPy: http://docs.scipy.org/doc/scipy/reference/
+.. _toctree: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html
+.. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+.. _references: https://www.sphinx-doc.org/en/stable/markup/inline.html
+.. _Python domain syntax: https://sphinx-doc.org/domains.html#the-python-domain
+.. _Sphinx: https://www.sphinx-doc.org/
+.. _Python: https://docs.python.org/
+.. _Numpy: https://docs.scipy.org/doc/numpy
+.. _SciPy: https://docs.scipy.org/doc/scipy/reference/
 .. _matplotlib: https://matplotlib.org/contents.html#
-.. _Pandas: http://pandas.pydata.org/pandas-docs/stable
-.. _Scikit-Learn: http://scikit-learn.org/stable
-.. _autodoc: http://www.sphinx-doc.org/en/stable/ext/autodoc.html
+.. _Pandas: https://pandas.pydata.org/pandas-docs/stable
+.. _Scikit-Learn: https://scikit-learn.org/stable
+.. _autodoc: https://www.sphinx-doc.org/en/stable/ext/autodoc.html
 .. _Google style: https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
 .. _NumPy style: https://numpydoc.readthedocs.io/en/latest/format.html
-.. _classical style: http://www.sphinx-doc.org/en/stable/domains.html#info-field-lists
+.. _classical style: https://www.sphinx-doc.org/en/stable/domains.html#info-field-lists

--- a/src/pyscaffold/templates/sphinx_makefile.template
+++ b/src/pyscaffold/templates/sphinx_makefile.template
@@ -11,7 +11,7 @@ AUTODOCDIR    = api
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $?), 1)
-$(error "The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/")
+$(error "The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from https://sphinx-doc.org/")
 endif
 
 .PHONY: help clean Makefile

--- a/src/pyscaffold/templates/tox_ini.template
+++ b/src/pyscaffold/templates/tox_ini.template
@@ -8,7 +8,7 @@ envlist = default
 
 
 [testenv]
-description = invoke pytest to run automated tests
+description = Invoke pytest to run automated tests
 isolated_build = ${isolated_build}
 setenv =
     TOXINIDIR = {toxinidir}
@@ -20,13 +20,13 @@ commands =
     pytest {posargs}
 
 
-[testenv:{clean,build}]
+[testenv:{build,clean}]
 description =
-    Build (or clean) the package in isolation according to instructions in:
-    https://setuptools.readthedocs.io/en/latest/build_meta.html#how-to-use-it
-    https://github.com/pypa/pep517/issues/91
-    https://github.com/pypa/build
+    build: Build the package in isolation according to PEP517, see https://github.com/pypa/build
+    clean: Remove old distribution files and temporary build artifacts (./build and ./dist)
 # NOTE: build is still experimental, please refer to the links for updates/issues
+# https://setuptools.readthedocs.io/en/latest/build_meta.html#how-to-use-it
+# https://github.com/pypa/pep517/issues/91
 skip_install = True
 changedir = {toxinidir}
 deps =
@@ -37,13 +37,18 @@ commands =
 # By default `build` produces wheels, you can also explicitly use the flags `--sdist` and `--wheel`
 
 
-[testenv:{docs,doctests}]
-description = invoke sphinx-build to build the docs/run doctests
+[testenv:{docs,doctests,linkcheck}]
+description =
+    docs: Invoke sphinx-build to build the docs
+    doctests: Invoke sphinx-build to run doctests
+    linkcheck: Check for broken links in the documentation
+usedevelop = True
 setenv =
     DOCSDIR = {toxinidir}/docs
     BUILDDIR = {toxinidir}/docs/_build
     docs: BUILD = html
     doctests: BUILD = doctest
+    linkcheck: BUILD = linkcheck
 deps =
     -r {toxinidir}/docs/requirements.txt
     # ^  requirements.txt shared with Read The Docs

--- a/src/pyscaffold/templates/tox_ini.template
+++ b/src/pyscaffold/templates/tox_ini.template
@@ -53,7 +53,7 @@ deps =
     -r {toxinidir}/docs/requirements.txt
     # ^  requirements.txt shared with Read The Docs
 commands =
-    sphinx-build -b {env:BUILD} -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/{env:BUILD}" {posargs}
+    sphinx-build --color -b {env:BUILD} -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/{env:BUILD}" {posargs}
 
 
 [testenv:publish]

--- a/src/pyscaffold/templates/tox_ini.template
+++ b/src/pyscaffold/templates/tox_ini.template
@@ -1,5 +1,5 @@
 # Tox configuration file
-# Read more under https://tox.readthedocs.org/
+# Read more under https://tox.readthedocs.io/
 # THIS SCRIPT IS SUPPOSED TO BE AN EXAMPLE. MODIFY IT ACCORDING TO YOUR NEEDS!
 
 [tox]
@@ -25,7 +25,7 @@ description =
     build: Build the package in isolation according to PEP517, see https://github.com/pypa/build
     clean: Remove old distribution files and temporary build artifacts (./build and ./dist)
 # NOTE: build is still experimental, please refer to the links for updates/issues
-# https://setuptools.readthedocs.io/en/latest/build_meta.html#how-to-use-it
+# https://setuptools.readthedocs.io/en/stable/build_meta.html#how-to-use-it
 # https://github.com/pypa/pep517/issues/91
 skip_install = True
 changedir = {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ deps =
     -r {toxinidir}/docs/requirements.txt
     # ^  requirements.txt shared with Read The Docs
 commands =
-    sphinx-build -b {env:BUILD} -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/{env:BUILD}" {posargs}
+    sphinx-build --color -b {env:BUILD} -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/{env:BUILD}" {posargs}
 
 
 [testenv:publish]

--- a/tox.ini
+++ b/tox.ini
@@ -42,13 +42,13 @@ commands =
     pytest -x -n auto -m "not slow and not system" {posargs}
 
 
-[testenv:{clean,build}]
+[testenv:{build,clean}]
 description =
-    Build (or clean) the package in isolation according to instructions in:
-    https://setuptools.readthedocs.io/en/latest/build_meta.html#how-to-use-it
-    https://github.com/pypa/pep517/issues/91
-    https://github.com/pypa/build
+    build: Build the package in isolation according to PEP517, see https://github.com/pypa/build
+    clean: Remove old distribution files and temporary build artifacts (./build and ./dist)
 # NOTE: build is still experimental, please refer to the links for updates/issues
+# https://setuptools.readthedocs.io/en/latest/build_meta.html#how-to-use-it
+# https://github.com/pypa/pep517/issues/91
 skip_install = True
 changedir = {toxinidir}
 deps =
@@ -59,14 +59,18 @@ commands =
 # By default `build` produces wheels, you can also explicitly use the flags `--sdist` and `--wheel`
 
 
-[testenv:{docs,doctests}]
-description = invoke sphinx-build to build the docs/run doctests
+[testenv:{docs,doctests,linkcheck}]
+description =
+    docs: Invoke sphinx-build to build the docs
+    doctests: Invoke sphinx-build to run doctests
+    linkcheck: Check for broken links in the documentation
 usedevelop = True
 setenv =
     DOCSDIR = {toxinidir}/docs
     BUILDDIR = {toxinidir}/docs/_build
     docs: BUILD = html
     doctests: BUILD = doctest
+    linkcheck: BUILD = linkcheck
 deps =
     -r {toxinidir}/docs/requirements.txt
     # ^  requirements.txt shared with Read The Docs


### PR DESCRIPTION
There are still a few warnings for `tox -e linkcheck`:
```bash
/home/abravalheri/projects/pyscaffold/docs/dependencies.rst.rst:306:
WARNING: broken link: https://anaconda.org
(403 Client Error: Forbidden for url: https://anaconda.org/)

/home/abravalheri/projects/pyscaffold/docs/faq.rst.rst:69:
WARNING: broken link: https://crates.io
(404 Client Error: Not Found for url: https://crates.io/)

/home/abravalheri/projects/pyscaffold/docs/contributing.rst.rst:5:
WARNING: broken link: https://www.blue-yonder.com
(HTTPSConnectionPool(host='www.blue-yonder.com', port=443): Max retries
exceeded with url: / (Caused by
SSLError(SSLCertVerificationError("hostname 'www.blue-yonder.com'
doesn't match either of '*.jda.com', 'jda.com'"))))
```