### PR TITLE
replace py.test with pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -116,7 +116,7 @@ pyscaffold.cli =
 # e.g. --cov-report html (or xml) for html/xml output or --junit-xml junit.xml
 # in order to write a coverage file that can be read by Jenkins.
 # CAUTION: --cov flags may prohibit setting breakpoints while debugging.
-#          Comment those flags to avoid this py.test issue.
+#          Comment those flags to avoid this pytest issue.
 addopts =
     --cov pyscaffold --cov-config .coveragerc --cov-report term-missing
     --verbose

--- a/src/pyscaffold/templates/setup_cfg.template
+++ b/src/pyscaffold/templates/setup_cfg.template
@@ -80,7 +80,7 @@ testing =
 # e.g. --cov-report html (or xml) for html/xml output or --junitxml junit.xml
 # in order to write a coverage file that can be read by Jenkins.
 # CAUTION: --cov flags may prohibit setting breakpoints while debugging.
-#          Comment those flags to avoid this py.test issue.
+#          Comment those flags to avoid this pytest issue.
 addopts =
     --cov ${qual_pkg} --cov-report term-missing
     --verbose

--- a/tox.ini
+++ b/tox.ini
@@ -27,9 +27,9 @@ extras =
     # all
     testing
 commands =
-    default: py.test -k "not system" {posargs}
-    system: py.test -k system {posargs}
-    all: py.test -vv {posargs}
+    default: pytest -k "not system" {posargs}
+    system: pytest -k system {posargs}
+    all: pytest -vv {posargs}
 
 
 [testenv:fast]


### PR DESCRIPTION
## Purpose

`py.test` is outdated and should be replaced with pytest


> pytest used to be part of the py package, which provided several developer utilities, all starting with py., thus providing nice TAB-completion. If you install pip install pycmd you get these tools from a separate package. Once pytest became a separate package, the py.test name was retained due to avoid a naming conflict with another tool. This conflict was eventually resolved, and the pytest command was therefore introduced. In future versions of pytest, we may deprecate and later remove the py.test command to avoid perpetuating the confusion.


## Approach


#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

## Resources & Links

Related posts:

    https://stackoverflow.com/questions/39495429/py-test-vs-pytest-command
    https://meta.stackoverflow.com/questions/366905/rename-py-test-to-pytest?noredirect=1&lq=1
