### PR TITLE
Note that templates and the generated boilerplate code is 0BSD-licensed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,8 +11,7 @@ Version 4.X.X, 2021-XX-XX
 
 - Added *linkcheck* task to ``tox.ini``, :pr:`456`
 - Updated configuration for Sphinx and ReadTheDocs, :pr:`455`
-
-    - Note that templates and the generated boilerplate code is 0BSD-licensed, :pr:`461`
+- Note that templates and the generated boilerplate code is 0BSD-licensed, :pr:`461`
 
 
 Current versions

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Version 4.X.X, 2021-XX-XX
 - Added *linkcheck* task to ``tox.ini``, :pr:`456`
 - Updated configuration for Sphinx and ReadTheDocs, :pr:`455`
 
+    - Note that templates and the generated boilerplate code is 0BSD-licensed, :pr:`461`
+
 
 Current versions
 ================

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,10 @@
+PyScaffold is licensed under the MIT license; see below for details.
+
+The template files under `pyscaffold.templates`, used for the the generated
+projects, are licensed under BSD 0-Clause license; see below for details.
+
+----------------------------------------------------------------------
+
 The MIT License (MIT)
 
 Copyright (c) 2014 Blue Yonder GmbH
@@ -19,3 +26,20 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+----------------------------------------------------------------------
+
+BSD 0-Clause License
+
+Copyright (c) 2014 Blue Yonder GmbH
+
+Permission to use, copy, modify, and/or distribute this software for
+any purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+OF THIS SOFTWARE.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -161,7 +161,7 @@ How can I use PyScaffold if my project is nested within a larger repository, e.g
 
 
 What is the license of the generated project scaffold? Is there anything I need to consider?
-    The source code of PyScaffold itself is MIT-licensed with the exception of the subpackage ``pyscaffold.templates``,
+    The source code of PyScaffold itself is MIT-licensed with the exception of the `*.template` files under the ``pyscaffold.templates`` subpackage,
     which is licensed under the BSD 0-Clause license (0BSD). Thus, also the generated boilerplate code for your project
     is 0BSD-licensed and consequently you have no obligations at all and can do whatever you want except of suing us ;-)
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -160,6 +160,12 @@ How can I use PyScaffold if my project is nested within a larger repository, e.g
     In future versions of PyScaffold this will be much simpler as ``pyproject.toml`` will completely replace ``setup.py``.
 
 
+What is the license of the generated project scaffold? Is there anything I need to consider?
+    The source code of PyScaffold itself is MIT-licensed with the exception of the subpackage ``pyscaffold.templates``,
+    which is licensed under the BSD 0-Clause license (0BSD). Thus, also the generated boilerplate code for your project
+    is 0BSD-licensed and consequently you have no obligations at all and can do whatever you want except of suing us ;-)
+
+
 File Organisation and Directory Structure
 -----------------------------------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -162,7 +162,7 @@ How can I use PyScaffold if my project is nested within a larger repository, e.g
 
 What is the license of the generated project scaffold? Is there anything I need to consider?
     The source code of PyScaffold itself is MIT-licensed with the exception of the `*.template` files under the ``pyscaffold.templates`` subpackage,
-    which is licensed under the BSD 0-Clause license (0BSD). Thus, also the generated boilerplate code for your project
+    which are licensed under the BSD 0-Clause license (0BSD). Thus, also the generated boilerplate code for your project
     is 0BSD-licensed and consequently you have no obligations at all and can do whatever you want except of suing us ;-)
 
 

--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -1,5 +1,7 @@
 """
 Templates for all files of a project's scaffold
+
+All template files within this subpackage are licensed under the BSD 0-Clause license.
 """
 
 import os

--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -1,7 +1,8 @@
 """
 Templates for all files of a project's scaffold
 
-All template files (`*.template`) within this subpackage are licensed under the BSD 0-Clause license.
+All template files (`*.template`) within this subpackage are licensed
+under the BSD 0-Clause license.
 """
 
 import os

--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -1,7 +1,7 @@
 """
 Templates for all files of a project's scaffold
 
-All template files within this subpackage are licensed under the BSD 0-Clause license.
+All template files (`*.template`) within this subpackage are licensed under the BSD 0-Clause license.
 """
 
 import os


### PR DESCRIPTION
## Purpose

This addresses the points as discussed under conversation #459.


