### PR TITLE
Update copyright notice

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -7,7 +7,8 @@ projects, are licensed under BSD 0-Clause license; see below for details.
 
 The MIT License (MIT)
 
-Copyright (c) 2014 Blue Yonder GmbH
+Copyright (c) 2018-present, PyScaffold contributors
+Copyright (c) 2014-2018 Blue Yonder GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +32,8 @@ SOFTWARE.
 
 BSD 0-Clause License
 
-Copyright (c) 2014 Blue Yonder GmbH
+Copyright (c) 2018-present, PyScaffold contributors
+Copyright (c) 2014-2018 Blue Yonder GmbH
 
 Permission to use, copy, modify, and/or distribute this software for
 any purpose with or without fee is hereby granted.


### PR DESCRIPTION
Hi @FlorianWilhelm, what do you think about this change? This is just a suggestion that we can simply drop (I am not a lawyer, just replicating patterns 😝 I see around)... 

Since we are updating PyScaffold's license, I thought about updating the copyright notice also to reflect the current situation of the project.

The main inspiration comes from projects like:

- https://github.com/ponylang/ponyc/blob/main/LICENSE
- https://github.com/Homebrew/brew/blob/master/LICENSE.txt

Alternatively we could do like NetBeans does and describe the transferring more in details:

- https://github.com/apache/netbeans/blob/master/NOTICE