### PR TITLE
Split extensions.rst into re-usable files and add pipeline image (1st step #376)

### DIFF
--- a/docs/action-pipeline.rst
+++ b/docs/action-pipeline.rst
@@ -1,0 +1,59 @@
+Action Pipeline
+===============
+
+PyScaffold organizes the generation of a project into a series of steps with
+well defined purposes. As shown in the figure bellow,
+each step is called **action** and is implemented as a
+simple function that receives two arguments: a project structure and a :obj:`dict`
+with options (some of them parsed from command line arguments, other from
+default values).
+
+.. image:: gfx/action-pipeline-paths.svg
+   :alt: PyScaffold's action pipeline
+   :align: center
+
+An action **MUST** return a tuple also composed by a project structure and a
+:obj:`dict` with options. The return values, thus, are usually modified versions
+of the input arguments. Additionally an action can also have side effects, like
+creating directories or adding files to version control. The following
+pseudo-code illustrates a basic action:
+
+.. code-block:: python
+
+    def action(project_structure, options):
+        new_struct, new_opts = modify(project_structure, options)
+        some_side_effect()
+        return new_struct, new_opts
+
+The output of each action is used as the input of the subsequent action,
+forming a pipeline. Initially the structure argument is just an empty :obj:`dict`.
+Each action is uniquely identified by a string in the format
+``<module name>:<function name>``, similarly to the convention used for a
+`setuptools entry point`_.
+For example, if an action is defined in the ``action`` function of the
+``extras.py`` file that is part of the ``pyscaffoldext.contrib`` project,
+the **action identifier** is ``pyscaffoldext.contrib.extras:action``.
+
+By default, the sequence of actions taken by PyScaffold is:
+
+#. :obj:`pyscaffold.actions:get_default_options <pyscaffold.actions.get_default_options>`
+#. :obj:`pyscaffold.actions:verify_options_consistency <pyscaffold.actions.verify_options_consistency>`
+#. :obj:`pyscaffold.structure:define_structure <pyscaffold.structure.define_structure>`
+#. :obj:`pyscaffold.actions:verify_project_dir <pyscaffold.actions.verify_project_dir>`
+#. :obj:`pyscaffold.update:version_migration <pyscaffold.update.version_migration>`
+#. :obj:`pyscaffold.structure:create_structure <pyscaffold.structure.create_structure>`
+#. :obj:`pyscaffold.actions:init_git <pyscaffold.actions.init_git>`
+#. :obj:`pyscaffold.actions:report_done <pyscaffold.actions.report_done>`
+
+(as given by :obj:`pyscaffold.actions.DEFAULT`)
+
+The project structure is usually empty until :obj:`~pyscaffold.structure.define_structure`
+This action just loads the in-memory :obj:`dict` representation, that is only written
+to disk by the :obj:`~pyscaffold.structure.create_structure` action.
+
+Note that, this sequence varies according to the command line options.
+To retrieve an updated list, please use ``putup --list-actions`` or
+``putup --dry-run``.
+
+
+.. _setuptools entry point: https://setuptools.readthedocs.io/en/stable/userguide/entry_point.html

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -7,17 +7,15 @@ Extending PyScaffold
 PyScaffold is carefully designed to cover the essentials of authoring and
 distributing Python packages. Most of time, tweaking ``putup`` options is
 enough to ensure proper configuration of a project.
-However, for advanced use cases a deeper level of programmability may be
-required and PyScaffold's extension systems provides this.
+However, for advanced use cases PyScaffold can be extended at runtime by other
+Python packages, providing a deeper level of programmability and customization.
 
-PyScaffold can be extended at runtime by other Python packages.
-Therefore it is possible to change the behaviour of the ``putup`` command line
-tool without changing the PyScaffold code itself. In order to explain how this
-mechanism works, the following sections define a few important concepts and
-present a comprehensive guide about how to create custom extensions.
-
-Additionally, `Cookiecutter templates`_ can also be used but writing a native
-PyScaffold extension is the preferred way.
+From the standpoint of PyScaffold, an extension is just an class inheriting
+from :obj:`~pyscaffold.extensions.Extension` overriding and implementing
+certain methods that allow the manipulation of a *in-memory* **project structure
+representation** via PyScaffold's internal **action pipeline** mechanism.
+The following sections describe these two key concepts in detail and present a
+comprehensive guide about how to create custom extensions.
 
 .. tip::
 
@@ -26,153 +24,9 @@ PyScaffold extension is the preferred way.
     and then create your own extension template with
     ``putup --custom-extension pyscaffoldext-my-own-extension``.
 
-.. _coreconcepts:
 
-Project Structure Representation
-================================
-
-Each Python package project is internally represented by PyScaffold as a tree
-data structure, that directly relates to a directory entry in the file system.
-This tree is implemented as a simple (and possibly nested) :obj:`dict` in which
-keys indicate the path where files will be generated, while values indicate
-their content. For instance, the following dict::
-
-    {
-        "folder": {
-            "file.txt": "Hello World!",
-            "another-folder": {
-                "empty-file.txt": ""
-            }
-        }
-    }
-
-represents a project directory in the file system that contains a single
-directory named ``folder``. In turn, ``folder`` contains two entries.
-The first entry is a file named ``file.txt`` with content ``Hello World!``
-while the second entry is a sub-directory named ``another-folder``. Finally,
-``another-folder`` contains an empty file named ``empty-file.txt``.
-
-.. versionchanged:: 4.0
-    Prior to version 4.0, the project structure included the top level
-    directory of the project. Now it considers everything **under** the
-    project folder.
-
-Additionally, tuple values are also allowed in order to specify a
-**file operation** (or simply **file op**) that will be used to produce the file.
-In this case, the first element of the tuple is the file content, while the
-second element will be a function (or more generally a :obj:`callable` object)
-responsible for writing that content to the disk. For example, the dict::
-
-    from pyscaffold.operations import create
-
-    {
-        "src": {
-            "namespace": {
-                "module.py": ('print("Hello World!")', create)
-            }
-        }
-    }
-
-represents a ``src/namespace/module.py`` file, under the project directory,
-with content ``print("Hello World!")``, that will written to the disk.
-When no operation is specified (i.e. when using a simple string instead of a
-tuple), PyScaffold will assume :obj:`~pyscaffold.operations.create` by default.
-
-.. note::
-
-    The :obj:`~pyscaffold.operations.create` function simply creates a text file
-    to the disk using UTF-8 encoding and the default file permissions. This
-    behaviour can be modified by wrapping :obj:`~pyscaffold.operations.create`
-    within other fuctions/callables, for example::
-
-        from pyscaffold.operations import create, no_overwrite
-
-        {"file": ("content", no_overwrite(create))}
-
-    will prevent the ``file`` to be written if it already exists. See
-    :mod:`pyscaffold.operations` for more information on how to write your own
-    file operation and other options.
-
-Finally, while it is simple to represent file contents as a string directly,
-most of the times we want to *customize* them according to the project
-parameters being created (e.g. package or author's name). So PyScaffold also
-accepts :obj:`string.Template` objects and functions (with a single :obj:`dict`
-argument and a :obj:`str` return value) to be used as contents. These templates
-and functions will be called with :obj:`PyScaffold's options
-<pyscaffold.operations.ScaffoldOpts>` when its time to create the file to the
-disk.
-
-.. note::
-
-    :obj:`string.Template` objects will have :obj:`~string.Template.safe_substitute`
-    called (not simply :obj:`~string.Template.substitute`).
-
-This tree representation is often referred in this document as **project
-structure** or simply **structure**.
-
-
-
-Scaffold Actions
-================
-
-PyScaffold organizes the generation of a project into a series of steps with
-well defined purposes. Each step is called **action** and is implemented as a
-simple function that receives two arguments: a project structure and a dict
-with options (some of them parsed from command line arguments, other from
-default values).
-
-An action **MUST** return a tuple also composed by a project structure and a
-dict with options. The return values, thus, are usually modified versions
-of the input arguments. Additionally an action can also have side effects, like
-creating directories or adding files to version control. The following
-pseudo-code illustrates a basic action:
-
-.. code-block:: python
-
-    def action(project_structure, options):
-        new_struct, new_opts = modify(project_structure, options)
-        some_side_effect()
-        return new_struct, new_opts
-
-The output of each action is used as the input of the subsequent action,
-forming a pipeline. Initially the structure argument is just an empty dict.
-Each action is uniquely identified by a string in the format
-``<module name>:<function name>``, similarly to the convention used for a
-`setuptools entry point`_.
-For example, if an action is defined in the ``action`` function of the
-``extras.py`` file that is part of the ``pyscaffoldext.contrib`` project,
-the **action identifier** is ``pyscaffoldext.contrib.extras:action``.
-
-By default, the sequence of actions taken by PyScaffold is:
-
-#. :obj:`pyscaffold.actions:get_default_options <pyscaffold.actions.get_default_options>`
-#. :obj:`pyscaffold.actions:verify_options_consistency <pyscaffold.actions.verify_options_consistency>`
-#. :obj:`pyscaffold.structure:define_structure <pyscaffold.structure.define_structure>`
-#. :obj:`pyscaffold.actions:verify_project_dir <pyscaffold.actions.verify_project_dir>`
-#. :obj:`pyscaffold.update:version_migration <pyscaffold.update.version_migration>`
-#. :obj:`pyscaffold.structure:create_structure <pyscaffold.structure.create_structure>`
-#. :obj:`pyscaffold.actions:init_git <pyscaffold.actions.init_git>`
-#. :obj:`pyscaffold.actions:report_done <pyscaffold.actions.report_done>`
-
-(as given by :obj:`pyscaffold.actions.DEFAULT`)
-
-The project structure is usually empty until :obj:`~pyscaffold.structure.define_structure`
-This action just loads the in-memory dict representation, that is only written
-to disk by the :obj:`~pyscaffold.structure.create_structure` action.
-
-Note that, this sequence varies according to the command line options.
-To retrieve an updated list, please use ``putup --list-actions`` or
-``putup --dry-run``.
-
-
-What are Extensions?
-====================
-
-From the standpoint of PyScaffold, an extension is just an class inheriting
-from :obj:`~pyscaffold.extensions.Extension` overriding and
-implementing certain methods. These methods allow injecting actions at arbitrary
-positions in the aforementioned list. Furthermore, extensions can also remove
-actions.
+.. include:: project-structure.rst
+.. include:: action-pipeline.rst
 
 Creating an Extension
 =====================

--- a/docs/gfx/action-pipeline-paths.svg
+++ b/docs/gfx/action-pipeline-paths.svg
@@ -1,0 +1,1284 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 200 111.67605"
+   height="422.08273"
+   width="755.90552">
+  <defs
+     id="defs2">
+    <marker
+       style="overflow:visible"
+       id="marker2294"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#3b82f6;fill-opacity:1;fill-rule:evenodd;stroke:#3b82f6;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path2292" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker2134"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#3b82f6;fill-opacity:1;fill-rule:evenodd;stroke:#3b82f6;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path2132" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker1974"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#3b82f6;fill-opacity:1;fill-rule:evenodd;stroke:#3b82f6;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1972" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1718"
+       style="overflow:visible">
+      <path
+         id="path1716"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#10b981;fill-opacity:1;fill-rule:evenodd;stroke:#10b981;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1570"
+       style="overflow:visible">
+      <path
+         id="path1568"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#10b981;fill-opacity:1;fill-rule:evenodd;stroke:#10b981;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1434"
+       style="overflow:visible">
+      <path
+         id="path1432"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#10b981;fill-opacity:1;fill-rule:evenodd;stroke:#10b981;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleInM"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#be185d;fill-opacity:1;fill-rule:evenodd;stroke:#be185d;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1158" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1052" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker11851"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path11849" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker11255"
+       style="overflow:visible">
+      <path
+         id="path11253"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#be185d;fill-opacity:1;fill-rule:evenodd;stroke:#be185d;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker11008"
+       style="overflow:visible">
+      <path
+         id="path11006"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#3b82f6;fill-opacity:1;fill-rule:evenodd;stroke:#3b82f6;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker10474"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#10b981;fill-opacity:1;fill-rule:evenodd;stroke:#10b981;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path10472" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker10150"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#3b82f6;fill-opacity:1;fill-rule:evenodd;stroke:#3b82f6;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path10148" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker9280"
+       style="overflow:visible">
+      <path
+         id="path9278"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#10b981;fill-opacity:1;fill-rule:evenodd;stroke:#10b981;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker9026"
+       style="overflow:visible">
+      <path
+         id="path9024"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker8881"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path8879" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker8419"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path8417" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker8275"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path8273" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7249"
+       style="overflow:visible">
+      <path
+         id="path7247"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#3b82f6;fill-opacity:1;fill-rule:evenodd;stroke:#3b82f6;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker6805"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#10b981;fill-opacity:1;fill-rule:evenodd;stroke:#10b981;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path6803" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3232"
+       style="overflow:visible">
+      <path
+         id="path3230"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Send"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1037" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1031" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2125"
+       style="overflow:visible">
+      <path
+         id="path2123"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.2)" />
+    </marker>
+  </defs>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-210.45579,-351.48375)"
+     id="layer1">
+    <g
+       transform="translate(-33.680162,59.124827)"
+       id="g6777" />
+    <path
+       id="rect6761"
+       d="m 255.38903,385.28952 h 87.19046 c 1.14739,0 2.0711,0.92371 2.0711,2.0711 v 46.59816 c 0,1.14739 -0.92371,2.0711 -2.0711,2.0711 h -87.19046 c -1.14739,0 -2.0711,-0.92371 -2.0711,-2.0711 v -46.59816 c 0,-1.14739 0.92371,-2.0711 2.0711,-2.0711 z"
+       style="fill:#fffbeb;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" />
+    <g
+       id="text6765"
+       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:5.01202059px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       aria-label="Action">
+      <path
+         id="path1339"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 257.48875,390.21823 -0.22104,-0.81477 h -1.16947 l -0.22104,0.81477 h -0.72739 l 1.11293,-3.55468 h 0.86361 l 1.11035,3.55468 z m -0.80706,-3.02777 -0.45751,1.68609 h 0.91245 z" />
+      <path
+         id="path1341"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 260.01714,389.75044 q 0.16964,0 0.32386,-0.0617 0.15678,-0.0617 0.31871,-0.17478 l 0.30843,0.43437 q -0.18506,0.15936 -0.44208,0.25446 -0.25703,0.0925 -0.53719,0.0925 -0.42152,0 -0.72996,-0.17735 -0.30586,-0.17735 -0.47035,-0.49863 -0.16193,-0.32128 -0.16193,-0.74538 0,-0.42152 0.1645,-0.75052 0.16706,-0.33156 0.47807,-0.51662 0.311,-0.18763 0.72995,-0.18763 0.29044,0 0.52691,0.0822 0.23903,0.0822 0.43951,0.24931 l -0.30072,0.41639 q -0.31614,-0.2159 -0.64514,-0.2159 -0.31614,0 -0.49863,0.22618 -0.17992,0.22618 -0.17992,0.69654 0,0.46008 0.17992,0.66827 0.18249,0.20819 0.49606,0.20819 z" />
+      <path
+         id="path1343"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 264.07998,390.06659 q -0.15935,0.10538 -0.37783,0.16706 -0.2159,0.0617 -0.4575,0.0617 -0.32643,0 -0.55261,-0.11566 -0.22362,-0.11566 -0.33671,-0.32643 -0.11309,-0.21333 -0.11309,-0.50377 v -1.37252 h -0.59116 v -0.48064 h 0.59116 v -0.59887 l 0.67855,-0.0822 v 0.68112 h 0.8996 l -0.0694,0.48064 h -0.8302 v 1.36995 q 0,0.21333 0.10281,0.311 0.10281,0.0951 0.33157,0.0951 0.26216,0 0.49092,-0.12337 z" />
+      <path
+         id="path1345"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 265.9401,386.1238 q 0.12338,0 0.21848,0.054 0.0951,0.0514 0.14907,0.14394 0.054,0.0925 0.054,0.20562 0,0.11309 -0.054,0.20562 -0.054,0.0925 -0.14907,0.1465 -0.0951,0.054 -0.21848,0.054 -0.12337,0 -0.22104,-0.054 -0.0951,-0.054 -0.14908,-0.1465 -0.054,-0.0925 -0.054,-0.20562 0,-0.11309 0.054,-0.20562 0.054,-0.0925 0.14908,-0.14394 0.0977,-0.054 0.22104,-0.054 z m -1.01011,1.37252 h 1.44963 v 2.24127 h 0.7171 v 0.48064 h -2.19244 v -0.48064 h 0.79679 v -1.76063 h -0.77108 z" />
+      <path
+         id="path1347"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 269.02881,387.41921 q 0.40096,0 0.68626,0.17735 0.2853,0.17478 0.43181,0.49863 0.14907,0.32128 0.14907,0.75566 0,0.44209 -0.14907,0.76851 -0.14908,0.32385 -0.43695,0.5012 -0.2853,0.17478 -0.68369,0.17478 -0.40096,0 -0.68626,-0.17221 -0.2853,-0.17221 -0.43438,-0.49606 -0.14907,-0.32385 -0.14907,-0.77108 0,-0.42666 0.14907,-0.75052 0.15165,-0.32642 0.43695,-0.50634 0.28787,-0.17992 0.68626,-0.17992 z m 0,0.51148 q -0.28787,0 -0.42666,0.22619 -0.1388,0.22361 -0.1388,0.69911 0,0.48064 0.1388,0.70425 0.13879,0.22362 0.42409,0.22362 0.2853,0 0.42409,-0.22362 0.1388,-0.22618 0.1388,-0.70939 0,-0.47036 -0.1388,-0.69397 -0.13879,-0.22619 -0.42152,-0.22619 z" />
+      <path
+         id="path1349"
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 270.98146,390.21823 v -2.72191 h 0.59116 l 0.0488,0.3367 q 0.17478,-0.20562 0.39325,-0.30843 0.21847,-0.10538 0.47036,-0.10538 0.36497,0 0.55774,0.21076 0.19535,0.21076 0.19535,0.5963 v 1.99196 h -0.67856 v -1.72722 q 0,-0.2159 -0.0283,-0.33413 -0.0257,-0.12081 -0.0977,-0.17478 -0.0694,-0.0566 -0.20562,-0.0566 -0.29815,0 -0.56803,0.36241 v 1.93027 z" />
+    </g>
+    <path
+       id="rect6725"
+       d="m 255.38902,366.00128 h 87.19045 c 1.14739,0 2.0711,0.92371 2.0711,2.0711 v 7.16891 c 0,1.1474 -0.92371,2.07111 -2.0711,2.07111 h -87.19045 c -1.14739,0 -2.0711,-0.92371 -2.0711,-2.07111 v -7.16891 c 0,-1.14739 0.92371,-2.0711 2.0711,-2.0711 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" />
+    <g
+       id="text8747"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       transform="rotate(90)"
+       aria-label="...">
+      <path
+         id="path1353"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26850107"
+         d="m 371.81628,-298.98935 q 0,-0.11309 0.054,-0.20819 0.054,-0.0951 0.14908,-0.14908 0.0925,-0.054 0.20819,-0.054 0.1208,0 0.21847,0.054 0.0951,0.054 0.14908,0.14908 0.054,0.0925 0.054,0.20819 0,0.11823 -0.054,0.2159 -0.054,0.0951 -0.14908,0.15165 -0.0977,0.054 -0.21847,0.054 -0.11566,0 -0.20819,-0.054 -0.0951,-0.0566 -0.14908,-0.15165 -0.054,-0.0977 -0.054,-0.2159 z m 2.05621,0 q 0,-0.11309 0.054,-0.20819 0.054,-0.0951 0.1465,-0.14908 0.0951,-0.054 0.21077,-0.054 0.1208,0 0.2159,0.054 0.0977,0.054 0.15164,0.14908 0.054,0.0925 0.054,0.20819 0,0.11823 -0.054,0.2159 -0.054,0.0951 -0.15164,0.15165 -0.0951,0.054 -0.2159,0.054 -0.11567,0 -0.21077,-0.054 -0.0925,-0.0566 -0.1465,-0.15165 -0.054,-0.0977 -0.054,-0.2159 z m -4.11242,0 q 0,-0.11309 0.054,-0.20819 0.054,-0.0951 0.14908,-0.14908 0.0925,-0.054 0.20819,-0.054 0.1208,0 0.21847,0.054 0.0951,0.054 0.14908,0.14908 0.054,0.0925 0.054,0.20819 0,0.11823 -0.054,0.2159 -0.054,0.0951 -0.14908,0.15165 -0.0977,0.054 -0.21847,0.054 -0.11566,0 -0.20819,-0.054 -0.0951,-0.0566 -0.14908,-0.15165 -0.054,-0.0977 -0.054,-0.2159 z" />
+    </g>
+    <g
+       id="text9232-6"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.01202059px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       aria-label="previous action">
+      <path
+         id="path1356"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 256.51337,373.47262 q -0.20068,0 -0.36709,-0.11013 -0.16397,-0.11257 -0.24963,-0.30591 h -0.022 l 0.0171,0.29123 v 1.27993 h -0.23249 v -3.85936 h 0.19089 l 0.0245,0.36465 h 0.022 q 0.0979,-0.20068 0.24963,-0.30836 0.15417,-0.10768 0.33527,-0.10768 0.77824,0 0.77824,1.37292 0,0.66321 -0.19089,1.02296 -0.19089,0.35975 -0.55553,0.35975 z m -0.0465,-2.53538 q -0.29123,0 -0.43317,0.25697 -0.14194,0.25696 -0.14194,0.80515 v 0.0759 q 0,0.61182 0.14439,0.90059 0.14439,0.28634 0.44051,0.28634 0.27409,0 0.40625,-0.28389 0.1346,-0.28633 0.1346,-0.88836 0,-0.57511 -0.12482,-0.86389 -0.12481,-0.28878 -0.42582,-0.28878 z" />
+      <path
+         id="path1358"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 258.57887,370.71699 q 0.12481,0 0.23249,0.0343 l -0.0563,0.23249 q -0.0881,-0.0367 -0.1811,-0.0367 -0.1346,0 -0.25207,0.1395 -0.11502,0.13704 -0.18109,0.38422 -0.0661,0.24717 -0.0661,0.54574 v 1.40719 h -0.23249 v -2.6553 h 0.19089 l 0.0245,0.46498 h 0.0171 q 0.18599,-0.51637 0.50414,-0.51637 z" />
+      <path
+         id="path1360"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 259.96647,373.47262 q -0.42093,0 -0.64853,-0.3573 -0.22514,-0.35975 -0.22514,-1.00094 0,-0.68034 0.20067,-1.03764 0.20313,-0.35975 0.58245,-0.35975 0.33039,0 0.52127,0.3157 0.19089,0.31325 0.19089,0.84675 v 0.21536 h -1.2579 q 0.005,0.58001 0.16397,0.86879 0.15907,0.28878 0.48211,0.28878 0.24962,0 0.52617,-0.16397 v 0.22515 q -0.25452,0.15907 -0.53596,0.15907 z m -0.10523,-2.54517 q -0.47967,0 -0.52616,0.95689 h 1.02051 q 0,-0.43806 -0.1346,-0.69747 -0.13215,-0.25942 -0.35975,-0.25942 z" />
+      <path
+         id="path1362"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 261.47644,373.42368 -0.6265,-2.6553 h 0.23494 l 0.39646,1.7082 q 0.0685,0.29612 0.13215,0.64608 h 0.0196 q 0.0171,-0.12726 0.0489,-0.28388 0.0318,-0.15663 0.48212,-2.0704 h 0.23493 l -0.64608,2.6553 z" />
+      <path
+         id="path1364"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 263.00844,373.42368 h -0.23249 v -2.6553 h 0.23249 z m -0.26676,-3.39193 q 0,-0.11013 0.0441,-0.17131 0.0465,-0.0612 0.11747,-0.0612 0.0661,0 0.10524,0.0612 0.0392,0.0612 0.0392,0.17131 0,0.10523 -0.0392,0.16886 -0.0392,0.0612 -0.10524,0.0612 -0.071,0 -0.11747,-0.0612 -0.0441,-0.0636 -0.0441,-0.16886 z" />
+      <path
+         id="path1366"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 265.21099,372.08991 q 0,0.67055 -0.21292,1.02786 -0.21046,0.35485 -0.60448,0.35485 -0.38911,0 -0.59713,-0.35485 -0.20557,-0.35731 -0.20557,-1.02786 0,-1.37292 0.81249,-1.37292 0.38178,0 0.59469,0.35975 0.21292,0.35975 0.21292,1.01317 z m -1.37782,0 q 0,0.57511 0.13705,0.86878 0.13704,0.29368 0.42827,0.29368 0.57021,0 0.57021,-1.16246 0,-1.15267 -0.57021,-1.15267 -0.29857,0 -0.43317,0.28878 -0.13215,0.28878 -0.13215,0.86389 z" />
+      <path
+         id="path1368"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 266.02348,370.76838 v 1.73267 q 0,0.39401 0.093,0.57511 0.0954,0.1811 0.29122,0.1811 0.30102,0 0.44051,-0.24228 0.14194,-0.24473 0.14194,-0.78802 v -1.45858 h 0.23005 v 2.6553 h -0.19578 l -0.0294,-0.37199 h -0.0196 q -0.0856,0.20312 -0.23739,0.31325 -0.15173,0.10768 -0.33038,0.10768 -0.32059,0 -0.46987,-0.2276 -0.14684,-0.22759 -0.14684,-0.74397 v -1.73267 z" />
+      <path
+         id="path1370"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 268.97734,372.75802 q 0,0.33527 -0.1762,0.52616 -0.17621,0.18844 -0.50904,0.18844 -0.18109,0 -0.31814,-0.0465 -0.13705,-0.0465 -0.21291,-0.10278 v -0.27165 q 0.0906,0.0906 0.23983,0.14684 0.14928,0.0538 0.30591,0.0538 0.20557,0 0.32304,-0.1346 0.11747,-0.1346 0.11747,-0.35975 0,-0.17621 -0.0857,-0.29612 -0.0832,-0.12237 -0.32059,-0.27655 -0.27165,-0.17131 -0.37199,-0.27409 -0.0979,-0.10279 -0.15417,-0.23004 -0.0538,-0.12726 -0.0538,-0.30347 0,-0.28633 0.19333,-0.47232 0.19334,-0.18844 0.4919,-0.18844 0.3206,0 0.53596,0.15173 l -0.11992,0.20312 q -0.20068,-0.1346 -0.42583,-0.1346 -0.20557,0 -0.32793,0.12237 -0.12236,0.11991 -0.12236,0.31814 0,0.17621 0.0832,0.29612 0.0832,0.11747 0.35241,0.28633 0.26431,0.17376 0.3622,0.27899 0.0979,0.10279 0.14439,0.23005 0.0489,0.12481 0.0489,0.28878 z" />
+      <path
+         id="path1372"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 271.47846,373.42368 -0.0294,-0.37199 h -0.01 q -0.19089,0.42093 -0.57756,0.42093 -0.25941,0 -0.41848,-0.20557 -0.15663,-0.20802 -0.15663,-0.55553 0,-0.37933 0.2276,-0.59958 0.2276,-0.22271 0.63874,-0.24228 l 0.28633,-0.0147 v -0.22025 q 0,-0.37199 -0.093,-0.54085 -0.093,-0.17131 -0.30835,-0.17131 -0.2276,0 -0.46498,0.14928 l -0.10034,-0.18354 q 0.27654,-0.17131 0.58,-0.17131 0.32794,0 0.47233,0.20802 0.14439,0.20557 0.14439,0.69013 v 1.80854 z m -0.56532,-0.14929 q 0.24962,0 0.38667,-0.24473 0.13949,-0.24717 0.13949,-0.69747 v -0.27654 l -0.27654,0.0147 q -0.32059,0.0171 -0.47722,0.17865 -0.15418,0.15908 -0.15418,0.46743 0,0.28878 0.10279,0.42338 0.10278,0.1346 0.27899,0.1346 z" />
+      <path
+         id="path1374"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 273.05206,373.47262 q -0.39891,0 -0.60203,-0.34506 -0.20068,-0.34752 -0.20068,-1.01807 0,-0.68034 0.20312,-1.0352 0.20558,-0.3573 0.60448,-0.3573 0.24718,0 0.41114,0.0906 l -0.0906,0.20557 q -0.16396,-0.0759 -0.30101,-0.0759 -0.5849,0 -0.5849,1.16735 0,1.15757 0.5849,1.15757 0.17376,0 0.37688,-0.0783 v 0.19578 q -0.0808,0.0441 -0.19823,0.0685 -0.11747,0.0245 -0.20312,0.0245 z" />
+      <path
+         id="path1376"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 274.41274,373.25726 q 0.10768,0 0.19089,-0.0294 v 0.19579 q -0.10768,0.0489 -0.27654,0.0489 -0.41115,0 -0.41115,-0.61427 v -1.8844 h -0.23983 v -0.13704 l 0.23494,-0.0685 0.0759,-0.6314 h 0.16152 v 0.6314 h 0.42093 v 0.20557 h -0.42093 v 1.81833 q 0,0.2692 0.0587,0.36709 0.0587,0.0979 0.20557,0.0979 z" />
+      <path
+         id="path1378"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 275.2546,373.42368 h -0.23249 v -2.6553 h 0.23249 z m -0.26675,-3.39193 q 0,-0.11013 0.0441,-0.17131 0.0465,-0.0612 0.11747,-0.0612 0.0661,0 0.10523,0.0612 0.0392,0.0612 0.0392,0.17131 0,0.10523 -0.0392,0.16886 -0.0392,0.0612 -0.10523,0.0612 -0.071,0 -0.11747,-0.0612 -0.0441,-0.0636 -0.0441,-0.16886 z" />
+      <path
+         id="path1380"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 277.45715,372.08991 q 0,0.67055 -0.21291,1.02786 -0.21047,0.35485 -0.60448,0.35485 -0.38911,0 -0.59713,-0.35485 -0.20557,-0.35731 -0.20557,-1.02786 0,-1.37292 0.81249,-1.37292 0.38178,0 0.59469,0.35975 0.21291,0.35975 0.21291,1.01317 z m -1.37781,0 q 0,0.57511 0.13704,0.86878 0.13705,0.29368 0.42828,0.29368 0.57021,0 0.57021,-1.16246 0,-1.15267 -0.57021,-1.15267 -0.29857,0 -0.43317,0.28878 -0.13215,0.28878 -0.13215,0.86389 z" />
+      <path
+         id="path1382"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 279.24611,373.42368 v -1.83057 q 0,-0.66076 -0.39156,-0.66076 -0.29857,0 -0.43807,0.24717 -0.13704,0.24718 -0.13704,0.78558 v 1.45858 h -0.23249 v -2.6553 h 0.19578 l 0.0196,0.36954 h 0.022 q 0.0832,-0.20068 0.23983,-0.3108 0.15663,-0.11013 0.33528,-0.11013 0.30836,0 0.46254,0.20802 0.15417,0.20557 0.15417,0.66321 v 1.83546 z" />
+    </g>
+    <g
+       transform="matrix(1.0148073,0,0,1.0148073,70.364914,71.991742)"
+       id="g7643">
+      <path
+         style="fill:none;stroke:#10b981;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1434)"
+         d="m 209.78646,282.06996 v 5.73399"
+         id="path7639" />
+      <path
+         id="path7641"
+         d="m 240.78051,282.06996 v 5.73399"
+         style="fill:none;stroke:#3b82f6;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1974)" />
+    </g>
+    <g
+       transform="matrix(1.0148073,0,0,1.0148073,70.364914,150.07626)"
+       id="g7655">
+      <path
+         style="fill:none;stroke:#10b981;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1718)"
+         d="m 209.78646,282.06996 v 5.73399"
+         id="path7651" />
+      <path
+         id="path7653"
+         d="m 240.78051,282.06996 v 5.73399"
+         style="fill:none;stroke:#3b82f6;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2294)" />
+    </g>
+    <g
+       id="g7661"
+       transform="matrix(1.0148073,0,0,1.0148073,70.364914,169.3645)">
+      <path
+         id="path7657"
+         d="m 209.78646,282.06996 v 5.73399"
+         style="fill:none;stroke:#10b981;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker6805)" />
+      <path
+         style="fill:none;stroke:#3b82f6;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker7249)"
+         d="m 240.78051,282.06996 v 5.73399"
+         id="path7659" />
+    </g>
+    <path
+       id="rect8801"
+       d="m 255.38902,444.08582 h 87.19045 c 1.14739,0 2.0711,0.92371 2.0711,2.0711 v 7.16891 c 0,1.14739 -0.92371,2.0711 -2.0711,2.0711 h -87.19045 c -1.14739,0 -2.0711,-0.92371 -2.0711,-2.0711 v -7.16891 c 0,-1.14739 0.92371,-2.0711 2.0711,-2.0711 z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" />
+    <g
+       id="text8805"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       transform="rotate(90)"
+       aria-label="...">
+      <path
+         id="path1386"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26850107"
+         d="m 449.90078,-298.98938 q 0,-0.11309 0.054,-0.20819 0.054,-0.0951 0.14907,-0.14908 0.0925,-0.054 0.2082,-0.054 0.1208,0 0.21847,0.054 0.0951,0.054 0.14907,0.14908 0.054,0.0925 0.054,0.20819 0,0.11823 -0.054,0.2159 -0.054,0.0951 -0.14907,0.15165 -0.0977,0.054 -0.21847,0.054 -0.11567,0 -0.2082,-0.054 -0.0951,-0.0566 -0.14907,-0.15165 -0.054,-0.0977 -0.054,-0.2159 z m 2.05622,0 q 0,-0.11309 0.054,-0.20819 0.054,-0.0951 0.14651,-0.14908 0.0951,-0.054 0.21076,-0.054 0.1208,0 0.2159,0.054 0.0977,0.054 0.15165,0.14908 0.054,0.0925 0.054,0.20819 0,0.11823 -0.054,0.2159 -0.054,0.0951 -0.15165,0.15165 -0.0951,0.054 -0.2159,0.054 -0.11566,0 -0.21076,-0.054 -0.0925,-0.0566 -0.14651,-0.15165 -0.054,-0.0977 -0.054,-0.2159 z m -4.11243,0 q 0,-0.11309 0.054,-0.20819 0.054,-0.0951 0.14908,-0.14908 0.0925,-0.054 0.20819,-0.054 0.1208,0 0.21847,0.054 0.0951,0.054 0.14908,0.14908 0.054,0.0925 0.054,0.20819 0,0.11823 -0.054,0.2159 -0.054,0.0951 -0.14908,0.15165 -0.0977,0.054 -0.21847,0.054 -0.11566,0 -0.20819,-0.054 -0.0951,-0.0566 -0.14908,-0.15165 -0.054,-0.0977 -0.054,-0.2159 z" />
+    </g>
+    <g
+       id="text1250"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.01202059px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       aria-label="next action">
+      <path
+         id="path1389"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 256.85843,451.66125 v -1.83056 q 0,-0.66076 -0.39156,-0.66076 -0.29857,0 -0.43806,0.24717 -0.13705,0.24718 -0.13705,0.78558 v 1.45857 h -0.23249 v -2.65529 h 0.19578 l 0.0196,0.36954 h 0.022 q 0.0832,-0.20068 0.23984,-0.3108 0.15662,-0.11013 0.33527,-0.11013 0.30836,0 0.46254,0.20802 0.15418,0.20557 0.15418,0.66321 v 1.83545 z" />
+      <path
+         id="path1391"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 258.54705,451.7102 q -0.42093,0 -0.64852,-0.3573 -0.22515,-0.35975 -0.22515,-1.00094 0,-0.68034 0.20067,-1.03764 0.20313,-0.35975 0.58245,-0.35975 0.33039,0 0.52127,0.3157 0.19089,0.31325 0.19089,0.84675 v 0.21536 h -1.2579 q 0.005,0.58001 0.16397,0.86879 0.15907,0.28878 0.48211,0.28878 0.24962,0 0.52617,-0.16397 v 0.22515 q -0.25452,0.15907 -0.53596,0.15907 z m -0.10523,-2.54517 q -0.47967,0 -0.52616,0.95689 h 1.02051 q 0,-0.43806 -0.1346,-0.69748 -0.13215,-0.25941 -0.35975,-0.25941 z" />
+      <path
+         id="path1393"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 260.1231,450.28344 -0.58245,-1.27748 h 0.25207 l 0.4454,1.0768 0.46498,-1.0768 h 0.24228 l -0.59224,1.30685 0.62161,1.34844 h -0.24473 l -0.49679,-1.14777 -0.5017,1.14777 h -0.23983 z" />
+      <path
+         id="path1395"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 261.90227,451.49484 q 0.10768,0 0.19089,-0.0294 v 0.19578 q -0.10768,0.0489 -0.27655,0.0489 -0.41114,0 -0.41114,-0.61427 v -1.8844 h -0.23983 v -0.13705 l 0.23494,-0.0685 0.0759,-0.6314 h 0.16152 v 0.6314 h 0.42093 v 0.20557 h -0.42093 v 1.81833 q 0,0.2692 0.0587,0.36709 0.0587,0.0979 0.20557,0.0979 z" />
+      <path
+         id="path1397"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 264.47925,451.66125 -0.0294,-0.37198 h -0.01 q -0.19088,0.42093 -0.57755,0.42093 -0.25942,0 -0.41849,-0.20557 -0.15662,-0.20802 -0.15662,-0.55553 0,-0.37933 0.22759,-0.59958 0.2276,-0.22271 0.63874,-0.24229 l 0.28633,-0.0147 v -0.22025 q 0,-0.37199 -0.093,-0.54085 -0.093,-0.17131 -0.30836,-0.17131 -0.2276,0 -0.46498,0.14928 l -0.10034,-0.18354 q 0.27654,-0.17131 0.58,-0.17131 0.32794,0 0.47233,0.20802 0.14439,0.20557 0.14439,0.69013 v 1.80853 z m -0.56532,-0.14928 q 0.24962,0 0.38667,-0.24473 0.13949,-0.24717 0.13949,-0.69747 v -0.27654 l -0.27654,0.0147 q -0.32059,0.0171 -0.47722,0.17865 -0.15418,0.15908 -0.15418,0.46743 0,0.28878 0.10279,0.42338 0.10278,0.1346 0.27899,0.1346 z" />
+      <path
+         id="path1399"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 266.05285,451.7102 q -0.39891,0 -0.60203,-0.34507 -0.20068,-0.34751 -0.20068,-1.01806 0,-0.68034 0.20312,-1.0352 0.20558,-0.3573 0.60448,-0.3573 0.24718,0 0.41114,0.0906 l -0.0905,0.20557 q -0.16397,-0.0759 -0.30102,-0.0759 -0.5849,0 -0.5849,1.16735 0,1.15756 0.5849,1.15756 0.17376,0 0.37688,-0.0783 v 0.19578 q -0.0808,0.044 -0.19823,0.0685 -0.11747,0.0245 -0.20312,0.0245 z" />
+      <path
+         id="path1401"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 267.41353,451.49484 q 0.10768,0 0.19089,-0.0294 v 0.19578 q -0.10768,0.0489 -0.27654,0.0489 -0.41114,0 -0.41114,-0.61427 v -1.8844 h -0.23984 v -0.13705 l 0.23494,-0.0685 0.0759,-0.6314 h 0.16152 v 0.6314 h 0.42093 v 0.20557 h -0.42093 v 1.81833 q 0,0.2692 0.0587,0.36709 0.0587,0.0979 0.20557,0.0979 z" />
+      <path
+         id="path1403"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 268.2554,451.66125 h -0.2325 v -2.65529 h 0.2325 z m -0.26676,-3.39192 q 0,-0.11013 0.0441,-0.17131 0.0465,-0.0612 0.11747,-0.0612 0.0661,0 0.10524,0.0612 0.0392,0.0612 0.0392,0.17131 0,0.10523 -0.0392,0.16886 -0.0392,0.0612 -0.10524,0.0612 -0.071,0 -0.11747,-0.0612 -0.0441,-0.0636 -0.0441,-0.16886 z" />
+      <path
+         id="path1405"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 270.45794,450.32749 q 0,0.67055 -0.21291,1.02786 -0.21046,0.35485 -0.60448,0.35485 -0.38911,0 -0.59713,-0.35485 -0.20557,-0.35731 -0.20557,-1.02786 0,-1.37292 0.81249,-1.37292 0.38178,0 0.59469,0.35975 0.21291,0.35975 0.21291,1.01317 z m -1.37781,0 q 0,0.57511 0.13704,0.86878 0.13705,0.29368 0.42828,0.29368 0.57021,0 0.57021,-1.16246 0,-1.15267 -0.57021,-1.15267 -0.29857,0 -0.43317,0.28878 -0.13215,0.28878 -0.13215,0.86389 z" />
+      <path
+         id="path1407"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         d="m 272.2469,451.66125 v -1.83056 q 0,-0.66076 -0.39156,-0.66076 -0.29857,0 -0.43806,0.24717 -0.13705,0.24718 -0.13705,0.78558 v 1.45857 h -0.23249 v -2.65529 h 0.19578 l 0.0196,0.36954 h 0.022 q 0.0832,-0.20068 0.23984,-0.3108 0.15662,-0.11013 0.33527,-0.11013 0.30836,0 0.46254,0.20802 0.15418,0.20557 0.15418,0.66321 v 1.83545 z" />
+    </g>
+    <g
+       transform="matrix(1.0148073,0,0,1.0148073,2.788212,173.99055)"
+       id="g9228">
+      <g
+         id="text8853"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         aria-label="Project Structure">
+        <path
+           id="path1410"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 238.16436,176.35029 q 0,0.62287 -0.28664,0.91502 -0.28387,0.29214 -0.84335,0.29214 h -0.28664 v 1.66467 h -0.27009 v -4.02938 h 0.55121 q 0.5898,0 0.86265,0.27836 0.27286,0.27837 0.27286,0.87919 z m -1.41663,0.95912 h 0.2701 q 0.47404,0 0.67248,-0.22325 0.19844,-0.22324 0.19844,-0.73587 0,-0.48782 -0.20671,-0.69729 -0.20395,-0.21221 -0.63389,-0.21221 h -0.30042 z" />
+        <path
+           id="path1412"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 239.58098,176.1739 q 0.14056,0 0.26183,0.0386 l -0.0634,0.26182 q -0.0992,-0.0413 -0.20395,-0.0413 -0.15159,0 -0.28388,0.1571 -0.12953,0.15434 -0.20395,0.4327 -0.0744,0.27837 -0.0744,0.61461 v 1.58474 h -0.26183 v -2.99034 h 0.21497 l 0.0276,0.52365 h 0.0193 q 0.20946,-0.58153 0.56775,-0.58153 z" />
+        <path
+           id="path1414"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 241.97877,177.72006 q 0,0.75517 -0.23978,1.15755 -0.23702,0.39963 -0.68075,0.39963 -0.43822,0 -0.67249,-0.39963 -0.23151,-0.40238 -0.23151,-1.15755 0,-1.54616 0.91502,-1.54616 0.42995,0 0.66973,0.40514 0.23978,0.40515 0.23978,1.14102 z m -1.55167,0 q 0,0.64768 0.15434,0.97841 0.15434,0.33073 0.48231,0.33073 0.64216,0 0.64216,-1.30914 0,-1.29811 -0.64216,-1.29811 -0.33624,0 -0.48783,0.32522 -0.14882,0.32521 -0.14882,0.97289 z" />
+        <path
+           id="path1416"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 242.41698,180.57811 q -0.11575,0 -0.18465,-0.0469 v -0.24805 q 0.0882,0.0441 0.17363,0.0441 0.12953,0 0.1819,-0.12678 0.0551,-0.12402 0.0551,-0.38585 v -3.5829 h 0.26183 v 3.54431 q 0,0.41066 -0.11851,0.60634 -0.11851,0.19568 -0.36932,0.19568 z m 0.18742,-5.17591 q 0,-0.12402 0.0496,-0.19293 0.0524,-0.0689 0.1323,-0.0689 0.0744,0 0.11851,0.0689 0.0441,0.0689 0.0441,0.19293 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.11851,0.0689 -0.0799,0 -0.1323,-0.0689 -0.0496,-0.0717 -0.0496,-0.19017 z" />
+        <path
+           id="path1418"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 244.55019,179.27724 q -0.47405,0 -0.73036,-0.40238 -0.25356,-0.40515 -0.25356,-1.12724 0,-0.76619 0.22599,-1.16858 0.22876,-0.40514 0.65595,-0.40514 0.37207,0 0.58705,0.35554 0.21497,0.35277 0.21497,0.9536 v 0.24253 h -1.41662 q 0.006,0.65319 0.18465,0.97841 0.17915,0.32522 0.54295,0.32522 0.28112,0 0.59256,-0.18466 v 0.25356 q -0.28664,0.17914 -0.60358,0.17914 z m -0.11852,-2.86632 q -0.54019,0 -0.59255,1.07763 h 1.14928 q 0,-0.49334 -0.15158,-0.78548 -0.14883,-0.29215 -0.40515,-0.29215 z" />
+        <path
+           id="path1420"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 246.68614,179.27724 q -0.44924,0 -0.67799,-0.3886 -0.226,-0.39137 -0.226,-1.14653 0,-0.76619 0.22876,-1.16582 0.23151,-0.40239 0.68075,-0.40239 0.27836,0 0.46302,0.10198 l -0.10198,0.23151 q -0.18465,-0.0854 -0.33899,-0.0854 -0.65871,0 -0.65871,1.31465 0,1.30362 0.65871,1.30362 0.19568,0 0.42443,-0.0882 v 0.22048 q -0.0909,0.0496 -0.22324,0.0772 -0.13229,0.0276 -0.22876,0.0276 z" />
+        <path
+           id="path1422"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 248.21852,179.03471 q 0.12127,0 0.21498,-0.0331 v 0.22048 q -0.12127,0.0551 -0.31144,0.0551 -0.46302,0 -0.46302,-0.69177 v -2.12218 h -0.2701 v -0.15434 l 0.26459,-0.0772 0.0854,-0.71107 h 0.1819 v 0.71107 h 0.47404 v 0.23151 h -0.47404 v 2.04776 q 0,0.30317 0.0661,0.41342 0.0661,0.11024 0.23151,0.11024 z" />
+        <path
+           id="path1424"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 251.55062,178.16654 q 0,0.4961 -0.27561,0.80478 -0.27561,0.30592 -0.70004,0.30592 -0.48231,0 -0.77446,-0.14056 v -0.29214 q 0.14332,0.0799 0.35553,0.12678 0.21222,0.0469 0.41893,0.0469 0.30868,0 0.50712,-0.23426 0.19843,-0.23427 0.19843,-0.59532 0,-0.33348 -0.14056,-0.52916 -0.14056,-0.19568 -0.53743,-0.39137 -0.31144,-0.15709 -0.46578,-0.30316 -0.15434,-0.14883 -0.22875,-0.34451 -0.0744,-0.19569 -0.0744,-0.46854 0,-0.29765 0.12127,-0.52916 0.12127,-0.23151 0.339,-0.35829 0.21773,-0.12954 0.4768,-0.12954 0.23427,0 0.42444,0.0524 0.19292,0.0524 0.30316,0.113 l -0.10473,0.25907 q -0.30592,-0.1571 -0.62287,-0.1571 -0.29766,0 -0.48507,0.20395 -0.18466,0.20119 -0.18466,0.53468 0,0.339 0.13505,0.52641 0.13505,0.18741 0.52917,0.38861 0.4079,0.19843 0.59531,0.46577 0.19017,0.26459 0.19017,0.64492 z" />
+        <path
+           id="path1426"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 252.73849,179.03471 q 0.12127,0 0.21497,-0.0331 v 0.22048 q -0.12126,0.0551 -0.31143,0.0551 -0.46303,0 -0.46303,-0.69177 v -2.12218 h -0.27009 v -0.15434 l 0.26458,-0.0772 0.0854,-0.71107 h 0.1819 v 0.71107 h 0.47405 v 0.23151 h -0.47405 v 2.04776 q 0,0.30317 0.0661,0.41342 0.0661,0.11024 0.23151,0.11024 z" />
+        <path
+           id="path1428"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 254.25433,176.1739 q 0.14056,0 0.26183,0.0386 l -0.0634,0.26182 q -0.0992,-0.0413 -0.20395,-0.0413 -0.15159,0 -0.28388,0.1571 -0.12953,0.15434 -0.20395,0.4327 -0.0744,0.27837 -0.0744,0.61461 v 1.58474 h -0.26183 v -2.99034 h 0.21498 l 0.0276,0.52365 h 0.0193 q 0.20946,-0.58153 0.56775,-0.58153 z" />
+        <path
+           id="path1430"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 255.21896,176.23178 v 1.9513 q 0,0.44373 0.10473,0.64768 0.10749,0.20395 0.32797,0.20395 0.339,0 0.4961,-0.27285 0.15985,-0.27561 0.15985,-0.88746 v -1.64262 h 0.25907 v 2.99034 h -0.22049 l -0.0331,-0.41892 h -0.0221 q -0.0965,0.22875 -0.26734,0.35278 -0.17087,0.12126 -0.37207,0.12126 -0.36104,0 -0.52916,-0.25631 -0.16537,-0.25632 -0.16537,-0.83785 v -1.9513 z" />
+        <path
+           id="path1433"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 258.1404,179.27724 q -0.44924,0 -0.678,-0.3886 -0.226,-0.39137 -0.226,-1.14653 0,-0.76619 0.22876,-1.16582 0.23151,-0.40239 0.68075,-0.40239 0.27836,0 0.46302,0.10198 l -0.10197,0.23151 q -0.18466,-0.0854 -0.339,-0.0854 -0.6587,0 -0.6587,1.31465 0,1.30362 0.6587,1.30362 0.19568,0 0.42443,-0.0882 v 0.22048 q -0.091,0.0496 -0.22324,0.0772 -0.13229,0.0276 -0.22875,0.0276 z" />
+        <path
+           id="path1435"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 259.67278,179.03471 q 0.12126,0 0.21497,-0.0331 v 0.22048 q -0.12127,0.0551 -0.31144,0.0551 -0.46302,0 -0.46302,-0.69177 v -2.12218 h -0.27009 v -0.15434 l 0.26458,-0.0772 0.0854,-0.71107 h 0.1819 v 0.71107 h 0.47405 v 0.23151 h -0.47405 v 2.04776 q 0,0.30317 0.0661,0.41342 0.0661,0.11024 0.23151,0.11024 z" />
+        <path
+           id="path1437"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 260.60984,176.23178 v 1.9513 q 0,0.44373 0.10473,0.64768 0.10749,0.20395 0.32798,0.20395 0.33899,0 0.49609,-0.27285 0.15985,-0.27561 0.15985,-0.88746 v -1.64262 h 0.25907 v 2.99034 h -0.22048 l -0.0331,-0.41892 h -0.022 q -0.0965,0.22875 -0.26734,0.35278 -0.17088,0.12126 -0.37207,0.12126 -0.36105,0 -0.52917,-0.25631 -0.16536,-0.25632 -0.16536,-0.83785 v -1.9513 z" />
+        <path
+           id="path1439"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 263.59192,176.1739 q 0.14056,0 0.26182,0.0386 l -0.0634,0.26182 q -0.0992,-0.0413 -0.20395,-0.0413 -0.15159,0 -0.28388,0.1571 -0.12954,0.15434 -0.20395,0.4327 -0.0744,0.27837 -0.0744,0.61461 v 1.58474 h -0.26183 v -2.99034 h 0.21497 l 0.0276,0.52365 h 0.0193 q 0.20946,-0.58153 0.56775,-0.58153 z" />
+        <path
+           id="path1441"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 265.15461,179.27724 q -0.47404,0 -0.73036,-0.40238 -0.25356,-0.40515 -0.25356,-1.12724 0,-0.76619 0.226,-1.16858 0.22876,-0.40514 0.65595,-0.40514 0.37207,0 0.58704,0.35554 0.21498,0.35277 0.21498,0.9536 v 0.24253 h -1.41663 q 0.006,0.65319 0.18466,0.97841 0.17915,0.32522 0.54295,0.32522 0.28112,0 0.59255,-0.18466 v 0.25356 q -0.28663,0.17914 -0.60358,0.17914 z m -0.11851,-2.86632 q -0.54019,0 -0.59255,1.07763 h 1.14928 q 0,-0.49334 -0.15158,-0.78548 -0.14883,-0.29215 -0.40515,-0.29215 z" />
+      </g>
+      <g
+         id="text8859"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         aria-label="{...}">
+        <path
+           id="path1444"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 271.0702,175.26595 q -0.32419,0 -0.51668,0.10131 -0.19249,0.0988 -0.1697,0.32672 l 0.11397,1.12708 q 0.008,0.0684 0.008,0.12664 0,0.22035 -0.0962,0.34192 -0.0937,0.11904 -0.29127,0.15957 0.20009,0.038 0.2938,0.14943 0.0937,0.11144 0.0937,0.33686 0,0.0658 -0.008,0.14183 l -0.11397,1.12708 q -0.003,0.0152 -0.003,0.0456 0,0.20516 0.18742,0.2938 0.18996,0.0887 0.50149,0.0887 v 0.26847 q -0.40018,0 -0.69145,-0.14943 -0.28873,-0.1469 -0.28873,-0.50655 0,-0.0253 0.005,-0.0912 l 0.11145,-1.03337 q 0.008,-0.0608 0.008,-0.11904 0,-0.14183 -0.0658,-0.23301 -0.0633,-0.0937 -0.23808,-0.14437 -0.17222,-0.0507 -0.49135,-0.0507 v -0.24821 q 0.31913,0 0.49135,-0.0481 0.17476,-0.0507 0.23808,-0.14184 0.0658,-0.0912 0.0658,-0.23301 0,-0.0557 -0.008,-0.11904 l -0.11145,-1.04096 q -0.005,-0.0608 -0.005,-0.0887 0,-0.35712 0.28873,-0.50655 0.28874,-0.14944 0.69145,-0.14944 z" />
+        <path
+           id="path1446"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 275.9942,178.8574 q 0,-0.11144 0.0532,-0.20515 0.0532,-0.0937 0.1469,-0.1469 0.0912,-0.0532 0.20515,-0.0532 0.11904,0 0.21528,0.0532 0.0937,0.0532 0.14691,0.1469 0.0532,0.0912 0.0532,0.20515 0,0.11651 -0.0532,0.21276 -0.0532,0.0937 -0.14691,0.14943 -0.0962,0.0532 -0.21528,0.0532 -0.11397,0 -0.20515,-0.0532 -0.0937,-0.0557 -0.1469,-0.14943 -0.0532,-0.0962 -0.0532,-0.21276 z m 2.02621,0 q 0,-0.11144 0.0532,-0.20515 0.0532,-0.0937 0.14436,-0.1469 0.0937,-0.0532 0.20769,-0.0532 0.11904,0 0.21275,0.0532 0.0962,0.0532 0.14944,0.1469 0.0532,0.0912 0.0532,0.20515 0,0.11651 -0.0532,0.21276 -0.0532,0.0937 -0.14944,0.14943 -0.0937,0.0532 -0.21275,0.0532 -0.11397,0 -0.20769,-0.0532 -0.0912,-0.0557 -0.14436,-0.14943 -0.0532,-0.0962 -0.0532,-0.21276 z m -4.05242,0 q 0,-0.11144 0.0532,-0.20515 0.0532,-0.0937 0.14691,-0.1469 0.0912,-0.0532 0.20515,-0.0532 0.11904,0 0.21528,0.0532 0.0937,0.0532 0.1469,0.1469 0.0532,0.0912 0.0532,0.20515 0,0.11651 -0.0532,0.21276 -0.0532,0.0937 -0.1469,0.14943 -0.0962,0.0532 -0.21528,0.0532 -0.11398,0 -0.20515,-0.0532 -0.0937,-0.0557 -0.14691,-0.14943 -0.0532,-0.0962 -0.0532,-0.21276 z" />
+        <path
+           id="path1448"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 281.73523,174.99747 q 0.40018,0 0.68891,0.14944 0.29127,0.1469 0.29127,0.50655 0,0.0253 -0.005,0.0912 l -0.11144,1.03843 q -0.005,0.0608 -0.005,0.0887 0,0.14943 0.0709,0.24821 0.0735,0.0988 0.24568,0.15196 0.17476,0.0532 0.47616,0.0532 v 0.24821 q -0.4407,0 -0.61799,0.11651 -0.17476,0.11651 -0.17476,0.34192 0,0.0279 0.005,0.0887 l 0.11144,1.0359 q 0.005,0.0608 0.005,0.0887 0,0.35712 -0.28873,0.50655 -0.28874,0.14943 -0.69145,0.14943 v -0.26847 q 0.32926,0 0.51922,-0.0988 0.18995,-0.0988 0.16716,-0.32926 l -0.11397,-1.12708 q -0.008,-0.0811 -0.008,-0.1469 0,-0.22795 0.10384,-0.33179 0.10384,-0.10638 0.35712,-0.14183 -0.24061,-0.0431 -0.34952,-0.16717 -0.10891,-0.1241 -0.10891,-0.35205 0,-0.076 0.005,-0.11651 l 0.11397,-1.12708 q 0.003,-0.0152 0.003,-0.0431 0,-0.20516 -0.18995,-0.29381 -0.18743,-0.0912 -0.49896,-0.0912 z" />
+      </g>
+      <g
+         id="text9144"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3b82f6;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         aria-label="{...}">
+        <path
+           id="path1451"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 301.98866,175.26595 q -0.3242,0 -0.51669,0.10131 -0.19249,0.0988 -0.16969,0.32672 l 0.11397,1.12708 q 0.008,0.0684 0.008,0.12664 0,0.22035 -0.0962,0.34192 -0.0937,0.11904 -0.29126,0.15957 0.20009,0.038 0.2938,0.14943 0.0937,0.11144 0.0937,0.33686 0,0.0658 -0.008,0.14183 l -0.11397,1.12708 q -0.003,0.0152 -0.003,0.0456 0,0.20516 0.18743,0.2938 0.18996,0.0887 0.50149,0.0887 v 0.26847 q -0.40018,0 -0.69145,-0.14943 -0.28873,-0.1469 -0.28873,-0.50655 0,-0.0253 0.005,-0.0912 l 0.11144,-1.03337 q 0.008,-0.0608 0.008,-0.11904 0,-0.14183 -0.0659,-0.23301 -0.0633,-0.0937 -0.23808,-0.14437 -0.17223,-0.0507 -0.49136,-0.0507 v -0.24821 q 0.31913,0 0.49136,-0.0481 0.17476,-0.0507 0.23808,-0.14184 0.0659,-0.0912 0.0659,-0.23301 0,-0.0557 -0.008,-0.11904 l -0.11144,-1.04096 q -0.005,-0.0608 -0.005,-0.0887 0,-0.35712 0.28873,-0.50655 0.28874,-0.14944 0.69145,-0.14944 z" />
+        <path
+           id="path1453"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 306.91265,178.8574 q 0,-0.11144 0.0532,-0.20515 0.0532,-0.0937 0.1469,-0.1469 0.0912,-0.0532 0.20516,-0.0532 0.11904,0 0.21528,0.0532 0.0937,0.0532 0.1469,0.1469 0.0532,0.0912 0.0532,0.20515 0,0.11651 -0.0532,0.21276 -0.0532,0.0937 -0.1469,0.14943 -0.0962,0.0532 -0.21528,0.0532 -0.11398,0 -0.20516,-0.0532 -0.0937,-0.0557 -0.1469,-0.14943 -0.0532,-0.0962 -0.0532,-0.21276 z m 2.02622,0 q 0,-0.11144 0.0532,-0.20515 0.0532,-0.0937 0.14437,-0.1469 0.0937,-0.0532 0.20769,-0.0532 0.11904,0 0.21275,0.0532 0.0963,0.0532 0.14943,0.1469 0.0532,0.0912 0.0532,0.20515 0,0.11651 -0.0532,0.21276 -0.0532,0.0937 -0.14943,0.14943 -0.0937,0.0532 -0.21275,0.0532 -0.11398,0 -0.20769,-0.0532 -0.0912,-0.0557 -0.14437,-0.14943 -0.0532,-0.0962 -0.0532,-0.21276 z m -4.05243,0 q 0,-0.11144 0.0532,-0.20515 0.0532,-0.0937 0.1469,-0.1469 0.0912,-0.0532 0.20516,-0.0532 0.11904,0 0.21528,0.0532 0.0937,0.0532 0.1469,0.1469 0.0532,0.0912 0.0532,0.20515 0,0.11651 -0.0532,0.21276 -0.0532,0.0937 -0.1469,0.14943 -0.0962,0.0532 -0.21528,0.0532 -0.11398,0 -0.20516,-0.0532 -0.0937,-0.0557 -0.1469,-0.14943 -0.0532,-0.0962 -0.0532,-0.21276 z" />
+        <path
+           id="path1455"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 312.65369,174.99747 q 0.40017,0 0.68891,0.14944 0.29127,0.1469 0.29127,0.50655 0,0.0253 -0.005,0.0912 l -0.11144,1.03843 q -0.005,0.0608 -0.005,0.0887 0,0.14943 0.0709,0.24821 0.0734,0.0988 0.24568,0.15196 0.17476,0.0532 0.47616,0.0532 v 0.24821 q -0.4407,0 -0.61799,0.11651 -0.17477,0.11651 -0.17477,0.34192 0,0.0279 0.005,0.0887 l 0.11144,1.0359 q 0.005,0.0608 0.005,0.0887 0,0.35712 -0.28874,0.50655 -0.28873,0.14943 -0.69144,0.14943 v -0.26847 q 0.32926,0 0.51921,-0.0988 0.18996,-0.0988 0.16717,-0.32926 l -0.11398,-1.12708 q -0.008,-0.0811 -0.008,-0.1469 0,-0.22795 0.10385,-0.33179 0.10384,-0.10638 0.35712,-0.14183 -0.24062,-0.0431 -0.34952,-0.16717 -0.10891,-0.1241 -0.10891,-0.35205 0,-0.076 0.005,-0.11651 l 0.11398,-1.12708 q 0.003,-0.0152 0.003,-0.0431 0,-0.20516 -0.18996,-0.29381 -0.18742,-0.0912 -0.49895,-0.0912 z" />
+      </g>
+      <g
+         id="text9148"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3b82f6;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         aria-label="Scaffold Options">
+        <path
+           id="path1458"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 319.28078,178.16654 q 0,0.4961 -0.27561,0.80478 -0.27561,0.30592 -0.70005,0.30592 -0.48231,0 -0.77445,-0.14056 v -0.29214 q 0.14331,0.0799 0.35553,0.12678 0.21222,0.0469 0.41892,0.0469 0.30868,0 0.50712,-0.23426 0.19844,-0.23427 0.19844,-0.59532 0,-0.33348 -0.14056,-0.52916 -0.14056,-0.19568 -0.53744,-0.39137 -0.31143,-0.15709 -0.46577,-0.30316 -0.15434,-0.14883 -0.22876,-0.34451 -0.0744,-0.19569 -0.0744,-0.46854 0,-0.29765 0.12127,-0.52916 0.12126,-0.23151 0.33899,-0.35829 0.21773,-0.12954 0.47681,-0.12954 0.23426,0 0.42443,0.0524 0.19293,0.0524 0.30317,0.113 l -0.10473,0.25907 q -0.30593,-0.1571 -0.62287,-0.1571 -0.29766,0 -0.48507,0.20395 -0.18466,0.20119 -0.18466,0.53468 0,0.339 0.13505,0.52641 0.13504,0.18741 0.52916,0.38861 0.4079,0.19843 0.59532,0.46577 0.19017,0.26459 0.19017,0.64492 z" />
+        <path
+           id="path1460"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 320.68913,179.27724 q -0.44924,0 -0.67799,-0.3886 -0.226,-0.39137 -0.226,-1.14653 0,-0.76619 0.22875,-1.16582 0.23151,-0.40239 0.68075,-0.40239 0.27837,0 0.46302,0.10198 l -0.10197,0.23151 q -0.18466,-0.0854 -0.339,-0.0854 -0.6587,0 -0.6587,1.31465 0,1.30362 0.6587,1.30362 0.19568,0 0.42444,-0.0882 v 0.22048 q -0.0909,0.0496 -0.22325,0.0772 -0.13229,0.0276 -0.22875,0.0276 z" />
+        <path
+           id="path1462"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 322.8306,179.22212 -0.0331,-0.41892 h -0.011 q -0.21497,0.47404 -0.65043,0.47404 -0.29214,0 -0.47129,-0.23151 -0.17639,-0.23426 -0.17639,-0.62563 0,-0.42719 0.25632,-0.67523 0.25631,-0.25081 0.71933,-0.27286 l 0.32246,-0.0165 v -0.24805 q 0,-0.41892 -0.10473,-0.60909 -0.10473,-0.19293 -0.34726,-0.19293 -0.25632,0 -0.52366,0.16812 l -0.113,-0.2067 q 0.31144,-0.19293 0.65319,-0.19293 0.36932,0 0.53193,0.23427 0.16261,0.23151 0.16261,0.77721 v 2.03674 z m -0.63665,-0.16812 q 0.28112,0 0.43546,-0.27561 0.15709,-0.27836 0.15709,-0.78548 v -0.31143 l -0.31143,0.0165 q -0.36105,0.0193 -0.53744,0.2012 -0.17363,0.17914 -0.17363,0.52641 0,0.32521 0.11576,0.4768 0.11575,0.15158 0.31419,0.15158 z" />
+        <path
+           id="path1464"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 324.59725,176.46329 h -0.46854 v 2.75883 h -0.25907 v -2.75883 h -0.38034 v -0.14883 l 0.38034,-0.113 v -0.226 q 0,-0.5705 0.13505,-0.82131 0.13505,-0.2508 0.46853,-0.2508 0.19293,0 0.35002,0.0689 l -0.091,0.24254 q -0.14607,-0.0689 -0.26458,-0.0689 -0.13505,0 -0.20395,0.0799 -0.0689,0.0799 -0.10197,0.25907 -0.0331,0.17915 -0.0331,0.4961 v 0.2508 h 0.46854 z m 1.27606,0 h -0.46853 v 2.75883 h -0.25907 v -2.75883 h -0.38034 v -0.14883 l 0.38034,-0.113 v -0.226 q 0,-0.5705 0.13504,-0.82131 0.13505,-0.2508 0.46854,-0.2508 0.19292,0 0.35002,0.0689 l -0.091,0.24254 q -0.14607,-0.0689 -0.26459,-0.0689 -0.13504,0 -0.20395,0.0799 -0.0689,0.0799 -0.10197,0.25907 -0.0331,0.17915 -0.0331,0.4961 v 0.2508 h 0.46853 z" />
+        <path
+           id="path1466"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 328.04234,177.72006 q 0,0.75517 -0.23978,1.15755 -0.23702,0.39963 -0.68075,0.39963 -0.43821,0 -0.67248,-0.39963 -0.23151,-0.40238 -0.23151,-1.15755 0,-1.54616 0.91502,-1.54616 0.42994,0 0.66972,0.40514 0.23978,0.40515 0.23978,1.14102 z m -1.55167,0 q 0,0.64768 0.15434,0.97841 0.15434,0.33073 0.48231,0.33073 0.64217,0 0.64217,-1.30914 0,-1.29811 -0.64217,-1.29811 -0.33624,0 -0.48782,0.32522 -0.14883,0.32521 -0.14883,0.97289 z" />
+        <path
+           id="path1468"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 328.96838,179.22212 h -0.26182 v -4.28845 h 0.26182 z" />
+        <path
+           id="path1470"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 330.49525,179.27724 q -0.87092,0 -0.87092,-1.54616 0,-0.76067 0.21773,-1.15755 0.21773,-0.39963 0.64217,-0.39963 0.20119,0 0.38033,0.11576 0.18191,0.11575 0.28939,0.3197 h 0.022 l -0.011,-0.33348 v -1.34221 h 0.26182 v 4.28845 h -0.21497 l -0.0221,-0.41892 h -0.0248 q -0.10749,0.22875 -0.27837,0.35278 -0.17087,0.12126 -0.39136,0.12126 z m 0.0165,-0.22875 q 0.31419,0 0.48231,-0.28939 0.17088,-0.29214 0.17088,-0.85714 v -0.17088 q 0,-0.67799 -0.16537,-0.99218 -0.16261,-0.31695 -0.49885,-0.31695 -0.32246,0 -0.46302,0.339 -0.14056,0.33624 -0.14056,0.97565 0,0.64492 0.14607,0.9784 0.14608,0.33349 0.46854,0.33349 z" />
+        <path
+           id="path1472"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 335.51131,177.20192 q 0,1.00045 -0.30041,1.53789 -0.29766,0.53743 -0.86265,0.53743 -0.57051,0 -0.86541,-0.54019 -0.2949,-0.54294 -0.2949,-1.54064 0,-1.0418 0.29214,-1.55167 0.29215,-0.50988 0.87643,-0.50988 0.56224,0 0.85714,0.53744 0.29766,0.53467 0.29766,1.52962 z m -2.04225,0 q 0,0.89848 0.22324,1.35874 0.226,0.45751 0.65595,0.45751 0.4327,0 0.65594,-0.45475 0.226,-0.45475 0.226,-1.3615 0,-0.89573 -0.22049,-1.35048 -0.22048,-0.45751 -0.65319,-0.45751 -0.44372,0 -0.66697,0.46302 -0.22048,0.46027 -0.22048,1.34497 z" />
+        <path
+           id="path1474"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 337.17598,179.27724 q -0.226,0 -0.41341,-0.12402 -0.18466,-0.12678 -0.28112,-0.34451 h -0.0248 l 0.0193,0.32797 v 1.44143 h -0.26183 v -4.34633 h 0.21497 l 0.0276,0.41065 h 0.0248 q 0.11024,-0.22599 0.28112,-0.34726 0.17363,-0.12127 0.37758,-0.12127 0.87643,0 0.87643,1.54616 0,0.7469 -0.21497,1.15204 -0.21497,0.40514 -0.62563,0.40514 z m -0.0524,-2.85529 q -0.32797,0 -0.48782,0.28939 -0.15985,0.28938 -0.15985,0.90675 v 0.0854 q 0,0.68902 0.1626,1.01424 0.16261,0.32246 0.4961,0.32246 0.30868,0 0.45751,-0.3197 0.15158,-0.32246 0.15158,-1.00046 0,-0.64768 -0.14056,-0.97289 -0.14056,-0.32522 -0.47956,-0.32522 z" />
+        <path
+           id="path1476"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 339.22099,179.03471 q 0.12127,0 0.21497,-0.0331 v 0.22048 q -0.12127,0.0551 -0.31143,0.0551 -0.46303,0 -0.46303,-0.69177 v -2.12218 h -0.27009 v -0.15434 l 0.26458,-0.0772 0.0854,-0.71107 h 0.1819 v 0.71107 h 0.47405 v 0.23151 h -0.47405 v 2.04776 q 0,0.30317 0.0661,0.41342 0.0661,0.11024 0.23151,0.11024 z" />
+        <path
+           id="path1478"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 340.16908,179.22212 h -0.26183 v -2.99034 h 0.26183 z m -0.30041,-3.81992 q 0,-0.12402 0.0496,-0.19293 0.0524,-0.0689 0.13229,-0.0689 0.0744,0 0.11851,0.0689 0.0441,0.0689 0.0441,0.19293 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.11851,0.0689 -0.0799,0 -0.13229,-0.0689 -0.0496,-0.0717 -0.0496,-0.19017 z" />
+        <path
+           id="path1480"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 342.64955,177.72006 q 0,0.75517 -0.23978,1.15755 -0.23702,0.39963 -0.68075,0.39963 -0.43822,0 -0.67249,-0.39963 -0.23151,-0.40238 -0.23151,-1.15755 0,-1.54616 0.91502,-1.54616 0.42995,0 0.66973,0.40514 0.23978,0.40515 0.23978,1.14102 z m -1.55167,0 q 0,0.64768 0.15434,0.97841 0.15434,0.33073 0.48231,0.33073 0.64216,0 0.64216,-1.30914 0,-1.29811 -0.64216,-1.29811 -0.33624,0 -0.48783,0.32522 -0.14882,0.32521 -0.14882,0.97289 z" />
+        <path
+           id="path1482"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 344.66424,179.22212 v -2.06154 q 0,-0.74414 -0.44097,-0.74414 -0.33624,0 -0.49334,0.27836 -0.15434,0.27836 -0.15434,0.8847 v 1.64262 h -0.26183 v -2.99034 h 0.22049 l 0.0221,0.41617 h 0.0248 q 0.0937,-0.226 0.2701,-0.35002 0.17639,-0.12403 0.37758,-0.12403 0.34727,0 0.5209,0.23427 0.17363,0.23151 0.17363,0.74689 v 2.06706 z" />
+        <path
+           id="path1484"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 346.89115,178.47247 q 0,0.37758 -0.19844,0.59256 -0.19844,0.21221 -0.57326,0.21221 -0.20395,0 -0.35829,-0.0524 -0.15434,-0.0524 -0.23978,-0.11576 v -0.30592 q 0.10197,0.10197 0.27009,0.16536 0.16812,0.0606 0.34451,0.0606 0.23151,0 0.36381,-0.15159 0.13229,-0.15158 0.13229,-0.40514 0,-0.19844 -0.0965,-0.33349 -0.0937,-0.1378 -0.36104,-0.31143 -0.30593,-0.19293 -0.41893,-0.30868 -0.11024,-0.11576 -0.17363,-0.25907 -0.0606,-0.14332 -0.0606,-0.34176 0,-0.32246 0.21773,-0.53192 0.21773,-0.21222 0.55397,-0.21222 0.36105,0 0.60358,0.17088 l -0.13505,0.22875 q -0.226,-0.15158 -0.47955,-0.15158 -0.23151,0 -0.36932,0.1378 -0.1378,0.13505 -0.1378,0.35829 0,0.19844 0.0937,0.33349 0.0937,0.13229 0.39688,0.32246 0.29766,0.19568 0.4079,0.31419 0.11024,0.11576 0.16261,0.25907 0.0551,0.14056 0.0551,0.32522 z" />
+      </g>
+    </g>
+    <g
+       id="text9232"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.01202059px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       aria-label="add/modify/
+remove files">
+      <path
+         id="path1487"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 268.28691,403.04593 -0.0294,-0.37199 h -0.01 q -0.19089,0.42093 -0.57756,0.42093 -0.25941,0 -0.41848,-0.20557 -0.15663,-0.20802 -0.15663,-0.55553 0,-0.37933 0.2276,-0.59958 0.22759,-0.2227 0.63874,-0.24228 l 0.28633,-0.0147 v -0.22026 q 0,-0.37199 -0.093,-0.54085 -0.093,-0.17131 -0.30836,-0.17131 -0.22759,0 -0.46498,0.14929 l -0.10034,-0.18355 q 0.27655,-0.17131 0.58001,-0.17131 0.32793,0 0.47232,0.20802 0.14439,0.20557 0.14439,0.69013 v 1.80854 z m -0.56532,-0.14928 q 0.24962,0 0.38667,-0.24473 0.1395,-0.24718 0.1395,-0.69748 v -0.27654 l -0.27655,0.0147 q -0.32059,0.0171 -0.47721,0.17865 -0.15418,0.15907 -0.15418,0.46743 0,0.28877 0.10278,0.42337 0.10279,0.13461 0.27899,0.13461 z" />
+      <path
+         id="path1489"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 269.82625,403.09487 q -0.77334,0 -0.77334,-1.37292 0,-0.67545 0.19334,-1.02785 0.19333,-0.35486 0.57021,-0.35486 0.17865,0 0.33772,0.10279 0.16152,0.10278 0.25697,0.28388 h 0.0196 l -0.01,-0.29612 v -1.19182 h 0.23249 v 3.80796 h -0.19089 l -0.0196,-0.37199 h -0.022 q -0.0954,0.20313 -0.24718,0.31325 -0.15173,0.10768 -0.34751,0.10768 z m 0.0147,-0.20312 q 0.27899,0 0.42828,-0.25696 0.15173,-0.25941 0.15173,-0.76111 v -0.15173 q 0,-0.60203 -0.14684,-0.88102 -0.14439,-0.28143 -0.44296,-0.28143 -0.28633,0 -0.41114,0.30101 -0.12481,0.29857 -0.12481,0.86634 0,0.57266 0.12971,0.86878 0.1297,0.29612 0.41603,0.29612 z" />
+      <path
+         id="path1491"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 272.00922,403.09487 q -0.77334,0 -0.77334,-1.37292 0,-0.67545 0.19334,-1.02785 0.19333,-0.35486 0.57021,-0.35486 0.17865,0 0.33772,0.10279 0.16152,0.10278 0.25697,0.28388 h 0.0196 l -0.01,-0.29612 v -1.19182 h 0.23249 v 3.80796 h -0.19089 l -0.0196,-0.37199 h -0.022 q -0.0954,0.20313 -0.24718,0.31325 -0.15173,0.10768 -0.34751,0.10768 z m 0.0147,-0.20312 q 0.27899,0 0.42828,-0.25696 0.15173,-0.25941 0.15173,-0.76111 v -0.15173 q 0,-0.60203 -0.14684,-0.88102 -0.14439,-0.28143 -0.44296,-0.28143 -0.28633,0 -0.41114,0.30101 -0.12481,0.29857 -0.12481,0.86634 0,0.57266 0.12971,0.86878 0.1297,0.29612 0.41603,0.29612 z" />
+      <path
+         id="path1493"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 274.83827,399.46801 -1.27748,3.57792 h -0.24717 l 1.28971,-3.57792 z" />
+      <path
+         id="path1495"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 277.54251,403.04593 v -1.80854 q 0,-0.6681 -0.39156,-0.6681 -0.2692,0 -0.38912,0.23493 -0.11747,0.2325 -0.11747,0.68769 v 1.55402 h -0.23004 v -1.80854 q 0,-0.33772 -0.0954,-0.50169 -0.0954,-0.16641 -0.29612,-0.16641 -0.2643,0 -0.38422,0.23983 -0.11992,0.23983 -0.11992,0.77823 v 1.45858 h -0.23249 v -2.6553 h 0.19578 l 0.0196,0.36954 h 0.022 q 0.15907,-0.42093 0.54085,-0.42093 0.22025,0 0.34751,0.11747 0.12726,0.11747 0.18354,0.34262 0.0954,-0.24473 0.23494,-0.35241 0.1395,-0.10768 0.3622,-0.10768 0.30101,0 0.44051,0.23249 0.13949,0.23005 0.13949,0.73908 v 1.73512 z" />
+      <path
+         id="path1497"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 279.97265,401.71216 q 0,0.67056 -0.21291,1.02786 -0.21046,0.35485 -0.60448,0.35485 -0.38911,0 -0.59713,-0.35485 -0.20557,-0.3573 -0.20557,-1.02786 0,-1.37292 0.81249,-1.37292 0.38178,0 0.59469,0.35975 0.21291,0.35975 0.21291,1.01317 z m -1.37781,0 q 0,0.57511 0.13705,0.86879 0.13704,0.29367 0.42827,0.29367 0.57021,0 0.57021,-1.16246 0,-1.15266 -0.57021,-1.15266 -0.29857,0 -0.43317,0.28878 -0.13215,0.28877 -0.13215,0.86388 z" />
+      <path
+         id="path1499"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 281.21098,403.09487 q -0.77334,0 -0.77334,-1.37292 0,-0.67545 0.19333,-1.02785 0.19334,-0.35486 0.57022,-0.35486 0.17865,0 0.33772,0.10279 0.16152,0.10278 0.25696,0.28388 h 0.0196 l -0.01,-0.29612 v -1.19182 h 0.2325 v 3.80796 h -0.19089 l -0.0196,-0.37199 h -0.022 q -0.0954,0.20313 -0.24717,0.31325 -0.15173,0.10768 -0.34751,0.10768 z m 0.0147,-0.20312 q 0.27899,0 0.42827,-0.25696 0.15173,-0.25941 0.15173,-0.76111 v -0.15173 q 0,-0.60203 -0.14683,-0.88102 -0.14439,-0.28143 -0.44296,-0.28143 -0.28633,0 -0.41114,0.30101 -0.12481,0.29857 -0.12481,0.86634 0,0.57266 0.1297,0.86878 0.12971,0.29612 0.41604,0.29612 z" />
+      <path
+         id="path1501"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 282.97791,403.04593 h -0.23249 v -2.6553 h 0.23249 z m -0.26675,-3.39193 q 0,-0.11012 0.044,-0.1713 0.0465,-0.0612 0.11747,-0.0612 0.0661,0 0.10523,0.0612 0.0392,0.0612 0.0392,0.1713 0,0.10524 -0.0392,0.16887 -0.0392,0.0612 -0.10523,0.0612 -0.071,0 -0.11747,-0.0612 -0.044,-0.0636 -0.044,-0.16887 z" />
+      <path
+         id="path1503"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 284.36307,400.59621 h -0.41604 v 2.44972 h -0.23004 v -2.44972 h -0.33773 v -0.13216 l 0.33773,-0.10034 v -0.20067 q 0,-0.50659 0.11991,-0.72929 0.11992,-0.2227 0.41604,-0.2227 0.17131,0 0.3108,0.0612 l -0.0808,0.21536 q -0.1297,-0.0612 -0.23494,-0.0612 -0.11991,0 -0.18109,0.071 -0.0612,0.071 -0.0906,0.23004 -0.0294,0.15908 -0.0294,0.44051 v 0.2227 h 0.41604 z" />
+      <path
+         id="path1505"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 285.12417,403.04103 -0.66321,-2.6504 h 0.23494 l 0.40135,1.65681 q 0.071,0.29857 0.13705,0.673 h 0.0196 q 0.0465,-0.32549 0.12971,-0.67789 l 0.39156,-1.65192 h 0.23494 l -0.77578,3.15699 q -0.0857,0.34996 -0.22515,0.52616 -0.13705,0.17621 -0.36709,0.17621 -0.093,0 -0.21047,-0.0416 v -0.21046 q 0.0979,0.0343 0.19089,0.0343 0.14683,0 0.23249,-0.12726 0.0857,-0.12481 0.15173,-0.4038 z" />
+      <path
+         id="path1507"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 287.68157,399.46801 -1.27747,3.57792 h -0.24718 l 1.28971,-3.57792 z" />
+      <path
+         id="path1509"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 268.60261,406.60427 q 0.12481,0 0.23249,0.0343 l -0.0563,0.23249 q -0.0881,-0.0367 -0.1811,-0.0367 -0.1346,0 -0.25207,0.1395 -0.11502,0.13704 -0.1811,0.38422 -0.0661,0.24717 -0.0661,0.54574 v 1.40718 h -0.23249 v -2.65529 h 0.19089 l 0.0245,0.46498 h 0.0171 q 0.186,-0.51637 0.50414,-0.51637 z" />
+      <path
+         id="path1511"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 269.99022,409.3599 q -0.42093,0 -0.64853,-0.3573 -0.22515,-0.35975 -0.22515,-1.00094 0,-0.68034 0.20068,-1.03764 0.20312,-0.35975 0.58245,-0.35975 0.33038,0 0.52127,0.3157 0.19089,0.31325 0.19089,0.84675 v 0.21536 h -1.2579 q 0.005,0.58001 0.16396,0.86879 0.15908,0.28878 0.48212,0.28878 0.24962,0 0.52616,-0.16397 v 0.22515 q -0.25452,0.15907 -0.53595,0.15907 z m -0.10524,-2.54517 q -0.47966,0 -0.52616,0.95689 h 1.02051 q 0,-0.43806 -0.1346,-0.69748 -0.13215,-0.25941 -0.35975,-0.25941 z" />
+      <path
+         id="path1513"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 273.46045,409.31095 v -1.80853 q 0,-0.66811 -0.39156,-0.66811 -0.2692,0 -0.38912,0.23494 -0.11747,0.23249 -0.11747,0.68768 v 1.55402 h -0.23004 v -1.80853 q 0,-0.33773 -0.0954,-0.50169 -0.0955,-0.16642 -0.29612,-0.16642 -0.26431,0 -0.38423,0.23983 -0.11991,0.23984 -0.11991,0.77824 v 1.45857 h -0.23249 v -2.65529 h 0.19578 l 0.0196,0.36954 h 0.022 q 0.15907,-0.42093 0.54085,-0.42093 0.22025,0 0.34751,0.11747 0.12726,0.11747 0.18355,0.34262 0.0954,-0.24473 0.23494,-0.35241 0.13949,-0.10768 0.36219,-0.10768 0.30102,0 0.44051,0.23249 0.1395,0.23004 0.1395,0.73908 v 1.73511 z" />
+      <path
+         id="path1515"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 275.8906,407.97719 q 0,0.67055 -0.21291,1.02786 -0.21047,0.35485 -0.60448,0.35485 -0.38912,0 -0.59714,-0.35485 -0.20557,-0.35731 -0.20557,-1.02786 0,-1.37292 0.8125,-1.37292 0.38177,0 0.59469,0.35975 0.21291,0.35975 0.21291,1.01317 z m -1.37782,0 q 0,0.57511 0.13705,0.86878 0.13705,0.29368 0.42827,0.29368 0.57022,0 0.57022,-1.16246 0,-1.15267 -0.57022,-1.15267 -0.29856,0 -0.43316,0.28878 -0.13216,0.28878 -0.13216,0.86389 z" />
+      <path
+         id="path1517"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 276.77651,409.31095 -0.6265,-2.65529 h 0.23494 l 0.39646,1.7082 q 0.0685,0.29612 0.13215,0.64608 h 0.0196 q 0.0171,-0.12726 0.0489,-0.28388 0.0318,-0.15663 0.48212,-2.0704 h 0.23494 l -0.64609,2.65529 z" />
+      <path
+         id="path1519"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 278.82978,409.3599 q -0.42093,0 -0.64853,-0.3573 -0.22515,-0.35975 -0.22515,-1.00094 0,-0.68034 0.20068,-1.03764 0.20312,-0.35975 0.58245,-0.35975 0.33038,0 0.52127,0.3157 0.19089,0.31325 0.19089,0.84675 v 0.21536 h -1.2579 q 0.005,0.58001 0.16396,0.86879 0.15908,0.28878 0.48212,0.28878 0.24962,0 0.52616,-0.16397 v 0.22515 q -0.25452,0.15907 -0.53595,0.15907 z m -0.10524,-2.54517 q -0.47966,0 -0.52616,0.95689 h 1.02051 q 0,-0.43806 -0.1346,-0.69748 -0.13215,-0.25941 -0.35975,-0.25941 z" />
+      <path
+         id="path1521"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 281.66127,406.86123 h -0.41603 v 2.44972 h -0.23005 v -2.44972 h -0.33772 v -0.13215 l 0.33772,-0.10034 v -0.20068 q 0,-0.50658 0.11992,-0.72928 0.11992,-0.22271 0.41604,-0.22271 0.17131,0 0.3108,0.0612 l -0.0808,0.21536 q -0.1297,-0.0612 -0.23494,-0.0612 -0.11991,0 -0.1811,0.071 -0.0612,0.071 -0.0906,0.23005 -0.0294,0.15907 -0.0294,0.44051 v 0.2227 h 0.41603 z m 0.66322,2.44972 H 282.092 v -2.65529 h 0.23249 z m -0.26676,-3.39192 q 0,-0.11013 0.0441,-0.17131 0.0465,-0.0612 0.11747,-0.0612 0.0661,0 0.10524,0.0612 0.0391,0.0612 0.0391,0.17131 0,0.10523 -0.0391,0.16886 -0.0392,0.0612 -0.10524,0.0612 -0.071,0 -0.11747,-0.0612 -0.0441,-0.0636 -0.0441,-0.16886 z" />
+      <path
+         id="path1523"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 283.27158,409.31095 h -0.23249 v -3.80796 h 0.23249 z" />
+      <path
+         id="path1525"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 284.73261,409.3599 q -0.42094,0 -0.64853,-0.3573 -0.22515,-0.35975 -0.22515,-1.00094 0,-0.68034 0.20068,-1.03764 0.20312,-0.35975 0.58245,-0.35975 0.33038,0 0.52127,0.3157 0.19088,0.31325 0.19088,0.84675 v 0.21536 h -1.2579 q 0.005,0.58001 0.16397,0.86879 0.15908,0.28878 0.48212,0.28878 0.24962,0 0.52616,-0.16397 v 0.22515 q -0.25452,0.15907 -0.53595,0.15907 z m -0.10524,-2.54517 q -0.47966,0 -0.52616,0.95689 h 1.02051 q 0,-0.43806 -0.1346,-0.69748 -0.13215,-0.25941 -0.35975,-0.25941 z" />
+      <path
+         id="path1527"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         d="m 286.98899,408.6453 q 0,0.33527 -0.1762,0.52616 -0.1762,0.18844 -0.50903,0.18844 -0.1811,0 -0.31815,-0.0465 -0.13705,-0.0465 -0.21291,-0.10278 v -0.27165 q 0.0906,0.0906 0.23983,0.14684 0.14929,0.0538 0.30591,0.0538 0.20557,0 0.32304,-0.1346 0.11747,-0.1346 0.11747,-0.35975 0,-0.17621 -0.0857,-0.29612 -0.0832,-0.12237 -0.3206,-0.27655 -0.27165,-0.17131 -0.37198,-0.27409 -0.0979,-0.10279 -0.15418,-0.23005 -0.0538,-0.12725 -0.0538,-0.30346 0,-0.28633 0.19333,-0.47232 0.19334,-0.18844 0.49191,-0.18844 0.32059,0 0.53595,0.15173 l -0.11992,0.20312 q -0.20067,-0.1346 -0.42582,-0.1346 -0.20557,0 -0.32794,0.12237 -0.12236,0.11991 -0.12236,0.31814 0,0.17621 0.0832,0.29612 0.0832,0.11747 0.35241,0.28633 0.26431,0.17376 0.3622,0.27899 0.0979,0.10279 0.14439,0.23005 0.0489,0.12481 0.0489,0.28878 z" />
+    </g>
+    <g
+       id="text9236"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       aria-label="{...}">
+      <path
+         id="path1530"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26850107"
+         d="m 292.17947,416.67555 q -0.32899,0 -0.52433,0.10281 -0.19534,0.10024 -0.17221,0.33157 l 0.11566,1.14376 q 0.008,0.0694 0.008,0.12852 0,0.22361 -0.0977,0.34698 -0.0951,0.12081 -0.29558,0.16193 0.20305,0.0385 0.29815,0.15165 0.0951,0.11309 0.0951,0.34184 0,0.0668 -0.008,0.14394 l -0.11566,1.14377 q -0.003,0.0154 -0.003,0.0463 0,0.20819 0.1902,0.29815 0.19277,0.09 0.50891,0.09 v 0.27245 q -0.4061,0 -0.70168,-0.15165 -0.29301,-0.14907 -0.29301,-0.51405 0,-0.0257 0.005,-0.0925 l 0.11309,-1.04867 q 0.008,-0.0617 0.008,-0.1208 0,-0.14394 -0.0668,-0.23647 -0.0643,-0.0951 -0.2416,-0.1465 -0.17478,-0.0514 -0.49863,-0.0514 v -0.25188 q 0.32385,0 0.49863,-0.0488 0.17735,-0.0514 0.2416,-0.14393 0.0668,-0.0925 0.0668,-0.23647 0,-0.0565 -0.008,-0.1208 l -0.11309,-1.05638 q -0.005,-0.0617 -0.005,-0.09 0,-0.36241 0.29301,-0.51405 0.29301,-0.15165 0.70168,-0.15165 z" />
+      <path
+         id="path1532"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26850107"
+         d="m 297.17638,420.32019 q 0,-0.11309 0.054,-0.20819 0.054,-0.0951 0.14907,-0.14908 0.0925,-0.054 0.20819,-0.054 0.12081,0 0.21848,0.054 0.0951,0.054 0.14907,0.14908 0.054,0.0925 0.054,0.20819 0,0.11823 -0.054,0.2159 -0.054,0.0951 -0.14907,0.15165 -0.0977,0.054 -0.21848,0.054 -0.11566,0 -0.20819,-0.054 -0.0951,-0.0566 -0.14907,-0.15165 -0.054,-0.0977 -0.054,-0.2159 z m 2.05622,0 q 0,-0.11309 0.054,-0.20819 0.054,-0.0951 0.14651,-0.14908 0.0951,-0.054 0.21076,-0.054 0.1208,0 0.2159,0.054 0.0977,0.054 0.15165,0.14908 0.054,0.0925 0.054,0.20819 0,0.11823 -0.054,0.2159 -0.054,0.0951 -0.15165,0.15165 -0.0951,0.054 -0.2159,0.054 -0.11566,0 -0.21076,-0.054 -0.0925,-0.0566 -0.14651,-0.15165 -0.054,-0.0977 -0.054,-0.2159 z m -4.11243,0 q 0,-0.11309 0.054,-0.20819 0.054,-0.0951 0.14908,-0.14908 0.0925,-0.054 0.20819,-0.054 0.1208,0 0.21847,0.054 0.0951,0.054 0.14908,0.14908 0.054,0.0925 0.054,0.20819 0,0.11823 -0.054,0.2159 -0.054,0.0951 -0.14908,0.15165 -0.0977,0.054 -0.21847,0.054 -0.11566,0 -0.20819,-0.054 -0.0951,-0.0566 -0.14908,-0.15165 -0.054,-0.0977 -0.054,-0.2159 z" />
+      <path
+         id="path1534"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26850107"
+         d="m 303.00242,416.4031 q 0.40611,0 0.69912,0.15165 0.29558,0.14907 0.29558,0.51405 0,0.0257 -0.005,0.0925 l -0.11309,1.05381 q -0.005,0.0617 -0.005,0.09 0,0.15165 0.072,0.25189 0.0745,0.10024 0.24932,0.15421 0.17735,0.054 0.48321,0.054 v 0.25188 q -0.44723,0 -0.62715,0.11824 -0.17735,0.11823 -0.17735,0.34698 0,0.0283 0.005,0.09 l 0.11309,1.05124 q 0.005,0.0617 0.005,0.09 0,0.36241 -0.29301,0.51405 -0.29301,0.15165 -0.70169,0.15165 v -0.27245 q 0.33414,0 0.52691,-0.10024 0.19277,-0.10024 0.16964,-0.33413 l -0.11567,-1.14377 q -0.008,-0.0822 -0.008,-0.14908 0,-0.23132 0.10538,-0.3367 0.10539,-0.10795 0.36241,-0.14394 -0.24417,-0.0437 -0.35469,-0.16964 -0.11053,-0.12594 -0.11053,-0.35726 0,-0.0771 0.005,-0.11824 l 0.11567,-1.14376 q 0.003,-0.0154 0.003,-0.0437 0,-0.20819 -0.19277,-0.29815 -0.1902,-0.0925 -0.50635,-0.0925 z" />
+    </g>
+    <g
+       id="text9240"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       aria-label="{...}">
+      <path
+         id="path1537"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26850107"
+         d="m 324.1311,416.67555 q -0.32899,0 -0.52433,0.10281 -0.19534,0.10024 -0.17221,0.33157 l 0.11566,1.14376 q 0.008,0.0694 0.008,0.12852 0,0.22361 -0.0977,0.34698 -0.0951,0.12081 -0.29558,0.16193 0.20305,0.0385 0.29815,0.15165 0.0951,0.11309 0.0951,0.34184 0,0.0668 -0.008,0.14394 l -0.11566,1.14377 q -0.003,0.0154 -0.003,0.0463 0,0.20819 0.1902,0.29815 0.19277,0.09 0.50891,0.09 v 0.27245 q -0.4061,0 -0.70168,-0.15165 -0.29301,-0.14907 -0.29301,-0.51405 0,-0.0257 0.005,-0.0925 l 0.11309,-1.04867 q 0.008,-0.0617 0.008,-0.1208 0,-0.14394 -0.0668,-0.23647 -0.0643,-0.0951 -0.2416,-0.1465 -0.17478,-0.0514 -0.49863,-0.0514 v -0.25188 q 0.32385,0 0.49863,-0.0488 0.17735,-0.0514 0.2416,-0.14393 0.0668,-0.0925 0.0668,-0.23647 0,-0.0565 -0.008,-0.1208 l -0.11309,-1.05638 q -0.005,-0.0617 -0.005,-0.09 0,-0.36241 0.29301,-0.51405 0.29301,-0.15165 0.70168,-0.15165 z" />
+      <path
+         id="path1539"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26850107"
+         d="m 329.12801,420.32019 q 0,-0.11309 0.054,-0.20819 0.054,-0.0951 0.14907,-0.14908 0.0925,-0.054 0.20819,-0.054 0.12081,0 0.21848,0.054 0.0951,0.054 0.14907,0.14908 0.054,0.0925 0.054,0.20819 0,0.11823 -0.054,0.2159 -0.054,0.0951 -0.14907,0.15165 -0.0977,0.054 -0.21848,0.054 -0.11566,0 -0.20819,-0.054 -0.0951,-0.0566 -0.14907,-0.15165 -0.054,-0.0977 -0.054,-0.2159 z m 2.05621,0 q 0,-0.11309 0.054,-0.20819 0.054,-0.0951 0.14651,-0.14908 0.0951,-0.054 0.21076,-0.054 0.1208,0 0.2159,0.054 0.0977,0.054 0.15165,0.14908 0.054,0.0925 0.054,0.20819 0,0.11823 -0.054,0.2159 -0.054,0.0951 -0.15165,0.15165 -0.0951,0.054 -0.2159,0.054 -0.11566,0 -0.21076,-0.054 -0.0925,-0.0566 -0.14651,-0.15165 -0.054,-0.0977 -0.054,-0.2159 z m -4.11242,0 q 0,-0.11309 0.054,-0.20819 0.054,-0.0951 0.14908,-0.14908 0.0925,-0.054 0.20819,-0.054 0.1208,0 0.21847,0.054 0.0951,0.054 0.14908,0.14908 0.054,0.0925 0.054,0.20819 0,0.11823 -0.054,0.2159 -0.054,0.0951 -0.14908,0.15165 -0.0977,0.054 -0.21847,0.054 -0.11566,0 -0.20819,-0.054 -0.0951,-0.0566 -0.14908,-0.15165 -0.054,-0.0977 -0.054,-0.2159 z" />
+      <path
+         id="path1541"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26850107"
+         d="m 334.95405,416.4031 q 0.40611,0 0.69912,0.15165 0.29558,0.14907 0.29558,0.51405 0,0.0257 -0.005,0.0925 l -0.1131,1.05381 q -0.005,0.0617 -0.005,0.09 0,0.15165 0.072,0.25189 0.0745,0.10024 0.24932,0.15421 0.17735,0.054 0.48321,0.054 v 0.25188 q -0.44723,0 -0.62715,0.11824 -0.17735,0.11823 -0.17735,0.34698 0,0.0283 0.005,0.09 l 0.1131,1.05124 q 0.005,0.0617 0.005,0.09 0,0.36241 -0.29301,0.51405 -0.29301,0.15165 -0.70169,0.15165 v -0.27245 q 0.33414,0 0.52691,-0.10024 0.19277,-0.10024 0.16964,-0.33413 l -0.11567,-1.14377 q -0.008,-0.0822 -0.008,-0.14908 0,-0.23132 0.10538,-0.3367 0.10539,-0.10795 0.36241,-0.14394 -0.24417,-0.0437 -0.3547,-0.16964 -0.11052,-0.12594 -0.11052,-0.35726 0,-0.0771 0.005,-0.11824 l 0.11567,-1.14376 q 0.003,-0.0154 0.003,-0.0437 0,-0.20819 -0.19277,-0.29815 -0.1902,-0.0925 -0.50635,-0.0925 z" />
+    </g>
+    <g
+       id="text9244"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.01202059px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3b82f6;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       aria-label="read/modify
+options">
+      <path
+         id="path1544"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 321.64434,394.2021 q 0.12481,0 0.23249,0.0343 l -0.0563,0.23249 q -0.0881,-0.0367 -0.18109,-0.0367 -0.1346,0 -0.25207,0.13949 -0.11502,0.13705 -0.1811,0.38423 -0.0661,0.24717 -0.0661,0.54574 v 1.40718 h -0.23249 v -2.65529 h 0.19089 l 0.0245,0.46498 h 0.0171 q 0.186,-0.51637 0.50414,-0.51637 z" />
+      <path
+         id="path1546"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 323.03195,396.95773 q -0.42094,0 -0.64853,-0.3573 -0.22515,-0.35975 -0.22515,-1.00094 0,-0.68034 0.20068,-1.03764 0.20312,-0.35975 0.58245,-0.35975 0.33038,0 0.52127,0.31569 0.19088,0.31326 0.19088,0.84676 v 0.21536 h -1.2579 q 0.005,0.58001 0.16397,0.86879 0.15907,0.28877 0.48212,0.28877 0.24962,0 0.52616,-0.16396 v 0.22515 q -0.25452,0.15907 -0.53595,0.15907 z m -0.10524,-2.54517 q -0.47966,0 -0.52616,0.95689 h 1.02051 q 0,-0.43807 -0.1346,-0.69748 -0.13215,-0.25941 -0.35975,-0.25941 z" />
+      <path
+         id="path1548"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 325.27365,396.90878 -0.0294,-0.37198 h -0.01 q -0.19088,0.42093 -0.57755,0.42093 -0.25941,0 -0.41849,-0.20557 -0.15662,-0.20802 -0.15662,-0.55553 0,-0.37933 0.22759,-0.59959 0.2276,-0.2227 0.63874,-0.24228 l 0.28633,-0.0147 v -0.22026 q 0,-0.37198 -0.093,-0.54084 -0.093,-0.17131 -0.30836,-0.17131 -0.2276,0 -0.46498,0.14928 l -0.10034,-0.18354 q 0.27654,-0.17131 0.58,-0.17131 0.32794,0 0.47233,0.20801 0.14439,0.20558 0.14439,0.69014 v 1.80853 z m -0.56532,-0.14928 q 0.24962,0 0.38667,-0.24473 0.13949,-0.24717 0.13949,-0.69747 v -0.27654 l -0.27654,0.0147 q -0.32059,0.0171 -0.47722,0.17865 -0.15417,0.15907 -0.15417,0.46743 0,0.28878 0.10278,0.42338 0.10279,0.1346 0.27899,0.1346 z" />
+      <path
+         id="path1550"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 326.81299,396.95773 q -0.77334,0 -0.77334,-1.37292 0,-0.67545 0.19333,-1.02786 0.19334,-0.35485 0.57022,-0.35485 0.17865,0 0.33772,0.10278 0.16152,0.10279 0.25697,0.28389 h 0.0196 l -0.01,-0.29612 v -1.19183 h 0.23249 v 3.80796 h -0.19089 l -0.0196,-0.37198 h -0.022 q -0.0955,0.20312 -0.24718,0.31325 -0.15173,0.10768 -0.34751,0.10768 z m 0.0147,-0.20313 q 0.27899,0 0.42827,-0.25696 0.15174,-0.25941 0.15174,-0.7611 v -0.15173 q 0,-0.60203 -0.14684,-0.88102 -0.14439,-0.28144 -0.44296,-0.28144 -0.28633,0 -0.41114,0.30102 -0.12481,0.29856 -0.12481,0.86633 0,0.57266 0.1297,0.86878 0.12971,0.29612 0.41604,0.29612 z" />
+      <path
+         id="path1552"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 329.64204,393.33087 -1.27748,3.57791 h -0.24718 l 1.28972,-3.57791 z" />
+      <path
+         id="path1554"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 332.34628,396.90878 v -1.80853 q 0,-0.66811 -0.39157,-0.66811 -0.2692,0 -0.38911,0.23494 -0.11747,0.23249 -0.11747,0.68768 v 1.55402 h -0.23005 v -1.80853 q 0,-0.33773 -0.0954,-0.5017 -0.0954,-0.16641 -0.29612,-0.16641 -0.26431,0 -0.38422,0.23983 -0.11992,0.23984 -0.11992,0.77824 v 1.45857 h -0.23249 v -2.65529 h 0.19578 l 0.0196,0.36954 h 0.022 q 0.15907,-0.42093 0.54084,-0.42093 0.22026,0 0.34752,0.11747 0.12725,0.11746 0.18354,0.34261 0.0954,-0.24472 0.23494,-0.3524 0.1395,-0.10768 0.3622,-0.10768 0.30101,0 0.44051,0.23249 0.13949,0.23004 0.13949,0.73907 v 1.73512 z" />
+      <path
+         id="path1556"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 334.77642,395.57502 q 0,0.67055 -0.21291,1.02785 -0.21047,0.35486 -0.60448,0.35486 -0.38911,0 -0.59713,-0.35486 -0.20557,-0.3573 -0.20557,-1.02785 0,-1.37292 0.81249,-1.37292 0.38178,0 0.59469,0.35975 0.21291,0.35975 0.21291,1.01317 z m -1.37781,0 q 0,0.57511 0.13704,0.86878 0.13705,0.29367 0.42828,0.29367 0.57021,0 0.57021,-1.16245 0,-1.15267 -0.57021,-1.15267 -0.29857,0 -0.43317,0.28878 -0.13215,0.28878 -0.13215,0.86389 z" />
+      <path
+         id="path1558"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 336.01474,396.95773 q -0.77334,0 -0.77334,-1.37292 0,-0.67545 0.19334,-1.02786 0.19333,-0.35485 0.57021,-0.35485 0.17866,0 0.33773,0.10278 0.16152,0.10279 0.25696,0.28389 h 0.0196 l -0.01,-0.29612 v -1.19183 h 0.23249 v 3.80796 h -0.19088 l -0.0196,-0.37198 h -0.022 q -0.0954,0.20312 -0.24717,0.31325 -0.15173,0.10768 -0.34752,0.10768 z m 0.0147,-0.20313 q 0.27899,0 0.42827,-0.25696 0.15173,-0.25941 0.15173,-0.7611 v -0.15173 q 0,-0.60203 -0.14683,-0.88102 -0.14439,-0.28144 -0.44296,-0.28144 -0.28633,0 -0.41114,0.30102 -0.12482,0.29856 -0.12482,0.86633 0,0.57266 0.12971,0.86878 0.12971,0.29612 0.41604,0.29612 z" />
+      <path
+         id="path1560"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 337.78168,396.90878 h -0.2325 v -2.65529 h 0.2325 z m -0.26676,-3.39192 q 0,-0.11013 0.044,-0.17131 0.0465,-0.0612 0.11747,-0.0612 0.0661,0 0.10524,0.0612 0.0392,0.0612 0.0392,0.17131 0,0.10523 -0.0392,0.16886 -0.0392,0.0612 -0.10524,0.0612 -0.071,0 -0.11747,-0.0612 -0.044,-0.0636 -0.044,-0.16886 z" />
+      <path
+         id="path1562"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 339.16683,394.45906 h -0.41603 v 2.44972 h -0.23005 v -2.44972 h -0.33772 v -0.13215 l 0.33772,-0.10034 v -0.20068 q 0,-0.50658 0.11992,-0.72929 0.11992,-0.2227 0.41604,-0.2227 0.17131,0 0.3108,0.0612 l -0.0808,0.21536 q -0.1297,-0.0612 -0.23494,-0.0612 -0.11991,0 -0.1811,0.071 -0.0612,0.071 -0.0905,0.23005 -0.0294,0.15907 -0.0294,0.44051 v 0.2227 h 0.41603 z" />
+      <path
+         id="path1564"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 339.92794,396.90389 -0.66321,-2.6504 h 0.23493 l 0.40136,1.6568 q 0.071,0.29857 0.13704,0.67301 h 0.0196 q 0.0465,-0.32549 0.12971,-0.6779 l 0.39156,-1.65191 h 0.23494 l -0.77579,3.15698 q -0.0856,0.34996 -0.22514,0.52617 -0.13705,0.1762 -0.3671,0.1762 -0.093,0 -0.21046,-0.0416 v -0.21047 q 0.0979,0.0343 0.19089,0.0343 0.14683,0 0.23249,-0.12726 0.0856,-0.12481 0.15173,-0.4038 z" />
+      <path
+         id="path1566"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 326.49484,401.84004 q 0,0.67056 -0.21291,1.02786 -0.21047,0.35485 -0.60448,0.35485 -0.38912,0 -0.59713,-0.35485 -0.20558,-0.3573 -0.20558,-1.02786 0,-1.37292 0.8125,-1.37292 0.38178,0 0.59469,0.35975 0.21291,0.35975 0.21291,1.01317 z m -1.37781,0 q 0,0.57511 0.13704,0.86879 0.13705,0.29367 0.42828,0.29367 0.57021,0 0.57021,-1.16246 0,-1.15266 -0.57021,-1.15266 -0.29857,0 -0.43317,0.28878 -0.13215,0.28877 -0.13215,0.86388 z" />
+      <path
+         id="path1569"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 327.93873,403.22275 q -0.20067,0 -0.36709,-0.11012 -0.16396,-0.11258 -0.24962,-0.30591 H 327.3 l 0.0171,0.29122 v 1.27993 h -0.2325 v -3.85936 h 0.19089 l 0.0245,0.36465 h 0.022 q 0.0979,-0.20068 0.24962,-0.30836 0.15418,-0.10768 0.33528,-0.10768 0.77823,0 0.77823,1.37292 0,0.66322 -0.19088,1.02296 -0.19089,0.35975 -0.55554,0.35975 z m -0.0465,-2.53537 q -0.29123,0 -0.43317,0.25696 -0.14194,0.25696 -0.14194,0.80515 v 0.0759 q 0,0.61182 0.14439,0.9006 0.14438,0.28633 0.4405,0.28633 0.2741,0 0.40625,-0.28389 0.1346,-0.28633 0.1346,-0.88836 0,-0.57511 -0.12481,-0.86388 -0.12481,-0.28878 -0.42582,-0.28878 z" />
+      <path
+         id="path1571"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 329.75461,403.00739 q 0.10768,0 0.19089,-0.0294 v 0.19578 q -0.10768,0.0489 -0.27654,0.0489 -0.41114,0 -0.41114,-0.61426 v -1.8844 h -0.23984 v -0.13705 l 0.23494,-0.0685 0.0759,-0.63139 h 0.16152 v 0.63139 h 0.42093 v 0.20558 h -0.42093 v 1.81832 q 0,0.2692 0.0587,0.36709 0.0587,0.0979 0.20557,0.0979 z" />
+      <path
+         id="path1573"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 330.59648,403.17381 h -0.2325 v -2.6553 h 0.2325 z m -0.26676,-3.39193 q 0,-0.11012 0.044,-0.1713 0.0465,-0.0612 0.11747,-0.0612 0.0661,0 0.10524,0.0612 0.0392,0.0612 0.0392,0.1713 0,0.10524 -0.0392,0.16887 -0.0392,0.0612 -0.10524,0.0612 -0.071,0 -0.11747,-0.0612 -0.044,-0.0636 -0.044,-0.16887 z" />
+      <path
+         id="path1575"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 332.79902,401.84004 q 0,0.67056 -0.21291,1.02786 -0.21047,0.35485 -0.60448,0.35485 -0.38911,0 -0.59713,-0.35485 -0.20557,-0.3573 -0.20557,-1.02786 0,-1.37292 0.81249,-1.37292 0.38178,0 0.59469,0.35975 0.21291,0.35975 0.21291,1.01317 z m -1.37781,0 q 0,0.57511 0.13704,0.86879 0.13705,0.29367 0.42828,0.29367 0.57021,0 0.57021,-1.16246 0,-1.15266 -0.57021,-1.15266 -0.29857,0 -0.43317,0.28878 -0.13215,0.28877 -0.13215,0.86388 z" />
+      <path
+         id="path1577"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 334.58798,403.17381 v -1.83056 q 0,-0.66077 -0.39156,-0.66077 -0.29857,0 -0.43806,0.24718 -0.13705,0.24717 -0.13705,0.78557 v 1.45858 h -0.23249 v -2.6553 h 0.19578 l 0.0196,0.36954 h 0.022 q 0.0832,-0.20067 0.23984,-0.3108 0.15662,-0.11013 0.33527,-0.11013 0.30836,0 0.46254,0.20802 0.15418,0.20557 0.15418,0.66321 v 1.83546 z" />
+      <path
+         id="path1579"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         d="m 336.56538,402.50815 q 0,0.33528 -0.1762,0.52616 -0.17621,0.18844 -0.50904,0.18844 -0.18109,0 -0.31814,-0.0465 -0.13705,-0.0465 -0.21291,-0.10279 v -0.27165 q 0.0905,0.0906 0.23983,0.14684 0.14928,0.0538 0.30591,0.0538 0.20557,0 0.32304,-0.1346 0.11747,-0.1346 0.11747,-0.35975 0,-0.1762 -0.0857,-0.29612 -0.0832,-0.12236 -0.32059,-0.27654 -0.27165,-0.17131 -0.37199,-0.2741 -0.0979,-0.10278 -0.15417,-0.23004 -0.0538,-0.12726 -0.0538,-0.30346 0,-0.28634 0.19333,-0.47233 0.19333,-0.18844 0.4919,-0.18844 0.3206,0 0.53596,0.15173 l -0.11992,0.20313 q -0.20068,-0.1346 -0.42583,-0.1346 -0.20557,0 -0.32793,0.12236 -0.12237,0.11992 -0.12237,0.31815 0,0.1762 0.0832,0.29612 0.0832,0.11747 0.35241,0.28633 0.26431,0.17375 0.3622,0.27899 0.0979,0.10278 0.14439,0.23004 0.0489,0.12481 0.0489,0.28878 z" />
+    </g>
+    <path
+       style="fill:none;stroke:#10b981;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker9280)"
+       d="m 283.25774,383.34553 c -1.52563,11.27587 14.33318,24.64852 14.52331,30.3912"
+       id="path9276" />
+    <g
+       id="g7649"
+       transform="matrix(1.0148073,0,0,1.0148073,70.364914,91.279991)">
+      <path
+         id="path7645"
+         d="m 209.78646,282.06996 v 5.73399"
+         style="fill:none;stroke:#10b981;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1570)" />
+      <path
+         style="fill:none;stroke:#3b82f6;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2134)"
+         d="m 240.78051,282.06996 v 5.73399"
+         id="path7647" />
+    </g>
+    <path
+       id="path10146"
+       d="m 314.71073,383.34553 c -1.52564,11.27587 14.33317,24.64852 14.52331,30.3912"
+       style="fill:none;stroke:#3b82f6;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker10150)" />
+    <path
+       id="path10470"
+       d="m 297.42569,422.80345 c -1.52564,11.27587 -14.35809,5.62878 -14.16795,11.37145"
+       style="fill:none;stroke:#10b981;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker10474)" />
+    <path
+       id="rect11226"
+       d="m 287.26555,411.84851 h 53.47127 c 1.30651,0 2.35832,1.05181 2.35832,2.35832 v 8.54667 c 0,1.30651 -1.05181,2.35832 -2.35832,2.35832 h -53.47127 c -1.30651,0 -2.35832,-1.05181 -2.35832,-2.35832 v -8.54667 c 0,-1.30651 1.05181,-2.35832 2.35832,-2.35832 z"
+       style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#be185d;stroke-width:0.57456082;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.57456083, 0.57456083;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" />
+    <path
+       style="fill:none;stroke:#3b82f6;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker11008)"
+       d="m 328.87867,422.80345 c -1.52563,11.27587 -14.35808,5.62878 -14.16794,11.37145"
+       id="path11004" />
+    <path
+       style="fill:none;stroke:#be185d;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker11255)"
+       d="m 284.61518,419.00309 c -6.42812,-0.12527 -53.4191,1.47554 -52.65523,18.70696"
+       id="path11251" />
+    <g
+       id="text11825"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.72802353px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#be185d;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       aria-label="Possible side-effects
+(e.g. write file to disk)">
+      <path
+         id="path1583"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 213.74493,444.2787 q 0,0.63209 -0.29088,0.92856 -0.28808,0.29647 -0.85584,0.29647 h -0.29088 v 1.68932 h -0.27409 v -4.08904 h 0.55937 q 0.59854,0 0.87543,0.28248 0.27689,0.28249 0.27689,0.89221 z m -1.4376,0.97331 h 0.2741 q 0.48106,0 0.68244,-0.22654 0.20137,-0.22655 0.20137,-0.74677 0,-0.49505 -0.20977,-0.70761 -0.20696,-0.21536 -0.64328,-0.21536 h -0.30486 z" />
+      <path
+         id="path1585"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 216.04956,445.66875 q 0,0.76635 -0.24332,1.17469 -0.24054,0.40555 -0.69084,0.40555 -0.4447,0 -0.68244,-0.40555 -0.23493,-0.40834 -0.23493,-1.17469 0,-1.56905 0.92856,-1.56905 0.43632,0 0.67965,0.41114 0.24332,0.41114 0.24332,1.15791 z m -1.57464,0 q 0,0.65727 0.15662,0.9929 0.15663,0.33562 0.48946,0.33562 0.65167,0 0.65167,-1.32852 0,-1.31733 -0.65167,-1.31733 -0.34122,0 -0.49505,0.33003 -0.15103,0.33003 -0.15103,0.9873 z" />
+      <path
+         id="path1587"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 217.91509,446.4323 q 0,0.38317 -0.20138,0.60133 -0.20137,0.21536 -0.58175,0.21536 -0.20697,0 -0.3636,-0.0531 -0.15662,-0.0531 -0.24333,-0.11747 v -0.31045 q 0.10349,0.10348 0.2741,0.16781 0.17061,0.0615 0.34961,0.0615 0.23494,0 0.36919,-0.15383 0.13425,-0.15383 0.13425,-0.41114 0,-0.20137 -0.0979,-0.33842 -0.0951,-0.13985 -0.36639,-0.31605 -0.31046,-0.19578 -0.42513,-0.31325 -0.11188,-0.11747 -0.1762,-0.26291 -0.0615,-0.14544 -0.0615,-0.34681 0,-0.32724 0.22096,-0.5398 0.22095,-0.21536 0.56217,-0.21536 0.3664,0 0.61252,0.1734 l -0.13705,0.23215 q -0.22934,-0.15383 -0.48665,-0.15383 -0.23494,0 -0.37479,0.13984 -0.13984,0.13705 -0.13984,0.3636 0,0.20137 0.0951,0.33842 0.0951,0.13425 0.40275,0.32724 0.30207,0.19858 0.41394,0.31884 0.11188,0.11747 0.16502,0.26291 0.0559,0.14264 0.0559,0.33003 z" />
+      <path
+         id="path1589"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 219.71628,446.4323 q 0,0.38317 -0.20137,0.60133 -0.20138,0.21536 -0.58176,0.21536 -0.20697,0 -0.36359,-0.0531 -0.15663,-0.0531 -0.24333,-0.11747 v -0.31045 q 0.10348,0.10348 0.27409,0.16781 0.17061,0.0615 0.34962,0.0615 0.23493,0 0.36918,-0.15383 0.13425,-0.15383 0.13425,-0.41114 0,-0.20137 -0.0979,-0.33842 -0.0951,-0.13985 -0.36639,-0.31605 -0.31045,-0.19578 -0.42513,-0.31325 -0.11187,-0.11747 -0.1762,-0.26291 -0.0615,-0.14544 -0.0615,-0.34681 0,-0.32724 0.22095,-0.5398 0.22096,-0.21536 0.56218,-0.21536 0.36639,0 0.61252,0.1734 l -0.13705,0.23215 q -0.22935,-0.15383 -0.48666,-0.15383 -0.23494,0 -0.37478,0.13984 -0.13985,0.13705 -0.13985,0.3636 0,0.20137 0.0951,0.33842 0.0951,0.13425 0.40275,0.32724 0.30206,0.19858 0.41394,0.31884 0.11187,0.11747 0.16501,0.26291 0.0559,0.14264 0.0559,0.33003 z" />
+      <path
+         id="path1591"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="M 220.59171,447.19305 H 220.326 v -3.03462 h 0.26571 z m -0.30486,-3.87648 q 0,-0.12586 0.0503,-0.19578 0.0531,-0.0699 0.13425,-0.0699 0.0755,0 0.12027,0.0699 0.0447,0.0699 0.0447,0.19578 0,0.12027 -0.0447,0.19298 -0.0447,0.0699 -0.12027,0.0699 -0.0811,0 -0.13425,-0.0699 -0.0503,-0.0727 -0.0503,-0.19298 z" />
+      <path
+         id="path1593"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 222.33976,444.10529 q 0.88941,0 0.88941,1.56346 0,0.77194 -0.22095,1.17749 -0.22096,0.40275 -0.63769,0.40275 -0.21816,0 -0.39716,-0.12026 -0.179,-0.12027 -0.29647,-0.35521 h -0.0224 l -0.0364,0.41953 h -0.21815 v -4.35195 h 0.2657 v 1.35089 l -0.0112,0.3664 h 0.0224 q 0.24053,-0.4531 0.66286,-0.4531 z m -0.0112,0.24613 q -0.34961,0 -0.50623,0.30766 -0.15663,0.30765 -0.15663,1.00967 v 0.0699 q 0,1.26979 0.67405,1.26979 0.30766,0 0.45869,-0.32724 0.15383,-0.32723 0.15383,-1.01247 0,-0.65727 -0.14824,-0.9873 -0.14823,-0.33003 -0.47547,-0.33003 z" />
+      <path
+         id="path1595"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 224.16054,447.19305 h -0.26571 v -4.35195 h 0.26571 z" />
+      <path
+         id="path1597"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 225.83028,447.24899 q -0.48107,0 -0.74118,-0.40834 -0.25731,-0.41115 -0.25731,-1.14393 0,-0.77753 0.22934,-1.18588 0.23214,-0.41114 0.66566,-0.41114 0.37758,0 0.59574,0.3608 0.21816,0.358 0.21816,0.96772 v 0.24612 h -1.4376 q 0.006,0.66287 0.18739,0.9929 0.18179,0.33003 0.55098,0.33003 0.28529,0 0.60133,-0.18739 v 0.25731 q -0.29087,0.1818 -0.61251,0.1818 z m -0.12027,-2.90876 q -0.54819,0 -0.60133,1.09358 h 1.1663 q 0,-0.50064 -0.15383,-0.79711 -0.15103,-0.29647 -0.41114,-0.29647 z" />
+      <path
+         id="path1599"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 229.48301,446.4323 q 0,0.38317 -0.20138,0.60133 -0.20137,0.21536 -0.58175,0.21536 -0.20697,0 -0.36359,-0.0531 -0.15663,-0.0531 -0.24333,-0.11747 v -0.31045 q 0.10348,0.10348 0.27409,0.16781 0.17061,0.0615 0.34961,0.0615 0.23494,0 0.36919,-0.15383 0.13425,-0.15383 0.13425,-0.41114 0,-0.20137 -0.0979,-0.33842 -0.0951,-0.13985 -0.36639,-0.31605 -0.31045,-0.19578 -0.42513,-0.31325 -0.11187,-0.11747 -0.1762,-0.26291 -0.0615,-0.14544 -0.0615,-0.34681 0,-0.32724 0.22095,-0.5398 0.22096,-0.21536 0.56218,-0.21536 0.36639,0 0.61251,0.1734 l -0.13704,0.23215 q -0.22935,-0.15383 -0.48666,-0.15383 -0.23494,0 -0.37478,0.13984 -0.13985,0.13705 -0.13985,0.3636 0,0.20137 0.0951,0.33842 0.0951,0.13425 0.40275,0.32724 0.30206,0.19858 0.41394,0.31884 0.11187,0.11747 0.16501,0.26291 0.0559,0.14264 0.0559,0.33003 z" />
+      <path
+         id="path1601"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 230.35844,447.19305 h -0.26571 v -3.03462 h 0.26571 z m -0.30486,-3.87648 q 0,-0.12586 0.0503,-0.19578 0.0531,-0.0699 0.13425,-0.0699 0.0755,0 0.12027,0.0699 0.0447,0.0699 0.0447,0.19578 0,0.12027 -0.0447,0.19298 -0.0447,0.0699 -0.12027,0.0699 -0.0811,0 -0.13425,-0.0699 -0.0503,-0.0727 -0.0503,-0.19298 z" />
+      <path
+         id="path1603"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 231.90791,447.24899 q -0.88382,0 -0.88382,-1.56905 0,-0.77194 0.22096,-1.17469 0.22095,-0.40555 0.65167,-0.40555 0.20418,0 0.38597,0.11747 0.1846,0.11747 0.29368,0.32444 h 0.0224 l -0.0112,-0.33843 v -1.36208 h 0.26571 v 4.35195 h -0.21816 l -0.0224,-0.42512 h -0.0252 q -0.10908,0.23214 -0.28248,0.358 -0.17341,0.12306 -0.39716,0.12306 z m 0.0168,-0.23214 q 0.31885,0 0.48946,-0.29367 0.1734,-0.29647 0.1734,-0.86983 v -0.17341 q 0,-0.68804 -0.16781,-1.00688 -0.16502,-0.32164 -0.50624,-0.32164 -0.32723,0 -0.46987,0.34401 -0.14264,0.34122 -0.14264,0.9901 0,0.65447 0.14823,0.9929 0.14824,0.33842 0.47547,0.33842 z" />
+      <path
+         id="path1605"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 234.523,447.24899 q -0.48106,0 -0.74118,-0.40834 -0.25731,-0.41115 -0.25731,-1.14393 0,-0.77753 0.22935,-1.18588 0.23214,-0.41114 0.66565,-0.41114 0.37758,0 0.59574,0.3608 0.21816,0.358 0.21816,0.96772 v 0.24612 h -1.4376 q 0.006,0.66287 0.18739,0.9929 0.1818,0.33003 0.55099,0.33003 0.28528,0 0.60133,-0.18739 v 0.25731 q -0.29088,0.1818 -0.61252,0.1818 z m -0.12027,-2.90876 q -0.54819,0 -0.60133,1.09358 h 1.1663 q 0,-0.50064 -0.15382,-0.79711 -0.15104,-0.29647 -0.41115,-0.29647 z" />
+      <path
+         id="path1607"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 235.65294,445.78902 v -0.28529 h 1.14673 v 0.28529 z" />
+      <path
+         id="path1609"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 238.21489,447.24899 q -0.48106,0 -0.74117,-0.40834 -0.25732,-0.41115 -0.25732,-1.14393 0,-0.77753 0.22935,-1.18588 0.23214,-0.41114 0.66566,-0.41114 0.37758,0 0.59573,0.3608 0.21816,0.358 0.21816,0.96772 v 0.24612 h -1.4376 q 0.006,0.66287 0.18739,0.9929 0.1818,0.33003 0.55099,0.33003 0.28528,0 0.60133,-0.18739 v 0.25731 q -0.29088,0.1818 -0.61252,0.1818 z m -0.12027,-2.90876 q -0.54819,0 -0.60133,1.09358 h 1.16631 q 0,-0.50064 -0.15383,-0.79711 -0.15104,-0.29647 -0.41115,-0.29647 z" />
+      <path
+         id="path1611"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 240.37688,444.39337 h -0.47547 v 2.79968 h -0.26291 v -2.79968 h -0.38597 v -0.15103 l 0.38597,-0.11467 v -0.22935 q 0,-0.57895 0.13705,-0.83347 0.13705,-0.25452 0.47547,-0.25452 0.19578,0 0.35521,0.0699 l -0.0923,0.24612 q -0.14824,-0.0699 -0.2685,-0.0699 -0.13705,0 -0.20697,0.0811 -0.0699,0.0811 -0.10349,0.26291 -0.0336,0.18179 -0.0336,0.50344 v 0.25451 h 0.47547 z m 1.29496,0 h -0.47547 v 2.79968 h -0.26291 v -2.79968 h -0.38597 v -0.15103 l 0.38597,-0.11467 v -0.22935 q 0,-0.57895 0.13705,-0.83347 0.13705,-0.25452 0.47547,-0.25452 0.19578,0 0.35521,0.0699 l -0.0923,0.24612 q -0.14824,-0.0699 -0.2685,-0.0699 -0.13705,0 -0.20697,0.0811 -0.0699,0.0811 -0.10349,0.26291 -0.0336,0.18179 -0.0336,0.50344 v 0.25451 h 0.47547 z" />
+      <path
+         id="path1613"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 243.02553,447.24899 q -0.48106,0 -0.74117,-0.40834 -0.25731,-0.41115 -0.25731,-1.14393 0,-0.77753 0.22934,-1.18588 0.23214,-0.41114 0.66566,-0.41114 0.37758,0 0.59574,0.3608 0.21815,0.358 0.21815,0.96772 v 0.24612 h -1.4376 q 0.006,0.66287 0.1874,0.9929 0.18179,0.33003 0.55098,0.33003 0.28528,0 0.60133,-0.18739 v 0.25731 q -0.29087,0.1818 -0.61252,0.1818 z m -0.12026,-2.90876 q -0.54819,0 -0.60133,1.09358 h 1.1663 q 0,-0.50064 -0.15383,-0.79711 -0.15103,-0.29647 -0.41114,-0.29647 z" />
+      <path
+         id="path1615"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 245.19312,447.24899 q -0.45589,0 -0.68803,-0.39436 -0.22935,-0.39716 -0.22935,-1.1635 0,-0.77754 0.23214,-1.18309 0.23494,-0.40834 0.69084,-0.40834 0.28248,0 0.46987,0.10348 l -0.10348,0.23494 q -0.18739,-0.0867 -0.34402,-0.0867 -0.66845,0 -0.66845,1.33411 0,1.32293 0.66845,1.32293 0.19858,0 0.43072,-0.0895 v 0.22375 q -0.0923,0.0503 -0.22655,0.0783 -0.13425,0.028 -0.23214,0.028 z" />
+      <path
+         id="path1617"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 246.74819,447.00287 q 0.12306,0 0.21816,-0.0336 v 0.22375 q -0.12306,0.0559 -0.31605,0.0559 -0.46988,0 -0.46988,-0.70202 v -2.1536 h -0.27409 v -0.15662 l 0.2685,-0.0783 0.0867,-0.72159 h 0.1846 v 0.72159 h 0.48106 v 0.23494 h -0.48106 v 2.07809 q 0,0.30765 0.0671,0.41953 0.0671,0.11188 0.23494,0.11188 z" />
+      <path
+         id="path1619"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 248.63609,446.4323 q 0,0.38317 -0.20138,0.60133 -0.20137,0.21536 -0.58175,0.21536 -0.20697,0 -0.36359,-0.0531 -0.15663,-0.0531 -0.24333,-0.11747 v -0.31045 q 0.10348,0.10348 0.27409,0.16781 0.17061,0.0615 0.34961,0.0615 0.23494,0 0.36919,-0.15383 0.13425,-0.15383 0.13425,-0.41114 0,-0.20137 -0.0979,-0.33842 -0.0951,-0.13985 -0.36639,-0.31605 -0.31045,-0.19578 -0.42513,-0.31325 -0.11187,-0.11747 -0.1762,-0.26291 -0.0615,-0.14544 -0.0615,-0.34681 0,-0.32724 0.22095,-0.5398 0.22096,-0.21536 0.56218,-0.21536 0.36639,0 0.61251,0.1734 l -0.13704,0.23215 q -0.22935,-0.15383 -0.48666,-0.15383 -0.23494,0 -0.37478,0.13984 -0.13985,0.13705 -0.13985,0.3636 0,0.20137 0.0951,0.33842 0.0951,0.13425 0.40275,0.32724 0.30206,0.19858 0.41394,0.31884 0.11187,0.11747 0.16501,0.26291 0.0559,0.14264 0.0559,0.33003 z" />
+      <path
+         id="path1621"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 210.45579,452.78403 q 0,-0.72439 0.21816,-1.38166 0.21816,-0.66007 0.61252,-1.13833 h 0.22375 q -0.37479,0.55378 -0.56777,1.20266 -0.19299,0.64608 -0.19299,1.31174 0,0.67964 0.20138,1.33971 0.20417,0.66006 0.55378,1.14112 h -0.21815 q -0.39996,-0.46708 -0.61532,-1.11036 -0.21536,-0.64328 -0.21536,-1.36488 z" />
+      <path
+         id="path1623"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 213.00935,454.40902 q -0.48107,0 -0.74118,-0.40834 -0.25731,-0.41115 -0.25731,-1.14393 0,-0.77754 0.22934,-1.18588 0.23215,-0.41114 0.66566,-0.41114 0.37758,0 0.59574,0.3608 0.21816,0.358 0.21816,0.96772 v 0.24612 h -1.4376 q 0.006,0.66287 0.18739,0.9929 0.1818,0.33003 0.55099,0.33003 0.28528,0 0.60133,-0.18739 v 0.25731 q -0.29088,0.1818 -0.61252,0.1818 z m -0.12027,-2.90876 q -0.54819,0 -0.60133,1.09358 h 1.1663 q 0,-0.50064 -0.15383,-0.79711 -0.15103,-0.29647 -0.41114,-0.29647 z" />
+      <path
+         id="path1625"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 214.36304,454.10136 q 0,-0.29926 0.21816,-0.29926 0.0895,0 0.15383,0.0671 0.0643,0.0671 0.0643,0.23214 0,0.15943 -0.0643,0.22935 -0.0643,0.0671 -0.15383,0.0671 -0.21816,0 -0.21816,-0.29647 z" />
+      <path
+         id="path1627"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 217.17112,451.31846 v 0.18739 l -0.41394,0.0476 q 0.0839,0.10908 0.13704,0.31325 0.0531,0.20138 0.0531,0.41394 0,0.44191 -0.20137,0.716 -0.19858,0.2741 -0.52582,0.2741 h -0.0671 l -0.0587,-0.006 q -0.13425,0.0951 -0.21256,0.19019 -0.0755,0.0951 -0.0755,0.22096 0,0.12865 0.10068,0.20137 0.10069,0.0699 0.2713,0.0699 h 0.19019 q 0.40555,0 0.6293,0.20976 0.22375,0.20977 0.22375,0.60693 0,0.4447 -0.30206,0.70481 -0.29927,0.26011 -0.79152,0.26011 -0.41115,0 -0.6321,-0.20976 -0.22095,-0.20697 -0.22095,-0.59854 0,-0.28528 0.14543,-0.48945 0.14544,-0.20138 0.4559,-0.31885 -0.13985,-0.0615 -0.22655,-0.17061 -0.0839,-0.10908 -0.0839,-0.26011 0,-0.13705 0.0895,-0.24333 0.0923,-0.10908 0.26011,-0.23214 -0.23214,-0.10628 -0.3524,-0.34402 -0.11747,-0.23773 -0.11747,-0.55937 0,-0.48387 0.20417,-0.76355 0.20417,-0.27969 0.55938,-0.27969 0.19019,0 0.31884,0.0587 z m -1.63339,3.58002 q 0,0.28808 0.14824,0.4503 0.15103,0.16221 0.45309,0.16221 0.37479,0 0.59294,-0.19578 0.22096,-0.19578 0.22096,-0.537 0,-0.27409 -0.15103,-0.42513 -0.14824,-0.14823 -0.43352,-0.14823 h -0.19578 q -0.2741,0 -0.4559,0.19019 -0.179,0.19298 -0.179,0.50344 z m 0.16502,-2.58992 q 0,0.37199 0.13705,0.56497 0.13705,0.19019 0.36359,0.19019 0.48666,0 0.48666,-0.78313 0,-0.37758 -0.12586,-0.59014 -0.12306,-0.21257 -0.3608,-0.21257 -0.24333,0 -0.37198,0.21816 -0.12866,0.21816 -0.12866,0.61252 z" />
+      <path
+         id="path1629"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 217.61862,454.10136 q 0,-0.29926 0.21815,-0.29926 0.0895,0 0.15383,0.0671 0.0643,0.0671 0.0643,0.23214 0,0.15943 -0.0643,0.22935 -0.0643,0.0671 -0.15383,0.0671 -0.21815,0 -0.21815,-0.29647 z" />
+      <path
+         id="path1631"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 221.59859,454.35308 -0.41954,-2.05571 q -0.006,-0.0224 -0.0112,-0.0476 -0.003,-0.0252 -0.0867,-0.537 h -0.006 l -0.0392,0.23774 -0.0643,0.34681 -0.43351,2.05571 h -0.31605 l -0.66007,-3.03462 h 0.26571 l 0.37758,1.76763 0.1762,0.92298 h 0.0168 q 0.0504,-0.39996 0.16222,-0.92857 l 0.37758,-1.76204 h 0.27969 l 0.38038,1.76763 q 0.0447,0.19858 0.15942,0.92298 h 0.0168 q 0.008,-0.0923 0.0811,-0.46429 0.0755,-0.37198 0.47547,-2.22632 h 0.26291 l -0.68244,3.03462 z" />
+      <path
+         id="path1633"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 223.89763,451.25973 q 0.14264,0 0.2657,0.0392 l -0.0643,0.26571 q -0.10068,-0.042 -0.20697,-0.042 -0.15383,0 -0.28808,0.15943 -0.13145,0.15662 -0.20697,0.43911 -0.0755,0.28248 -0.0755,0.6237 v 1.60821 h -0.26571 v -3.03462 h 0.21816 l 0.028,0.53141 h 0.0196 q 0.21256,-0.59014 0.57616,-0.59014 z" />
+      <path
+         id="path1635"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 224.88773,454.35308 h -0.26571 v -3.03462 h 0.26571 z m -0.30487,-3.87648 q 0,-0.12586 0.0503,-0.19578 0.0531,-0.0699 0.13425,-0.0699 0.0755,0 0.12027,0.0699 0.0447,0.0699 0.0447,0.19578 0,0.12027 -0.0447,0.19298 -0.0447,0.0699 -0.12027,0.0699 -0.0811,0 -0.13425,-0.0699 -0.0503,-0.0727 -0.0503,-0.19298 z" />
+      <path
+         id="path1637"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 226.25261,454.1629 q 0.12306,0 0.21815,-0.0336 v 0.22375 q -0.12306,0.0559 -0.31605,0.0559 -0.46987,0 -0.46987,-0.70202 v -2.1536 h -0.2741 v -0.15663 l 0.2685,-0.0783 0.0867,-0.72159 h 0.18459 v 0.72159 h 0.48107 v 0.23494 h -0.48107 v 2.07809 q 0,0.30765 0.0671,0.41953 0.0671,0.11188 0.23494,0.11188 z" />
+      <path
+         id="path1639"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 227.81047,454.40902 q -0.48106,0 -0.74117,-0.40834 -0.25732,-0.41115 -0.25732,-1.14393 0,-0.77754 0.22935,-1.18588 0.23214,-0.41114 0.66566,-0.41114 0.37758,0 0.59573,0.3608 0.21816,0.358 0.21816,0.96772 v 0.24612 h -1.4376 q 0.006,0.66287 0.18739,0.9929 0.1818,0.33003 0.55099,0.33003 0.28528,0 0.60133,-0.18739 v 0.25731 q -0.29088,0.1818 -0.61252,0.1818 z m -0.12026,-2.90876 q -0.54819,0 -0.60134,1.09358 h 1.16631 q 0,-0.50064 -0.15383,-0.79711 -0.15103,-0.29647 -0.41114,-0.29647 z" />
+      <path
+         id="path1641"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="M 231.04647,451.5534 H 230.571 v 2.79968 h -0.26291 v -2.79968 h -0.38597 v -0.15103 l 0.38597,-0.11467 v -0.22935 q 0,-0.57895 0.13705,-0.83347 0.13705,-0.25452 0.47547,-0.25452 0.19578,0 0.35521,0.0699 l -0.0923,0.24613 q -0.14824,-0.0699 -0.2685,-0.0699 -0.13705,0 -0.20697,0.0811 -0.0699,0.0811 -0.10349,0.26291 -0.0336,0.18179 -0.0336,0.50344 v 0.25451 h 0.47547 z m 0.75796,2.79968 h -0.26571 v -3.03462 h 0.26571 z m -0.30486,-3.87648 q 0,-0.12586 0.0503,-0.19578 0.0531,-0.0699 0.13425,-0.0699 0.0755,0 0.12027,0.0699 0.0447,0.0699 0.0447,0.19578 0,0.12027 -0.0447,0.19298 -0.0447,0.0699 -0.12027,0.0699 -0.0811,0 -0.13425,-0.0699 -0.0503,-0.0727 -0.0503,-0.19298 z" />
+      <path
+         id="path1643"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 232.88682,454.35308 h -0.2657 v -4.35195 h 0.2657 z" />
+      <path
+         id="path1645"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 234.55656,454.40902 q -0.48106,0 -0.74117,-0.40834 -0.25732,-0.41115 -0.25732,-1.14393 0,-0.77754 0.22935,-1.18588 0.23214,-0.41114 0.66566,-0.41114 0.37758,0 0.59573,0.3608 0.21816,0.358 0.21816,0.96772 v 0.24612 h -1.4376 q 0.006,0.66287 0.18739,0.9929 0.1818,0.33003 0.55099,0.33003 0.28528,0 0.60133,-0.18739 v 0.25731 q -0.29088,0.1818 -0.61252,0.1818 z m -0.12026,-2.90876 q -0.54819,0 -0.60134,1.09358 h 1.16631 q 0,-0.50064 -0.15383,-0.79711 -0.15103,-0.29647 -0.41114,-0.29647 z" />
+      <path
+         id="path1647"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 237.5744,454.1629 q 0.12307,0 0.21816,-0.0336 v 0.22375 q -0.12306,0.0559 -0.31605,0.0559 -0.46987,0 -0.46987,-0.70202 v -2.1536 h -0.2741 v -0.15663 l 0.2685,-0.0783 0.0867,-0.72159 h 0.1846 v 0.72159 h 0.48106 v 0.23494 h -0.48106 v 2.07809 q 0,0.30765 0.0671,0.41953 0.0671,0.11188 0.23494,0.11188 z" />
+      <path
+         id="path1649"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 239.97972,452.82878 q 0,0.76635 -0.24332,1.17469 -0.24054,0.40555 -0.69084,0.40555 -0.4447,0 -0.68244,-0.40555 -0.23493,-0.40834 -0.23493,-1.17469 0,-1.56905 0.92856,-1.56905 0.43632,0 0.67965,0.41114 0.24332,0.41114 0.24332,1.15791 z m -1.57464,0 q 0,0.65727 0.15662,0.9929 0.15663,0.33562 0.48946,0.33562 0.65167,0 0.65167,-1.32852 0,-1.31733 -0.65167,-1.31733 -0.34122,0 -0.49505,0.33003 -0.15103,0.33003 -0.15103,0.9873 z" />
+      <path
+         id="path1651"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 242.46895,454.40902 q -0.88381,0 -0.88381,-1.56905 0,-0.77194 0.22095,-1.17469 0.22095,-0.40555 0.65168,-0.40555 0.20417,0 0.38597,0.11747 0.18459,0.11747 0.29367,0.32444 h 0.0224 l -0.0112,-0.33843 v -1.36208 h 0.2657 v 4.35195 h -0.21816 l -0.0224,-0.42512 h -0.0252 q -0.10908,0.23214 -0.28249,0.358 -0.17341,0.12306 -0.39716,0.12306 z m 0.0168,-0.23214 q 0.31885,0 0.48946,-0.29367 0.17341,-0.29647 0.17341,-0.86984 v -0.1734 q 0,-0.68804 -0.16782,-1.00688 -0.16501,-0.32164 -0.50623,-0.32164 -0.32724,0 -0.46988,0.34401 -0.14264,0.34122 -0.14264,0.9901 0,0.65447 0.14823,0.9929 0.14824,0.33842 0.47547,0.33842 z" />
+      <path
+         id="path1653"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 244.48831,454.35308 h -0.26571 v -3.03462 h 0.26571 z m -0.30487,-3.87648 q 0,-0.12586 0.0504,-0.19578 0.0531,-0.0699 0.13425,-0.0699 0.0755,0 0.12027,0.0699 0.0447,0.0699 0.0447,0.19578 0,0.12027 -0.0447,0.19298 -0.0448,0.0699 -0.12027,0.0699 -0.0811,0 -0.13425,-0.0699 -0.0504,-0.0727 -0.0504,-0.19298 z" />
+      <path
+         id="path1655"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 246.48808,453.59233 q 0,0.38317 -0.20138,0.60133 -0.20137,0.21536 -0.58175,0.21536 -0.20697,0 -0.36359,-0.0531 -0.15663,-0.0531 -0.24333,-0.11747 v -0.31045 q 0.10348,0.10348 0.27409,0.16781 0.17061,0.0615 0.34961,0.0615 0.23494,0 0.36919,-0.15383 0.13425,-0.15383 0.13425,-0.41114 0,-0.20138 -0.0979,-0.33842 -0.0951,-0.13985 -0.36639,-0.31605 -0.31045,-0.19578 -0.42513,-0.31325 -0.11187,-0.11747 -0.1762,-0.26291 -0.0615,-0.14544 -0.0615,-0.34681 0,-0.32724 0.22095,-0.5398 0.22096,-0.21536 0.56218,-0.21536 0.36639,0 0.61251,0.1734 l -0.13704,0.23215 q -0.22935,-0.15383 -0.48666,-0.15383 -0.23494,0 -0.37478,0.13984 -0.13985,0.13705 -0.13985,0.3636 0,0.20137 0.0951,0.33842 0.0951,0.13425 0.40275,0.32724 0.30206,0.19857 0.41394,0.31884 0.11187,0.11747 0.16501,0.26291 0.0559,0.14264 0.0559,0.33003 z" />
+      <path
+         id="path1657"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 247.3691,452.85116 0.17061,-0.30766 0.74956,-1.22504 h 0.28808 l -0.69922,1.11596 0.76075,1.91866 h -0.27968 l -0.66007,-1.67253 -0.33563,0.4419 v 1.23063 h -0.2657 v -4.35195 h 0.2657 v 2.34099 l -0.0196,0.50904 z" />
+      <path
+         id="path1659"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 249.973,452.78403 q 0,0.7216 -0.21536,1.36768 -0.21257,0.64328 -0.61532,1.10756 h -0.21815 q 0.36079,-0.50623 0.55658,-1.1607 0.19858,-0.65447 0.19858,-1.32013 0,-0.66846 -0.19299,-1.31174 -0.19298,-0.64608 -0.56777,-1.20266 h 0.22375 q 0.39996,0.47547 0.61532,1.13833 0.21536,0.66286 0.21536,1.38166 z" />
+    </g>
+    <path
+       id="path11847"
+       d="m 344.81141,418.98973 c 6.42813,0.12527 39.45705,-1.47554 38.69318,-18.70695"
+       style="fill:none;stroke:#be185d;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM)" />
+    <g
+       id="text12503"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.72802353px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#be185d;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       aria-label="Possible side-effects
+(e.g. read template from disk)">
+      <path
+         id="path1662"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 366.63697,388.66063 q 0,0.63209 -0.29087,0.92856 -0.28808,0.29647 -0.85585,0.29647 h -0.29088 v 1.68932 h -0.27409 v -4.08905 h 0.55938 q 0.59853,0 0.87542,0.28249 0.27689,0.28248 0.27689,0.89221 z m -1.4376,0.97331 h 0.2741 q 0.48106,0 0.68244,-0.22655 0.20138,-0.22654 0.20138,-0.74676 0,-0.49505 -0.20977,-0.70762 -0.20697,-0.21536 -0.64329,-0.21536 h -0.30486 z" />
+      <path
+         id="path1664"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 368.94161,390.05068 q 0,0.76635 -0.24333,1.17469 -0.24053,0.40555 -0.69083,0.40555 -0.44471,0 -0.68244,-0.40555 -0.23494,-0.40834 -0.23494,-1.17469 0,-1.56905 0.92857,-1.56905 0.43631,0 0.67964,0.41114 0.24333,0.41114 0.24333,1.15791 z m -1.57465,0 q 0,0.65727 0.15663,0.99289 0.15662,0.33563 0.48945,0.33563 0.65168,0 0.65168,-1.32852 0,-1.31733 -0.65168,-1.31733 -0.34122,0 -0.49505,0.33003 -0.15103,0.33003 -0.15103,0.9873 z" />
+      <path
+         id="path1666"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 370.80713,390.81423 q 0,0.38317 -0.20137,0.60133 -0.20138,0.21536 -0.58176,0.21536 -0.20697,0 -0.36359,-0.0531 -0.15663,-0.0531 -0.24333,-0.11747 v -0.31046 q 0.10348,0.10349 0.27409,0.16782 0.17061,0.0615 0.34961,0.0615 0.23494,0 0.36919,-0.15383 0.13425,-0.15383 0.13425,-0.41114 0,-0.20138 -0.0979,-0.33842 -0.0951,-0.13985 -0.36639,-0.31605 -0.31045,-0.19578 -0.42513,-0.31325 -0.11187,-0.11747 -0.1762,-0.26291 -0.0615,-0.14544 -0.0615,-0.34682 0,-0.32723 0.22095,-0.53979 0.22096,-0.21536 0.56218,-0.21536 0.36639,0 0.61252,0.1734 l -0.13705,0.23214 q -0.22935,-0.15382 -0.48666,-0.15382 -0.23494,0 -0.37478,0.13984 -0.13985,0.13705 -0.13985,0.36359 0,0.20138 0.0951,0.33843 0.0951,0.13425 0.40275,0.32723 0.30206,0.19858 0.41394,0.31885 0.11187,0.11747 0.16501,0.26291 0.0559,0.14264 0.0559,0.33003 z" />
+      <path
+         id="path1668"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 372.60833,390.81423 q 0,0.38317 -0.20138,0.60133 -0.20138,0.21536 -0.58175,0.21536 -0.20697,0 -0.3636,-0.0531 -0.15662,-0.0531 -0.24333,-0.11747 v -0.31046 q 0.10349,0.10349 0.2741,0.16782 0.17061,0.0615 0.34961,0.0615 0.23494,0 0.36919,-0.15383 0.13425,-0.15383 0.13425,-0.41114 0,-0.20138 -0.0979,-0.33842 -0.0951,-0.13985 -0.36639,-0.31605 -0.31046,-0.19578 -0.42513,-0.31325 -0.11188,-0.11747 -0.1762,-0.26291 -0.0615,-0.14544 -0.0615,-0.34682 0,-0.32723 0.22096,-0.53979 0.22095,-0.21536 0.56217,-0.21536 0.36639,0 0.61252,0.1734 l -0.13705,0.23214 q -0.22934,-0.15382 -0.48666,-0.15382 -0.23493,0 -0.37478,0.13984 -0.13984,0.13705 -0.13984,0.36359 0,0.20138 0.0951,0.33843 0.0951,0.13425 0.40275,0.32723 0.30207,0.19858 0.41394,0.31885 0.11188,0.11747 0.16502,0.26291 0.0559,0.14264 0.0559,0.33003 z" />
+      <path
+         id="path1670"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 373.48375,391.57498 h -0.2657 v -3.03462 h 0.2657 z m -0.30486,-3.87648 q 0,-0.12586 0.0503,-0.19579 0.0531,-0.0699 0.13425,-0.0699 0.0755,0 0.12026,0.0699 0.0448,0.0699 0.0448,0.19579 0,0.12026 -0.0448,0.19298 -0.0447,0.0699 -0.12026,0.0699 -0.0811,0 -0.13425,-0.0699 -0.0503,-0.0727 -0.0503,-0.19298 z" />
+      <path
+         id="path1672"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 375.23181,388.48722 q 0.88941,0 0.88941,1.56346 0,0.77194 -0.22096,1.17749 -0.22095,0.40275 -0.63769,0.40275 -0.21816,0 -0.39716,-0.12027 -0.179,-0.12026 -0.29647,-0.3552 h -0.0224 l -0.0364,0.41953 h -0.21816 v -4.35195 h 0.26571 v 1.35089 l -0.0112,0.36639 h 0.0224 q 0.24054,-0.45309 0.66287,-0.45309 z m -0.0112,0.24613 q -0.34961,0 -0.50624,0.30765 -0.15662,0.30766 -0.15662,1.00968 v 0.0699 q 0,1.26979 0.67405,1.26979 0.30765,0 0.45869,-0.32724 0.15382,-0.32723 0.15382,-1.01247 0,-0.65727 -0.14823,-0.9873 -0.14824,-0.33003 -0.47547,-0.33003 z" />
+      <path
+         id="path1674"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 377.05258,391.57498 h -0.2657 v -4.35195 h 0.2657 z" />
+      <path
+         id="path1676"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 378.72232,391.63092 q -0.48106,0 -0.74117,-0.40835 -0.25732,-0.41114 -0.25732,-1.14392 0,-0.77754 0.22935,-1.18588 0.23214,-0.41114 0.66566,-0.41114 0.37758,0 0.59573,0.36079 0.21816,0.35801 0.21816,0.96773 v 0.24612 h -1.4376 q 0.006,0.66286 0.18739,0.9929 0.1818,0.33003 0.55099,0.33003 0.28528,0 0.60133,-0.18739 v 0.25731 q -0.29088,0.1818 -0.61252,0.1818 z m -0.12027,-2.90876 q -0.54819,0 -0.60133,1.09358 h 1.16631 q 0,-0.50064 -0.15383,-0.79711 -0.15104,-0.29647 -0.41115,-0.29647 z" />
+      <path
+         id="path1678"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 382.37505,390.81423 q 0,0.38317 -0.20137,0.60133 -0.20138,0.21536 -0.58175,0.21536 -0.20697,0 -0.3636,-0.0531 -0.15662,-0.0531 -0.24333,-0.11747 v -0.31046 q 0.10349,0.10349 0.2741,0.16782 0.17061,0.0615 0.34961,0.0615 0.23494,0 0.36919,-0.15383 0.13425,-0.15383 0.13425,-0.41114 0,-0.20138 -0.0979,-0.33842 -0.0951,-0.13985 -0.3664,-0.31605 -0.31045,-0.19578 -0.42512,-0.31325 -0.11188,-0.11747 -0.17621,-0.26291 -0.0615,-0.14544 -0.0615,-0.34682 0,-0.32723 0.22096,-0.53979 0.22095,-0.21536 0.56217,-0.21536 0.36639,0 0.61252,0.1734 l -0.13705,0.23214 q -0.22934,-0.15382 -0.48666,-0.15382 -0.23494,0 -0.37478,0.13984 -0.13984,0.13705 -0.13984,0.36359 0,0.20138 0.0951,0.33843 0.0951,0.13425 0.40275,0.32723 0.30207,0.19858 0.41394,0.31885 0.11188,0.11747 0.16502,0.26291 0.0559,0.14264 0.0559,0.33003 z" />
+      <path
+         id="path1680"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 383.25048,391.57498 h -0.2657 v -3.03462 h 0.2657 z m -0.30486,-3.87648 q 0,-0.12586 0.0503,-0.19579 0.0531,-0.0699 0.13425,-0.0699 0.0755,0 0.12027,0.0699 0.0448,0.0699 0.0448,0.19579 0,0.12026 -0.0448,0.19298 -0.0447,0.0699 -0.12027,0.0699 -0.0811,0 -0.13425,-0.0699 -0.0503,-0.0727 -0.0503,-0.19298 z" />
+      <path
+         id="path1682"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 384.79995,391.63092 q -0.88381,0 -0.88381,-1.56905 0,-0.77194 0.22095,-1.1747 0.22096,-0.40554 0.65168,-0.40554 0.20417,0 0.38597,0.11746 0.18459,0.11747 0.29367,0.32444 h 0.0224 l -0.0112,-0.33842 v -1.36208 h 0.2657 v 4.35195 h -0.21816 l -0.0224,-0.42513 h -0.0252 q -0.10908,0.23215 -0.28249,0.35801 -0.1734,0.12306 -0.39716,0.12306 z m 0.0168,-0.23214 q 0.31884,0 0.48945,-0.29368 0.17341,-0.29647 0.17341,-0.86983 v -0.1734 q 0,-0.68804 -0.16782,-1.00688 -0.16501,-0.32164 -0.50623,-0.32164 -0.32724,0 -0.46988,0.34401 -0.14264,0.34122 -0.14264,0.9901 0,0.65447 0.14823,0.99289 0.14824,0.33843 0.47548,0.33843 z" />
+      <path
+         id="path1684"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 387.41504,391.63092 q -0.48106,0 -0.74117,-0.40835 -0.25731,-0.41114 -0.25731,-1.14392 0,-0.77754 0.22934,-1.18588 0.23214,-0.41114 0.66566,-0.41114 0.37758,0 0.59574,0.36079 0.21815,0.35801 0.21815,0.96773 v 0.24612 h -1.4376 q 0.006,0.66286 0.18739,0.9929 0.1818,0.33003 0.55099,0.33003 0.28528,0 0.60133,-0.18739 v 0.25731 q -0.29087,0.1818 -0.61252,0.1818 z m -0.12026,-2.90876 q -0.54819,0 -0.60133,1.09358 h 1.1663 q 0,-0.50064 -0.15383,-0.79711 -0.15103,-0.29647 -0.41114,-0.29647 z" />
+      <path
+         id="path1686"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 388.54499,390.17094 v -0.28528 h 1.14672 v 0.28528 z" />
+      <path
+         id="path1688"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 391.10693,391.63092 q -0.48106,0 -0.74117,-0.40835 -0.25731,-0.41114 -0.25731,-1.14392 0,-0.77754 0.22934,-1.18588 0.23214,-0.41114 0.66566,-0.41114 0.37758,0 0.59574,0.36079 0.21815,0.35801 0.21815,0.96773 v 0.24612 h -1.4376 q 0.006,0.66286 0.1874,0.9929 0.18179,0.33003 0.55098,0.33003 0.28528,0 0.60133,-0.18739 v 0.25731 q -0.29087,0.1818 -0.61252,0.1818 z m -0.12026,-2.90876 q -0.54819,0 -0.60133,1.09358 h 1.1663 q 0,-0.50064 -0.15383,-0.79711 -0.15103,-0.29647 -0.41114,-0.29647 z" />
+      <path
+         id="path1690"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 393.26893,388.7753 h -0.47547 v 2.79968 h -0.26291 v -2.79968 h -0.38597 v -0.15103 l 0.38597,-0.11468 v -0.22934 q 0,-0.57896 0.13705,-0.83347 0.13704,-0.25452 0.47547,-0.25452 0.19578,0 0.3552,0.0699 l -0.0923,0.24613 q -0.14823,-0.0699 -0.2685,-0.0699 -0.13704,0 -0.20697,0.0811 -0.0699,0.0811 -0.10348,0.2629 -0.0336,0.1818 -0.0336,0.50344 v 0.25452 h 0.47547 z m 1.29495,0 h -0.47547 v 2.79968 h -0.2629 v -2.79968 h -0.38597 v -0.15103 l 0.38597,-0.11468 v -0.22934 q 0,-0.57896 0.13704,-0.83347 0.13705,-0.25452 0.47547,-0.25452 0.19579,0 0.35521,0.0699 l -0.0923,0.24613 q -0.14823,-0.0699 -0.2685,-0.0699 -0.13705,0 -0.20697,0.0811 -0.0699,0.0811 -0.10348,0.2629 -0.0336,0.1818 -0.0336,0.50344 v 0.25452 h 0.47547 z" />
+      <path
+         id="path1692"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 395.91758,391.63092 q -0.48107,0 -0.74118,-0.40835 -0.25731,-0.41114 -0.25731,-1.14392 0,-0.77754 0.22934,-1.18588 0.23215,-0.41114 0.66566,-0.41114 0.37758,0 0.59574,0.36079 0.21816,0.35801 0.21816,0.96773 v 0.24612 h -1.4376 q 0.006,0.66286 0.18739,0.9929 0.1818,0.33003 0.55099,0.33003 0.28528,0 0.60133,-0.18739 v 0.25731 q -0.29088,0.1818 -0.61252,0.1818 z m -0.12027,-2.90876 q -0.54819,0 -0.60133,1.09358 h 1.1663 q 0,-0.50064 -0.15383,-0.79711 -0.15103,-0.29647 -0.41114,-0.29647 z" />
+      <path
+         id="path1694"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 398.08517,391.63092 q -0.4559,0 -0.68804,-0.39436 -0.22934,-0.39716 -0.22934,-1.16351 0,-0.77753 0.23214,-1.18308 0.23494,-0.40834 0.69083,-0.40834 0.28249,0 0.46988,0.10348 l -0.10349,0.23494 q -0.18739,-0.0867 -0.34401,-0.0867 -0.66846,0 -0.66846,1.33411 0,1.32293 0.66846,1.32293 0.19857,0 0.43072,-0.0895 v 0.22375 q -0.0923,0.0503 -0.22655,0.0783 -0.13425,0.028 -0.23214,0.028 z" />
+      <path
+         id="path1696"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 399.64024,391.38479 q 0.12306,0 0.21815,-0.0336 v 0.22375 q -0.12306,0.0559 -0.31605,0.0559 -0.46987,0 -0.46987,-0.70202 v -2.1536 h -0.2741 v -0.15663 l 0.2685,-0.0783 0.0867,-0.7216 h 0.18459 v 0.7216 h 0.48107 v 0.23494 h -0.48107 v 2.07808 q 0,0.30766 0.0671,0.41954 0.0671,0.11187 0.23494,0.11187 z" />
+      <path
+         id="path1698"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 401.52813,390.81423 q 0,0.38317 -0.20137,0.60133 -0.20138,0.21536 -0.58175,0.21536 -0.20697,0 -0.3636,-0.0531 -0.15662,-0.0531 -0.24333,-0.11747 v -0.31046 q 0.10349,0.10349 0.2741,0.16782 0.17061,0.0615 0.34961,0.0615 0.23494,0 0.36919,-0.15383 0.13425,-0.15383 0.13425,-0.41114 0,-0.20138 -0.0979,-0.33842 -0.0951,-0.13985 -0.3664,-0.31605 -0.31045,-0.19578 -0.42512,-0.31325 -0.11188,-0.11747 -0.17621,-0.26291 -0.0615,-0.14544 -0.0615,-0.34682 0,-0.32723 0.22096,-0.53979 0.22095,-0.21536 0.56217,-0.21536 0.36639,0 0.61252,0.1734 l -0.13705,0.23214 q -0.22934,-0.15382 -0.48666,-0.15382 -0.23494,0 -0.37478,0.13984 -0.13984,0.13705 -0.13984,0.36359 0,0.20138 0.0951,0.33843 0.0951,0.13425 0.40275,0.32723 0.30206,0.19858 0.41394,0.31885 0.11188,0.11747 0.16502,0.26291 0.0559,0.14264 0.0559,0.33003 z" />
+      <path
+         id="path1700"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 355.75709,397.16596 q 0,-0.7244 0.21815,-1.38166 0.21816,-0.66007 0.61252,-1.13834 h 0.22375 q -0.37478,0.55379 -0.56777,1.20266 -0.19298,0.64609 -0.19298,1.31174 0,0.67965 0.20137,1.33971 0.20418,0.66007 0.55379,1.14113 h -0.21816 q -0.39995,-0.46708 -0.61531,-1.11036 -0.21536,-0.64329 -0.21536,-1.36488 z" />
+      <path
+         id="path1702"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 358.31064,398.79095 q -0.48106,0 -0.74117,-0.40835 -0.25732,-0.41114 -0.25732,-1.14392 0,-0.77754 0.22935,-1.18588 0.23214,-0.41115 0.66566,-0.41115 0.37758,0 0.59573,0.3608 0.21816,0.358 0.21816,0.96773 v 0.24612 h -1.4376 q 0.006,0.66286 0.18739,0.9929 0.1818,0.33003 0.55099,0.33003 0.28528,0 0.60133,-0.18739 v 0.25731 q -0.29088,0.1818 -0.61252,0.1818 z m -0.12026,-2.90876 q -0.54819,0 -0.60133,1.09358 h 1.1663 q 0,-0.50064 -0.15383,-0.79711 -0.15103,-0.29647 -0.41114,-0.29647 z" />
+      <path
+         id="path1704"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 359.66434,398.48329 q 0,-0.29927 0.21815,-0.29927 0.0895,0 0.15383,0.0671 0.0643,0.0671 0.0643,0.23214 0,0.15942 -0.0643,0.22935 -0.0643,0.0671 -0.15383,0.0671 -0.21815,0 -0.21815,-0.29647 z" />
+      <path
+         id="path1706"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 362.47241,395.70039 v 0.18739 l -0.41394,0.0476 q 0.0839,0.10908 0.13705,0.31325 0.0531,0.20137 0.0531,0.41394 0,0.44191 -0.20138,0.716 -0.19858,0.2741 -0.52581,0.2741 h -0.0671 l -0.0587,-0.006 q -0.13425,0.0951 -0.21256,0.19019 -0.0755,0.0951 -0.0755,0.22095 0,0.12866 0.10069,0.20138 0.10069,0.0699 0.2713,0.0699 h 0.19018 q 0.40555,0 0.6293,0.20977 0.22375,0.20977 0.22375,0.60692 0,0.44471 -0.30206,0.70482 -0.29927,0.26011 -0.79152,0.26011 -0.41114,0 -0.6321,-0.20977 -0.22095,-0.20697 -0.22095,-0.59853 0,-0.28528 0.14544,-0.48946 0.14544,-0.20137 0.45589,-0.31884 -0.13984,-0.0615 -0.22655,-0.17061 -0.0839,-0.10908 -0.0839,-0.26011 0,-0.13705 0.0895,-0.24333 0.0923,-0.10908 0.26011,-0.23214 -0.23214,-0.10628 -0.35241,-0.34402 -0.11747,-0.23773 -0.11747,-0.55938 0,-0.48386 0.20417,-0.76355 0.20418,-0.27969 0.55938,-0.27969 0.19019,0 0.31885,0.0587 z m -1.63338,3.58001 q 0,0.28808 0.14823,0.4503 0.15104,0.16222 0.4531,0.16222 0.37478,0 0.59294,-0.19578 0.22095,-0.19578 0.22095,-0.537 0,-0.2741 -0.15103,-0.42513 -0.14823,-0.14823 -0.43352,-0.14823 h -0.19578 q -0.27409,0 -0.45589,0.19018 -0.179,0.19299 -0.179,0.50344 z m 0.16501,-2.58991 q 0,0.37198 0.13705,0.56497 0.13705,0.19019 0.3636,0.19019 0.48666,0 0.48666,-0.78313 0,-0.37758 -0.12586,-0.59014 -0.12307,-0.21257 -0.3608,-0.21257 -0.24333,0 -0.37199,0.21816 -0.12866,0.21816 -0.12866,0.61252 z" />
+      <path
+         id="path1708"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 362.91991,398.48329 q 0,-0.29927 0.21816,-0.29927 0.0895,0 0.15383,0.0671 0.0643,0.0671 0.0643,0.23214 0,0.15942 -0.0643,0.22935 -0.0643,0.0671 -0.15383,0.0671 -0.21816,0 -0.21816,-0.29647 z" />
+      <path
+         id="path1710"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 366.05522,395.64165 q 0.14264,0 0.26571,0.0392 l -0.0643,0.26571 q -0.10069,-0.042 -0.20697,-0.042 -0.15383,0 -0.28808,0.15942 -0.13146,0.15663 -0.20697,0.43912 -0.0755,0.28248 -0.0755,0.6237 v 1.60821 h -0.2657 v -3.03462 h 0.21816 l 0.028,0.53141 h 0.0196 q 0.21257,-0.59015 0.57616,-0.59015 z" />
+      <path
+         id="path1712"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 367.64106,398.79095 q -0.48107,0 -0.74118,-0.40835 -0.25731,-0.41114 -0.25731,-1.14392 0,-0.77754 0.22934,-1.18588 0.23214,-0.41115 0.66566,-0.41115 0.37758,0 0.59574,0.3608 0.21815,0.358 0.21815,0.96773 v 0.24612 h -1.43759 q 0.006,0.66286 0.18739,0.9929 0.18179,0.33003 0.55098,0.33003 0.28529,0 0.60133,-0.18739 v 0.25731 q -0.29087,0.1818 -0.61251,0.1818 z m -0.12027,-2.90876 q -0.54819,0 -0.60133,1.09358 h 1.1663 q 0,-0.50064 -0.15383,-0.79711 -0.15103,-0.29647 -0.41114,-0.29647 z" />
+      <path
+         id="path1714"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 370.203,398.73501 -0.0336,-0.42513 h -0.0112 q -0.21815,0.48107 -0.66006,0.48107 -0.29647,0 -0.47827,-0.23494 -0.179,-0.23773 -0.179,-0.63489 0,-0.43352 0.26011,-0.68524 0.26011,-0.25452 0.72999,-0.27689 l 0.32723,-0.0168 v -0.25172 q 0,-0.42513 -0.10628,-0.61811 -0.10628,-0.19579 -0.35241,-0.19579 -0.26011,0 -0.5314,0.17061 l -0.11468,-0.20976 q 0.31605,-0.19579 0.66287,-0.19579 0.37478,0 0.5398,0.23774 0.16501,0.23494 0.16501,0.78872 v 2.0669 z m -0.64608,-0.17061 q 0.28529,0 0.44191,-0.27969 0.15942,-0.28248 0.15942,-0.79711 v -0.31605 l -0.31604,0.0168 q -0.3664,0.0196 -0.5454,0.20418 -0.1762,0.18179 -0.1762,0.5342 0,0.33003 0.11747,0.48386 0.11747,0.15383 0.31884,0.15383 z" />
+      <path
+         id="path1717"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 371.96225,398.79095 q -0.88382,0 -0.88382,-1.56905 0,-0.77195 0.22095,-1.1747 0.22096,-0.40555 0.65168,-0.40555 0.20417,0 0.38597,0.11747 0.18459,0.11747 0.29367,0.32444 h 0.0224 l -0.0112,-0.33842 v -1.36208 h 0.2657 v 4.35195 h -0.21815 l -0.0224,-0.42513 h -0.0252 q -0.10908,0.23215 -0.28249,0.35801 -0.1734,0.12306 -0.39715,0.12306 z m 0.0168,-0.23214 q 0.31884,0 0.48945,-0.29368 0.17341,-0.29647 0.17341,-0.86983 v -0.1734 q 0,-0.68804 -0.16781,-1.00688 -0.16502,-0.32165 -0.50624,-0.32165 -0.32724,0 -0.46988,0.34402 -0.14264,0.34122 -0.14264,0.9901 0,0.65447 0.14824,0.99289 0.14823,0.33843 0.47547,0.33843 z" />
+      <path
+         id="path1719"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 375.34648,398.54482 q 0.12306,0 0.21816,-0.0336 v 0.22375 q -0.12307,0.0559 -0.31605,0.0559 -0.46988,0 -0.46988,-0.70202 v -2.1536 h -0.27409 v -0.15663 l 0.2685,-0.0783 0.0867,-0.7216 h 0.18459 v 0.7216 h 0.48107 v 0.23494 h -0.48107 v 2.07808 q 0,0.30766 0.0671,0.41954 0.0671,0.11187 0.23494,0.11187 z" />
+      <path
+         id="path1721"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 376.90434,398.79095 q -0.48106,0 -0.74117,-0.40835 -0.25732,-0.41114 -0.25732,-1.14392 0,-0.77754 0.22935,-1.18588 0.23214,-0.41115 0.66566,-0.41115 0.37758,0 0.59574,0.3608 0.21815,0.358 0.21815,0.96773 v 0.24612 h -1.4376 q 0.006,0.66286 0.18739,0.9929 0.1818,0.33003 0.55099,0.33003 0.28528,0 0.60133,-0.18739 v 0.25731 q -0.29087,0.1818 -0.61252,0.1818 z m -0.12026,-2.90876 q -0.54819,0 -0.60133,1.09358 h 1.1663 q 0,-0.50064 -0.15383,-0.79711 -0.15103,-0.29647 -0.41114,-0.29647 z" />
+      <path
+         id="path1723"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 380.87033,398.73501 v -2.0669 q 0,-0.76355 -0.4475,-0.76355 -0.30766,0 -0.44471,0.2685 -0.13425,0.26571 -0.13425,0.78593 v 1.77602 h -0.26291 v -2.0669 q 0,-0.38597 -0.10907,-0.57336 -0.10908,-0.19019 -0.33843,-0.19019 -0.30206,0 -0.43911,0.2741 -0.13705,0.27409 -0.13705,0.88941 v 1.66694 h -0.2657 v -3.03462 h 0.22375 l 0.0224,0.42233 h 0.0252 q 0.1818,-0.48107 0.61811,-0.48107 0.25172,0 0.39716,0.13426 0.14544,0.13425 0.20976,0.39156 0.10908,-0.27969 0.2685,-0.40275 0.15943,-0.12307 0.41394,-0.12307 0.34402,0 0.50344,0.26571 0.15943,0.26291 0.15943,0.84466 v 1.98299 z" />
+      <path
+         id="path1725"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 382.91485,398.79095 q -0.22934,0 -0.41953,-0.12586 -0.18739,-0.12866 -0.28528,-0.34961 h -0.0252 l 0.0196,0.33283 v 1.46277 h -0.2657 v -4.41069 h 0.21816 l 0.028,0.41674 h 0.0252 q 0.11187,-0.22935 0.28528,-0.35241 0.1762,-0.12307 0.38317,-0.12307 0.88941,0 0.88941,1.56906 0,0.75795 -0.21815,1.1691 -0.21816,0.41114 -0.6349,0.41114 z m -0.0531,-2.89758 q -0.33283,0 -0.49505,0.29368 -0.16222,0.29367 -0.16222,0.92017 v 0.0867 q 0,0.69922 0.16502,1.02925 0.16502,0.32724 0.50344,0.32724 0.31325,0 0.46428,-0.32444 0.15383,-0.32724 0.15383,-1.01527 0,-0.65727 -0.14264,-0.9873 -0.14264,-0.33004 -0.48666,-0.33004 z" />
+      <path
+         id="path1727"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 384.69927,398.73501 h -0.26571 v -4.35195 h 0.26571 z" />
+      <path
+         id="path1729"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 386.68226,398.73501 -0.0336,-0.42513 h -0.0112 q -0.21816,0.48107 -0.66007,0.48107 -0.29647,0 -0.47826,-0.23494 -0.179,-0.23773 -0.179,-0.63489 0,-0.43352 0.26011,-0.68524 0.26011,-0.25452 0.72998,-0.27689 l 0.32724,-0.0168 v -0.25172 q 0,-0.42513 -0.10628,-0.61811 -0.10628,-0.19579 -0.35241,-0.19579 -0.26011,0 -0.53141,0.17061 l -0.11467,-0.20976 q 0.31605,-0.19579 0.66286,-0.19579 0.37478,0 0.5398,0.23774 0.16502,0.23494 0.16502,0.78872 v 2.0669 z m -0.64608,-0.17061 q 0.28528,0 0.44191,-0.27969 0.15942,-0.28248 0.15942,-0.79711 v -0.31605 l -0.31605,0.0168 q -0.36639,0.0196 -0.54539,0.20418 -0.17621,0.18179 -0.17621,0.5342 0,0.33003 0.11747,0.48386 0.11747,0.15383 0.31885,0.15383 z" />
+      <path
+         id="path1731"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 388.25691,398.54482 q 0.12306,0 0.21815,-0.0336 v 0.22375 q -0.12306,0.0559 -0.31605,0.0559 -0.46987,0 -0.46987,-0.70202 v -2.1536 h -0.2741 v -0.15663 l 0.2685,-0.0783 0.0867,-0.7216 h 0.18459 v 0.7216 h 0.48107 v 0.23494 h -0.48107 v 2.07808 q 0,0.30766 0.0671,0.41954 0.0671,0.11187 0.23494,0.11187 z" />
+      <path
+         id="path1733"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 389.81477,398.79095 q -0.48106,0 -0.74117,-0.40835 -0.25732,-0.41114 -0.25732,-1.14392 0,-0.77754 0.22935,-1.18588 0.23214,-0.41115 0.66566,-0.41115 0.37758,0 0.59573,0.3608 0.21816,0.358 0.21816,0.96773 v 0.24612 h -1.4376 q 0.006,0.66286 0.18739,0.9929 0.1818,0.33003 0.55099,0.33003 0.28528,0 0.60133,-0.18739 v 0.25731 q -0.29088,0.1818 -0.61252,0.1818 z m -0.12026,-2.90876 q -0.54819,0 -0.60133,1.09358 h 1.1663 q 0,-0.50064 -0.15383,-0.79711 -0.15103,-0.29647 -0.41114,-0.29647 z" />
+      <path
+         id="path1735"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 393.05077,395.93533 h -0.47547 v 2.79968 h -0.26291 v -2.79968 h -0.38597 v -0.15103 l 0.38597,-0.11468 v -0.22934 q 0,-0.57896 0.13705,-0.83347 0.13705,-0.25452 0.47547,-0.25452 0.19578,0 0.3552,0.0699 l -0.0923,0.24613 q -0.14824,-0.0699 -0.2685,-0.0699 -0.13705,0 -0.20697,0.0811 -0.0699,0.0811 -0.10349,0.2629 -0.0336,0.1818 -0.0336,0.50344 v 0.25452 h 0.47547 z" />
+      <path
+         id="path1737"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 394.38209,395.64165 q 0.14264,0 0.2657,0.0392 l -0.0643,0.26571 q -0.10068,-0.042 -0.20696,-0.042 -0.15383,0 -0.28808,0.15942 -0.13146,0.15663 -0.20697,0.43912 -0.0755,0.28248 -0.0755,0.6237 v 1.60821 h -0.2657 v -3.03462 h 0.21815 l 0.028,0.53141 h 0.0196 q 0.21256,-0.59015 0.57616,-0.59015 z" />
+      <path
+         id="path1739"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 396.81538,397.21071 q 0,0.76634 -0.24333,1.17469 -0.24053,0.40555 -0.69083,0.40555 -0.44471,0 -0.68244,-0.40555 -0.23494,-0.40835 -0.23494,-1.17469 0,-1.56906 0.92857,-1.56906 0.43631,0 0.67964,0.41115 0.24333,0.41114 0.24333,1.15791 z m -1.57465,0 q 0,0.65727 0.15663,0.99289 0.15662,0.33563 0.48945,0.33563 0.65168,0 0.65168,-1.32852 0,-1.31734 -0.65168,-1.31734 -0.34122,0 -0.49505,0.33004 -0.15103,0.33003 -0.15103,0.9873 z" />
+      <path
+         id="path1741"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 400.06816,398.73501 v -2.0669 q 0,-0.76355 -0.4475,-0.76355 -0.30766,0 -0.44471,0.2685 -0.13425,0.26571 -0.13425,0.78593 v 1.77602 h -0.26291 v -2.0669 q 0,-0.38597 -0.10907,-0.57336 -0.10908,-0.19019 -0.33843,-0.19019 -0.30206,0 -0.43911,0.2741 -0.13705,0.27409 -0.13705,0.88941 v 1.66694 h -0.2657 v -3.03462 h 0.22375 l 0.0224,0.42233 h 0.0252 q 0.1818,-0.48107 0.61811,-0.48107 0.25172,0 0.39716,0.13426 0.14544,0.13425 0.20976,0.39156 0.10908,-0.27969 0.26851,-0.40275 0.15942,-0.12307 0.41393,-0.12307 0.34402,0 0.50344,0.26571 0.15943,0.26291 0.15943,0.84466 v 1.98299 z" />
+      <path
+         id="path1743"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 402.95175,398.79095 q -0.88382,0 -0.88382,-1.56905 0,-0.77195 0.22095,-1.1747 0.22096,-0.40555 0.65168,-0.40555 0.20417,0 0.38597,0.11747 0.18459,0.11747 0.29367,0.32444 h 0.0224 l -0.0112,-0.33842 v -1.36208 h 0.2657 v 4.35195 h -0.21815 l -0.0224,-0.42513 h -0.0252 q -0.10908,0.23215 -0.28249,0.35801 -0.1734,0.12306 -0.39715,0.12306 z m 0.0168,-0.23214 q 0.31884,0 0.48945,-0.29368 0.17341,-0.29647 0.17341,-0.86983 v -0.1734 q 0,-0.68804 -0.16781,-1.00688 -0.16502,-0.32165 -0.50624,-0.32165 -0.32724,0 -0.46988,0.34402 -0.14264,0.34122 -0.14264,0.9901 0,0.65447 0.14824,0.99289 0.14823,0.33843 0.47547,0.33843 z" />
+      <path
+         id="path1745"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 404.9711,398.73501 h -0.2657 v -3.03462 h 0.2657 z m -0.30486,-3.87648 q 0,-0.12586 0.0503,-0.19579 0.0531,-0.0699 0.13425,-0.0699 0.0755,0 0.12027,0.0699 0.0448,0.0699 0.0448,0.19579 0,0.12026 -0.0448,0.19298 -0.0447,0.0699 -0.12027,0.0699 -0.0811,0 -0.13425,-0.0699 -0.0503,-0.0727 -0.0503,-0.19298 z" />
+      <path
+         id="path1747"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 406.97087,397.97426 q 0,0.38317 -0.20137,0.60133 -0.20138,0.21536 -0.58175,0.21536 -0.20697,0 -0.3636,-0.0531 -0.15663,-0.0531 -0.24333,-0.11747 v -0.31046 q 0.10349,0.10349 0.2741,0.16782 0.17061,0.0615 0.34961,0.0615 0.23494,0 0.36919,-0.15383 0.13425,-0.15383 0.13425,-0.41114 0,-0.20138 -0.0979,-0.33843 -0.0951,-0.13984 -0.3664,-0.31604 -0.31045,-0.19579 -0.42512,-0.31325 -0.11188,-0.11747 -0.17621,-0.26291 -0.0615,-0.14544 -0.0615,-0.34682 0,-0.32723 0.22096,-0.5398 0.22095,-0.21536 0.56217,-0.21536 0.36639,0 0.61252,0.17341 l -0.13705,0.23214 q -0.22934,-0.15383 -0.48666,-0.15383 -0.23494,0 -0.37478,0.13985 -0.13985,0.13705 -0.13985,0.36359 0,0.20138 0.0951,0.33843 0.0951,0.13425 0.40275,0.32723 0.30206,0.19858 0.41394,0.31885 0.11188,0.11747 0.16502,0.26291 0.0559,0.14264 0.0559,0.33003 z" />
+      <path
+         id="path1749"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 407.8519,397.23308 0.17061,-0.30765 0.74956,-1.22504 h 0.28808 l -0.69922,1.11596 0.76075,1.91866 h -0.27969 l -0.66006,-1.67254 -0.33563,0.44191 v 1.23063 h -0.2657 v -4.35195 h 0.2657 v 2.34099 l -0.0196,0.50903 z" />
+      <path
+         id="path1751"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         d="m 410.4558,397.16596 q 0,0.72159 -0.21536,1.36768 -0.21257,0.64328 -0.61532,1.10756 h -0.21816 q 0.3608,-0.50623 0.55658,-1.16071 0.19858,-0.65447 0.19858,-1.32013 0,-0.66845 -0.19298,-1.31174 -0.19299,-0.64608 -0.56777,-1.20266 h 0.22375 q 0.39996,0.47547 0.61532,1.13834 0.21536,0.66286 0.21536,1.38166 z" />
+    </g>
+  </g>
+</svg>

--- a/docs/gfx/action-pipeline.svg
+++ b/docs/gfx/action-pipeline.svg
@@ -1,0 +1,757 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="755.90552"
+   height="422.08273"
+   viewBox="0 0 200 111.67605"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="action-pipeline.svg"
+   inkscape:export-filename="C:\Users\ab17624\sharing\pyscaffold-figs\action-pipeline.png"
+   inkscape:export-xdpi="100"
+   inkscape:export-ydpi="100">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2294"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2292"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#3b82f6;fill-opacity:1;fill-rule:evenodd;stroke:#3b82f6;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2134"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2132"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#3b82f6;fill-opacity:1;fill-rule:evenodd;stroke:#3b82f6;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker1974"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1972"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#3b82f6;fill-opacity:1;fill-rule:evenodd;stroke:#3b82f6;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1718"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         inkscape:connector-curvature="0"
+         transform="scale(0.4)"
+         style="fill:#10b981;fill-opacity:1;fill-rule:evenodd;stroke:#10b981;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1716" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1570"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         inkscape:connector-curvature="0"
+         transform="scale(0.4)"
+         style="fill:#10b981;fill-opacity:1;fill-rule:evenodd;stroke:#10b981;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1568" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker1434"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         inkscape:connector-curvature="0"
+         transform="scale(0.4)"
+         style="fill:#10b981;fill-opacity:1;fill-rule:evenodd;stroke:#10b981;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1432" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1158"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#be185d;fill-opacity:1;fill-rule:evenodd;stroke:#be185d;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(-0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Sstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1052"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker11851"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path11849"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker11255"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.4)"
+         style="fill:#be185d;fill-opacity:1;fill-rule:evenodd;stroke:#be185d;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path11253"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker11008"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#3b82f6;fill-opacity:1;fill-rule:evenodd;stroke:#3b82f6;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path11006"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker10474"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path10472"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#10b981;fill-opacity:1;fill-rule:evenodd;stroke:#10b981;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker10150"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path10148"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#3b82f6;fill-opacity:1;fill-rule:evenodd;stroke:#3b82f6;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9280"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.4)"
+         style="fill:#10b981;fill-opacity:1;fill-rule:evenodd;stroke:#10b981;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path9278"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9026"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path9024"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8881"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path8879"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8419"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path8417"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8275"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path8273"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker7249"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.4)"
+         style="fill:#3b82f6;fill-opacity:1;fill-rule:evenodd;stroke:#3b82f6;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path7247"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6805"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path6803"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#10b981;fill-opacity:1;fill-rule:evenodd;stroke:#10b981;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3232"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path3230"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Send"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1037"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1031"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2125"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutS">
+      <path
+         transform="scale(0.2)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path2123"
+         inkscape:connector-curvature="0" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.374055"
+     inkscape:cx="482.94771"
+     inkscape:cy="248.33271"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1387"
+     inkscape:window-x="1072"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-210.45579,-351.48375)">
+    <g
+       id="g6777"
+       transform="translate(-33.680162,59.124827)" />
+    <rect
+       style="fill:#fffbeb;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect6761"
+       width="91.332657"
+       height="50.740364"
+       x="253.31793"
+       y="385.28952"
+       ry="2.0711026" />
+    <text
+       id="text6765"
+       y="390.21823"
+       x="264.40051"
+       style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:5.01202059px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code Semi-Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         y="390.21823"
+         x="264.40051"
+         id="tspan6763"
+         sodipodi:role="line">Action</tspan></text>
+    <rect
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect6725"
+       width="91.332657"
+       height="11.311115"
+       x="253.31792"
+       y="366.00128"
+       ry="2.0711026" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       x="372.23047"
+       y="-298.61923"
+       id="text8747"
+       transform="rotate(90)"><tspan
+         sodipodi:role="line"
+         id="tspan8745"
+         x="372.23047"
+         y="-298.61923"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26850107">...</tspan></text>
+    <text
+       id="text9232-6"
+       y="373.42368"
+       x="255.30441"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.01202059px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       xml:space="preserve"><tspan
+         id="tspan9256-1"
+         y="373.42368"
+         x="255.30441"
+         sodipodi:role="line"
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107">previous action</tspan></text>
+    <g
+       id="g7643"
+       transform="matrix(1.0148073,0,0,1.0148073,70.364914,71.991742)">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7639"
+         d="m 209.78646,282.06996 v 5.73399"
+         style="fill:none;stroke:#10b981;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1434)" />
+      <path
+         style="fill:none;stroke:#3b82f6;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1974)"
+         d="m 240.78051,282.06996 v 5.73399"
+         id="path7641"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <g
+       id="g7655"
+       transform="matrix(1.0148073,0,0,1.0148073,70.364914,150.07626)">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7651"
+         d="m 209.78646,282.06996 v 5.73399"
+         style="fill:none;stroke:#10b981;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1718)" />
+      <path
+         style="fill:none;stroke:#3b82f6;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2294)"
+         d="m 240.78051,282.06996 v 5.73399"
+         id="path7653"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+    </g>
+    <g
+       transform="matrix(1.0148073,0,0,1.0148073,70.364914,169.3645)"
+       id="g7661">
+      <path
+         style="fill:none;stroke:#10b981;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker6805)"
+         d="m 209.78646,282.06996 v 5.73399"
+         id="path7657"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7659"
+         d="m 240.78051,282.06996 v 5.73399"
+         style="fill:none;stroke:#3b82f6;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker7249)" />
+    </g>
+    <rect
+       ry="2.0711026"
+       y="444.08582"
+       x="253.31792"
+       height="11.311115"
+       width="91.332657"
+       id="rect8801"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" />
+    <text
+       transform="rotate(90)"
+       id="text8805"
+       y="-298.61926"
+       x="450.31497"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26850107"
+         y="-298.61926"
+         x="450.31497"
+         id="tspan8803"
+         sodipodi:role="line">...</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.01202059px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       x="255.30441"
+       y="451.66125"
+       id="text1250"><tspan
+         style="font-size:5.01202059px;text-align:start;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:0.26850107"
+         sodipodi:role="line"
+         x="255.30441"
+         y="451.66125"
+         id="tspan1248">next action</tspan></text>
+    <g
+       id="g9228"
+       transform="matrix(1.0148073,0,0,1.0148073,2.788212,173.99055)">
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="251.07933"
+         y="179.22212"
+         id="text8853"><tspan
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           sodipodi:role="line"
+           x="251.07933"
+           y="179.22212"
+           id="tspan8851">Project Structure</tspan></text>
+      <text
+         id="text8859"
+         y="179.22212"
+         x="268.80591"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           y="179.22212"
+           x="268.80591"
+           id="tspan8857"
+           sodipodi:role="line">{...}</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3b82f6;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="299.72437"
+         y="179.22212"
+         id="text9144"><tspan
+           sodipodi:role="line"
+           id="tspan9142"
+           x="299.72437"
+           y="179.22212"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332">{...}</tspan></text>
+      <text
+         id="text9148"
+         y="179.22212"
+         x="332.19299"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3b82f6;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan9146"
+           y="179.22212"
+           x="332.19299"
+           sodipodi:role="line"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332">Scaffold Options</tspan></text>
+    </g>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.01202059px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       x="277.33939"
+       y="403.04593"
+       id="text9232"><tspan
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         sodipodi:role="line"
+         x="277.33939"
+         y="403.04593"
+         id="tspan9230">add/modify/</tspan><tspan
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26850107"
+         sodipodi:role="line"
+         x="277.33939"
+         y="409.31094"
+         id="tspan9256">remove files</tspan></text>
+    <text
+       id="text9236"
+       y="420.69031"
+       x="289.88165"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       xml:space="preserve"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26850107"
+         y="420.69031"
+         x="289.88165"
+         id="tspan9234"
+         sodipodi:role="line">{...}</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       x="321.83328"
+       y="420.69031"
+       id="text9240"><tspan
+         sodipodi:role="line"
+         id="tspan9238"
+         x="321.83328"
+         y="420.69031"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:5.01202059px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26850107">{...}</tspan></text>
+    <text
+       id="text9244"
+       y="396.90878"
+       x="330.69437"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.01202059px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3b82f6;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       xml:space="preserve"><tspan
+         id="tspan9242"
+         y="396.90878"
+         x="330.69437"
+         sodipodi:role="line"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107">read/modify</tspan><tspan
+         y="403.1738"
+         x="330.69437"
+         sodipodi:role="line"
+         style="font-size:5.01202059px;text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26850107"
+         id="tspan9262">options</tspan></text>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path9276"
+       d="m 283.25774,383.34553 c -1.52563,11.27587 14.33318,24.64852 14.52331,30.3912"
+       style="fill:none;stroke:#10b981;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker9280)" />
+    <g
+       transform="matrix(1.0148073,0,0,1.0148073,70.364914,91.279991)"
+       id="g7649">
+      <path
+         style="fill:none;stroke:#10b981;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1570)"
+         d="m 209.78646,282.06996 v 5.73399"
+         id="path7645"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path7647"
+         d="m 240.78051,282.06996 v 5.73399"
+         style="fill:none;stroke:#3b82f6;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker2134)" />
+    </g>
+    <path
+       style="fill:none;stroke:#3b82f6;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker10150)"
+       d="m 314.71073,383.34553 c -1.52564,11.27587 14.33317,24.64852 14.52331,30.3912"
+       id="path10146"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#10b981;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker10474)"
+       d="m 297.42569,422.80345 c -1.52564,11.27587 -14.35809,5.62878 -14.16795,11.37145"
+       id="path10470"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <rect
+       style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#be185d;stroke-width:0.57456082;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.57456083, 0.57456083;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+       id="rect11226"
+       width="58.187912"
+       height="13.263308"
+       x="284.90723"
+       y="411.84851"
+       ry="2.3583214" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path11004"
+       d="m 328.87867,422.80345 c -1.52563,11.27587 -14.35808,5.62878 -14.16794,11.37145"
+       style="fill:none;stroke:#3b82f6;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker11008)" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path11251"
+       d="m 284.61518,419.00309 c -6.42812,-0.12527 -53.4191,1.47554 -52.65523,18.70696"
+       style="fill:none;stroke:#be185d;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker11255)" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.72802353px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#be185d;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       x="230.213"
+       y="447.19305"
+       id="text11825"><tspan
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         sodipodi:role="line"
+         x="230.213"
+         y="447.19305"
+         id="tspan11829">Possible side-effects</tspan><tspan
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107"
+         sodipodi:role="line"
+         x="230.213"
+         y="454.35309"
+         id="tspan11833">(e.g. write file to disk)</tspan></text>
+    <path
+       style="fill:none;stroke:#be185d;stroke-width:0.60888439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#TriangleInM)"
+       d="m 344.81141,418.98973 c 6.42813,0.12527 39.45705,-1.47554 38.69318,-18.70695"
+       id="path11847"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       id="text12503"
+       y="391.57498"
+       x="383.10504"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.72802353px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#be185d;fill-opacity:1;stroke:none;stroke-width:0.26850107"
+       xml:space="preserve"><tspan
+         id="tspan12499"
+         y="391.57498"
+         x="383.10504"
+         sodipodi:role="line"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107">Possible side-effects</tspan><tspan
+         id="tspan12501"
+         y="398.73502"
+         x="383.10504"
+         sodipodi:role="line"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.26850107">(e.g. read template from disk)</tspan></text>
+  </g>
+</svg>

--- a/docs/gfx/api-paths.svg
+++ b/docs/gfx/api-paths.svg
@@ -1,0 +1,1231 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 199.99999 158.41367"
+   height="158.41367mm"
+   width="200mm">
+  <defs
+     id="defs2">
+    <marker
+       style="overflow:visible"
+       id="TriangleInM"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(-0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1158" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow2Sstart"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         id="path1052" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker11851"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path11849" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker11008"
+       style="overflow:visible">
+      <path
+         id="path11006"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker10150"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path10148" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker9026"
+       style="overflow:visible">
+      <path
+         id="path9024"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker8881"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path8879" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker8419"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#be185d;fill-opacity:1;fill-rule:evenodd;stroke:#be185d;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path8417" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker8275"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path8273" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7249"
+       style="overflow:visible">
+      <path
+         id="path7247"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4782"
+       style="overflow:visible">
+      <path
+         id="path4780"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker4378"
+       style="overflow:visible">
+      <path
+         id="path4376"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker3232"
+       style="overflow:visible">
+      <path
+         id="path3230"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="TriangleOutM"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path1167" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Send"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1037" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="Arrow1Mend"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         id="path1031" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker2125"
+       style="overflow:visible">
+      <path
+         id="path2123"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.2)" />
+    </marker>
+    <marker
+       style="overflow:visible"
+       id="marker6805-2"
+       refX="0"
+       refY="0"
+       orient="auto">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path6803-6" />
+    </marker>
+    <marker
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker7249-4"
+       style="overflow:visible">
+      <path
+         id="path7247-7"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+  </defs>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-28.706368,-121.7088)"
+     id="layer1">
+    <path
+       id="path1020"
+       d="m 188.76319,177.55051 c -8.13331,-0.1585 -20.51322,1.86695 -20.76003,9.35231"
+       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM)" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4378)"
+       d="m 188.76319,217.54896 c -8.13331,0.1585 -20.51322,-1.86695 -20.76003,-9.35231"
+       id="path4374" />
+    <g
+       transform="matrix(1.2840056,0,0,1.2840056,-6.5798686,-79.556336)"
+       id="g8257">
+      <path
+         id="rect827"
+         d="m 31.723146,193.03598 h 94.693994 c 2.07295,0 3.74178,1.66883 3.74178,3.74177 v 43.72806 c 0,2.07294 -1.66883,3.74178 -3.74178,3.74178 H 31.723146 c -2.072942,0 -3.741773,-1.66884 -3.741773,-3.74178 v -43.72806 c 0,-2.07294 1.668831,-3.74177 3.741773,-3.74177 z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#005ca0;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" />
+      <g
+         id="text831"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#005ca0;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         aria-label="Python API">
+        <path
+           id="path1210"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
+           d="m 30.123467,182.51356 q 0.247587,0 0.404224,0.0101 0.16169,0.0101 0.429489,0.0556 0.272851,0.0404 0.515386,0.16169 0.247588,0.11621 0.459806,0.30317 0.752868,0.66697 0.752868,1.7129 0,1.04593 -0.752868,1.7129 -0.212218,0.18695 -0.459806,0.30822 -0.242535,0.11622 -0.515386,0.16169 -0.267799,0.0404 -0.429489,0.0505 -0.156637,0.0101 -0.404224,0.0101 h -0.752868 v 2.62746 h -0.64676 v -7.11435 z m 1.768482,2.97105 q 0.146532,-0.33348 0.146532,-0.7276 0,-0.39412 -0.146532,-0.72255 -0.146531,-0.33349 -0.394119,-0.54571 -0.151584,-0.13137 -0.328432,-0.21221 -0.171796,-0.0808 -0.373908,-0.11117 -0.202112,-0.0303 -0.328432,-0.0354 -0.126321,-0.0101 -0.343591,-0.0101 h -0.752868 v 3.27422 h 0.752868 q 0.21727,0 0.343591,-0.005 0.12632,-0.0101 0.328432,-0.0404 0.202112,-0.0303 0.373908,-0.11116 0.176848,-0.0808 0.328432,-0.21222 0.247588,-0.21221 0.394119,-0.54065 z" />
+        <path
+           id="path1212"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
+           d="m 35.65629,188.41524 q 0.480017,-1.47542 1.076248,-3.9614 h 0.661918 q -0.02526,0.096 -0.121268,0.48002 -0.09095,0.37896 -0.116214,0.49012 -0.02526,0.10611 -0.111162,0.4497 -0.0859,0.33854 -0.12632,0.48002 -0.03537,0.13642 -0.116215,0.4497 -0.08085,0.30822 -0.136426,0.48506 -0.05053,0.17685 -0.136425,0.46992 -0.0859,0.29306 -0.16169,0.52044 -0.07074,0.22737 -0.166743,0.51033 -0.09095,0.28296 -0.186954,0.56086 -0.121267,0.34359 -0.192006,0.51539 -0.06569,0.17684 -0.192007,0.39917 -0.12632,0.22232 -0.272852,0.33854 -0.474963,0.39917 -1.465314,0.39917 v -0.60634 q 0.722552,0 0.990351,-0.20716 0.116214,-0.0859 0.212217,-0.26275 0.101057,-0.17685 0.156637,-0.32843 0.06063,-0.15159 0.222324,-0.61644 h -0.262746 q -0.545703,-0.99035 -0.914558,-2.09187 -0.363802,-1.10151 -0.666971,-2.43545 h 0.661918 q 0.525492,2.41524 1.31373,3.9614 z" />
+        <path
+           id="path1214"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
+           d="m 42.295678,189.63297 q -0.54065,0.0758 -0.970139,0.0758 -0.404225,0 -0.73771,-0.14653 -0.328432,-0.14653 -0.535597,-0.39917 -0.16169,-0.19201 -0.242535,-0.4497 -0.08084,-0.2577 -0.09095,-0.42949 -0.01011,-0.1718 -0.01011,-0.47497 v -2.71841 h -1.293519 v -0.63665 h 1.293519 v -1.29352 H 40.3554 v 1.29352 h 1.940278 v 0.63665 H 40.3554 v 2.66789 q 0,0.2779 0.0051,0.41433 0.01011,0.13642 0.06063,0.31327 0.05053,0.17685 0.151584,0.30317 0.262746,0.31327 0.803396,0.31327 0.358749,0 0.919611,-0.0758 z" />
+        <path
+           id="path1216"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
+           d="m 45.948857,184.373 q 0.363802,0 0.66697,0.14653 0.303168,0.14653 0.500228,0.39412 0.12632,0.15663 0.202112,0.32338 0.07579,0.16674 0.101056,0.36885 0.03032,0.20211 0.03537,0.33349 0.01011,0.13137 0.01011,0.36885 v 3.31969 h -0.64676 v -3.31969 q 0,-0.2779 -0.01011,-0.41433 -0.0051,-0.13643 -0.06063,-0.30317 -0.05053,-0.17179 -0.156637,-0.29811 -0.272852,-0.31328 -0.742763,-0.31328 -0.469911,0 -0.742762,0.31328 -0.106109,0.12632 -0.16169,0.29811 -0.05053,0.16674 -0.06063,0.30317 -0.0051,0.13643 -0.0051,0.41433 v 3.31969 h -0.646759 v -7.11435 h 0.646759 v 2.50619 h 0.05053 q 0.186953,-0.29306 0.459805,-0.46991 0.277904,-0.17684 0.560862,-0.17684 z" />
+        <path
+           id="path1218"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
+           d="m 50.173003,184.59027 q 0.373908,-0.21727 0.843819,-0.21727 0.469911,0 0.838766,0.21727 0.373908,0.21221 0.61139,0.59117 0.197059,0.32338 0.262745,0.76803 0.06569,0.4396 0.06569,1.09141 0,0.65181 -0.06569,1.09646 -0.06569,0.43959 -0.262745,0.76297 -0.237482,0.37896 -0.61139,0.59623 -0.368855,0.21222 -0.838766,0.21222 -0.469911,0 -0.843819,-0.21222 -0.368855,-0.21727 -0.606337,-0.59623 -0.197059,-0.32338 -0.262746,-0.76297 -0.06569,-0.44465 -0.06569,-1.09646 0,-0.65181 0.06569,-1.09141 0.06569,-0.44465 0.262746,-0.76803 0.237482,-0.37896 0.606337,-0.59117 z m 1.733113,0.88424 q -0.293063,-0.49518 -0.889294,-0.49518 -0.596231,0 -0.889294,0.49518 -0.111162,0.18695 -0.166743,0.46991 -0.05558,0.2779 -0.06569,0.50023 -0.01011,0.22232 -0.01011,0.59623 0,0.37391 0.01011,0.59623 0.0101,0.22232 0.06569,0.50528 0.05558,0.2779 0.166743,0.46486 0.293063,0.49517 0.889294,0.49517 0.596231,0 0.889294,-0.49517 0.111162,-0.18696 0.166743,-0.46486 0.05558,-0.28296 0.06569,-0.50528 0.01011,-0.22232 0.01011,-0.59623 0,-0.37391 -0.01011,-0.59623 -0.01011,-0.22233 -0.06569,-0.50023 -0.05558,-0.28296 -0.166743,-0.46991 z" />
+        <path
+           id="path1220"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
+           d="m 56.2869,184.373 q 0.363802,0 0.66697,0.14653 0.303169,0.14653 0.500228,0.39412 0.12632,0.15663 0.202112,0.32338 0.07579,0.16674 0.101057,0.36885 0.03032,0.20211 0.03537,0.33349 0.01011,0.13137 0.01011,0.36885 v 3.31969 h -0.64676 v -3.31969 q 0,-0.2779 -0.01011,-0.41433 -0.0051,-0.13643 -0.06063,-0.30317 -0.05053,-0.17179 -0.156637,-0.29811 -0.272851,-0.31328 -0.742762,-0.31328 -0.469911,0 -0.742763,0.31328 -0.106109,0.12632 -0.16169,0.29811 -0.05053,0.16674 -0.06063,0.30317 -0.0051,0.13643 -0.0051,0.41433 v 3.31969 h -0.64676 v -5.17407 h 0.64676 v 0.56591 h 0.05053 q 0.186954,-0.29306 0.459805,-0.46991 0.277905,-0.17684 0.560862,-0.17684 z" />
+        <path
+           id="path1222"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
+           d="m 64.133907,189.62791 q 0.4497,-4.23425 2.061545,-7.11435 h 0.656865 q 1.611846,2.8801 2.061546,7.11435 h -0.682129 q -0.07579,-0.91455 -0.277905,-1.96048 h -2.859888 q -0.02526,0.15663 -0.07579,0.46485 -0.05053,0.30317 -0.08084,0.50023 -0.03032,0.19706 -0.06569,0.47497 -0.03537,0.2779 -0.05558,0.52043 z m 3.713813,-2.56682 q -0.293063,-1.23794 -0.591178,-2.17271 -0.298116,-0.93477 -0.707393,-1.72301 h -0.05053 q -0.409277,0.78824 -0.707393,1.72301 -0.298116,0.93477 -0.591178,2.17271 z" />
+        <path
+           id="path1224"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
+           d="m 71.475636,182.51356 q 0.247587,0 0.404224,0.0101 0.16169,0.0101 0.429489,0.0556 0.272851,0.0404 0.515386,0.16169 0.247588,0.11621 0.459806,0.30317 0.752868,0.66697 0.752868,1.7129 0,1.04593 -0.752868,1.7129 -0.212218,0.18695 -0.459806,0.30822 -0.242535,0.11622 -0.515386,0.16169 -0.267799,0.0404 -0.429489,0.0505 -0.156637,0.0101 -0.404224,0.0101 h -0.752868 v 2.62746 h -0.64676 v -7.11435 z m 1.768482,2.97105 q 0.146532,-0.33348 0.146532,-0.7276 0,-0.39412 -0.146532,-0.72255 -0.146531,-0.33349 -0.394119,-0.54571 -0.151584,-0.13137 -0.328432,-0.21221 -0.171796,-0.0808 -0.373908,-0.11117 -0.202112,-0.0303 -0.328432,-0.0354 -0.126321,-0.0101 -0.343591,-0.0101 h -0.752868 v 3.27422 h 0.752868 q 0.21727,0 0.343591,-0.005 0.12632,-0.0101 0.328432,-0.0404 0.202112,-0.0303 0.373908,-0.11116 0.176848,-0.0808 0.328432,-0.21222 0.247588,-0.21221 0.394119,-0.54065 z" />
+        <path
+           id="path1226"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
+           d="m 78.478826,182.51356 v 0.60634 h -1.293518 v 5.90168 h 1.293518 v 0.60633 H 75.24503 v -0.60633 h 1.293518 V 183.1199 H 75.24503 v -0.60634 z" />
+      </g>
+      <g
+         id="text4720-4"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         aria-label="create_project">
+        <path
+           id="path1229"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           d="m 31.656051,198.83132 q 0.387512,0 0.721837,-0.23555 l 0.16463,0.21275 q -0.169695,0.14184 -0.412841,0.22795 -0.243145,0.0836 -0.460963,0.0836 -0.382447,0 -0.653453,-0.16716 -0.271005,-0.16716 -0.41284,-0.47616 -0.141835,-0.309 -0.141835,-0.7269 0,-0.40018 0.141835,-0.71424 0.141835,-0.31406 0.415373,-0.49389 0.273539,-0.17983 0.653453,-0.17983 0.488824,0 0.863673,0.3014 l -0.167163,0.22542 q -0.362185,-0.24821 -0.711706,-0.24821 -0.248211,0 -0.440701,0.12663 -0.189958,0.12664 -0.298866,0.37739 -0.106376,0.24821 -0.106376,0.60533 0,0.36218 0.106376,0.60533 0.106376,0.24061 0.296333,0.35965 0.19249,0.11651 0.443234,0.11651 z" />
+        <path
+           id="path1231"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           d="m 35.279693,196.35681 q 0.09371,0 0.169695,0.0127 0.07852,0.0127 0.189958,0.0405 l -0.03546,0.83581 h -0.303932 v -0.51922 l 0.0051,-0.0658 q -0.02026,-0.003 -0.06332,-0.003 -0.324194,0 -0.54961,0.22288 -0.222883,0.22035 -0.364718,0.68891 v 1.23599 h 0.547077 v 0.26341 h -1.294242 v -0.26341 h 0.433102 v -2.13005 H 33.580209 V 196.41 h 0.673715 l 0.05825,0.63825 q 0.167162,-0.34699 0.390045,-0.51921 0.222883,-0.17223 0.57747,-0.17223 z" />
+        <path
+           id="path1233"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           d="m 36.821404,197.86633 q 0.0051,0.32167 0.116507,0.53948 0.111442,0.21529 0.293801,0.32166 0.184892,0.10385 0.410308,0.10385 0.202621,0 0.364718,-0.0583 0.164629,-0.0582 0.352054,-0.18742 l 0.164629,0.23555 q -0.182359,0.14183 -0.415373,0.22035 -0.230481,0.0785 -0.453365,0.0785 -0.362185,0 -0.628125,-0.16969 -0.263407,-0.17223 -0.402709,-0.48376 -0.139302,-0.31153 -0.139302,-0.72437 0,-0.40271 0.139302,-0.71424 0.141834,-0.31406 0.397643,-0.48882 0.25581,-0.1773 0.585069,-0.1773 0.319128,0 0.552142,0.15703 0.233015,0.1545 0.354587,0.44577 0.124106,0.28874 0.124106,0.68385 0,0.0583 -0.0076,0.21781 z m 0.792755,-1.21066 q -0.22035,0 -0.392578,0.10385 -0.169695,0.10131 -0.273539,0.30899 -0.103843,0.20769 -0.121572,0.51415 h 1.51206 q -0.01013,-0.45589 -0.205154,-0.69144 -0.195023,-0.23555 -0.519217,-0.23555 z" />
+        <path
+           id="path1235"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           d="m 41.43789,198.54511 q 0,0.15704 0.05319,0.23555 0.05319,0.076 0.174761,0.11144 l -0.08611,0.23049 q -0.162097,-0.0253 -0.278604,-0.11651 -0.113974,-0.0937 -0.159564,-0.26594 -0.139302,0.18489 -0.349522,0.28367 -0.207686,0.0962 -0.471094,0.0962 -0.260874,0 -0.453364,-0.0988 -0.189958,-0.10131 -0.291268,-0.2862 -0.101311,-0.18489 -0.101311,-0.4331 0,-0.40524 0.316596,-0.62053 0.316595,-0.21528 0.91686,-0.21528 h 0.40271 v -0.25834 q 0,-0.29887 -0.172228,-0.43057 -0.169695,-0.13171 -0.493889,-0.13171 -0.306465,0 -0.681314,0.13424 l -0.09118,-0.25834 q 0.230481,-0.0861 0.428037,-0.12158 0.197555,-0.038 0.390046,-0.038 0.306464,0 0.519216,0.10385 0.212752,0.10384 0.319128,0.29126 0.108909,0.18743 0.108909,0.4407 z m -1.056162,0.3242 q 0.215285,0 0.405242,-0.10638 0.189957,-0.10637 0.324194,-0.29633 v -0.75983 h -0.440701 q -0.450832,0 -0.650921,0.15703 -0.197555,0.15703 -0.197555,0.4483 0,0.2786 0.136769,0.41791 0.139302,0.1393 0.422972,0.1393 z" />
+        <path
+           id="path1237"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           d="m 44.699348,198.94276 q -0.126639,0.0836 -0.314063,0.12917 -0.184892,0.0481 -0.352054,0.0481 -0.260875,0 -0.455898,-0.0962 -0.19249,-0.0962 -0.296333,-0.26594 -0.101311,-0.1697 -0.101311,-0.38498 V 196.6734 H 42.551564 V 196.41 h 0.628125 v -0.61293 l 0.314063,-0.038 V 196.41 h 0.937123 l -0.04306,0.2634 h -0.894066 v 1.69189 q 0,0.23808 0.129171,0.35965 0.129171,0.12157 0.417906,0.12157 0.276071,0 0.521749,-0.12917 z" />
+        <path
+           id="path1239"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           d="m 45.937127,197.86633 q 0.0051,0.32167 0.116507,0.53948 0.111442,0.21529 0.293801,0.32166 0.184891,0.10385 0.410307,0.10385 0.202621,0 0.364718,-0.0583 0.16463,-0.0582 0.352054,-0.18742 l 0.16463,0.23555 q -0.182359,0.14183 -0.415373,0.22035 -0.230482,0.0785 -0.453365,0.0785 -0.362185,0 -0.628125,-0.16969 -0.263408,-0.17223 -0.40271,-0.48376 -0.139302,-0.31153 -0.139302,-0.72437 0,-0.40271 0.139302,-0.71424 0.141835,-0.31406 0.397644,-0.48882 0.255809,-0.1773 0.585069,-0.1773 0.319128,0 0.552142,0.15703 0.233014,0.1545 0.354587,0.44577 0.124105,0.28874 0.124105,0.68385 0,0.0583 -0.0076,0.21781 z m 0.792755,-1.21066 q -0.220351,0 -0.392579,0.10385 -0.169695,0.10131 -0.273538,0.30899 -0.103843,0.20769 -0.121573,0.51415 h 1.51206 q -0.01013,-0.45589 -0.205154,-0.69144 -0.195022,-0.23555 -0.519216,-0.23555 z" />
+        <path
+           id="path1241"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           d="m 50.979117,199.98119 h -2.532764 v -0.29633 h 2.532764 z" />
+        <path
+           id="path1243"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           d="m 52.890611,196.36187 q 0.511619,0 0.734502,0.35966 0.225416,0.35965 0.225416,1.01817 0,0.4103 -0.111442,0.72183 -0.111441,0.309 -0.341923,0.48376 -0.230481,0.17476 -0.572404,0.17476 -0.453365,0 -0.724371,-0.31659 v 1.28158 l -0.314062,0.043 V 196.41 h 0.258341 l 0.03546,0.39257 q 0.1469,-0.20768 0.352054,-0.32419 0.207687,-0.11651 0.45843,-0.11651 z m -0.05572,0.26848 q -0.225416,0 -0.412841,0.13423 -0.187424,0.13171 -0.321661,0.32926 v 1.37782 q 0.111442,0.16717 0.288735,0.26594 0.179826,0.0963 0.38498,0.0963 0.369784,0 0.54961,-0.27101 0.182359,-0.27353 0.182359,-0.82821 0,-1.10428 -0.671182,-1.10428 z" />
+        <path
+           id="path1245"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           d="m 56.549713,196.35681 q 0.09371,0 0.169695,0.0127 0.07852,0.0127 0.189957,0.0405 l -0.03546,0.83581 h -0.303932 v -0.51922 l 0.0051,-0.0658 q -0.02026,-0.003 -0.06332,-0.003 -0.324193,0 -0.549609,0.22288 -0.222884,0.22035 -0.364718,0.68891 v 1.23599 h 0.547077 v 0.26341 h -1.294243 v -0.26341 h 0.433103 v -2.13005 H 54.850228 V 196.41 h 0.673716 l 0.05825,0.63825 q 0.167162,-0.34699 0.390046,-0.51921 0.222883,-0.17223 0.57747,-0.17223 z" />
+        <path
+           id="path1247"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           d="m 58.836056,196.36187 q 0.35712,0 0.602798,0.16717 0.245678,0.16716 0.367251,0.47615 0.121572,0.309 0.121572,0.73451 0,0.40017 -0.126638,0.71424 -0.124105,0.31153 -0.372316,0.48882 -0.248211,0.17729 -0.600265,0.17729 -0.35712,0 -0.605331,-0.16969 -0.245678,-0.17223 -0.369783,-0.48123 -0.124105,-0.309 -0.124105,-0.72437 0,-0.41284 0.124105,-0.72437 0.126638,-0.31153 0.374849,-0.48376 0.250744,-0.17476 0.607863,-0.17476 z m 0,0.27607 q -0.762362,0 -0.762362,1.10682 0,1.09669 0.754764,1.09669 0.754763,0 0.754763,-1.10175 0,-1.10176 -0.747165,-1.10176 z" />
+        <path
+           id="path1249"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           d="m 62.198824,195.20693 q 0.11904,0 0.19249,0.0735 0.07345,0.0709 0.07345,0.1773 0,0.11397 -0.07345,0.18742 -0.07345,0.0734 -0.19249,0.0734 -0.113974,0 -0.184892,-0.0734 -0.06838,-0.0735 -0.06838,-0.18742 0,-0.10638 0.07092,-0.1773 0.07092,-0.0735 0.182359,-0.0735 z m 0.362185,3.53827 q 0,0.5876 -0.420438,0.92193 -0.420439,0.33686 -1.215727,0.46096 l -0.05319,-0.24568 q 1.375291,-0.20008 1.375291,-1.11441 v -2.08447 H 61.094539 V 196.41 h 1.46647 z" />
+        <path
+           id="path1251"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           d="m 64.168572,197.86633 q 0.0051,0.32167 0.116507,0.53948 0.111442,0.21529 0.293801,0.32166 0.184892,0.10385 0.410308,0.10385 0.202621,0 0.364718,-0.0583 0.164629,-0.0582 0.352054,-0.18742 l 0.164629,0.23555 q -0.182359,0.14183 -0.415373,0.22035 -0.230481,0.0785 -0.453365,0.0785 -0.362185,0 -0.628125,-0.16969 -0.263407,-0.17223 -0.402709,-0.48376 -0.139302,-0.31153 -0.139302,-0.72437 0,-0.40271 0.139302,-0.71424 0.141834,-0.31406 0.397643,-0.48882 0.25581,-0.1773 0.585069,-0.1773 0.319128,0 0.552142,0.15703 0.233015,0.1545 0.354587,0.44577 0.124106,0.28874 0.124106,0.68385 0,0.0583 -0.0076,0.21781 z m 0.792755,-1.21066 q -0.22035,0 -0.392578,0.10385 -0.169695,0.10131 -0.273539,0.30899 -0.103843,0.20769 -0.121572,0.51415 h 1.51206 q -0.01013,-0.45589 -0.205154,-0.69144 -0.195023,-0.23555 -0.519217,-0.23555 z" />
+        <path
+           id="path1253"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           d="m 68.118941,198.83132 q 0.387513,0 0.721838,-0.23555 l 0.16463,0.21275 q -0.169696,0.14184 -0.412841,0.22795 -0.243145,0.0836 -0.460963,0.0836 -0.382447,0 -0.653453,-0.16716 -0.271006,-0.16716 -0.41284,-0.47616 -0.141835,-0.309 -0.141835,-0.7269 0,-0.40018 0.141835,-0.71424 0.141834,-0.31406 0.415373,-0.49389 0.273538,-0.17983 0.653453,-0.17983 0.488823,0 0.863672,0.3014 l -0.167162,0.22542 q -0.362185,-0.24821 -0.711707,-0.24821 -0.248211,0 -0.440701,0.12663 -0.189957,0.12664 -0.298866,0.37739 -0.106376,0.24821 -0.106376,0.60533 0,0.36218 0.106376,0.60533 0.106376,0.24061 0.296334,0.35965 0.19249,0.11651 0.443233,0.11651 z" />
+        <path
+           id="path1255"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           d="m 72.046515,198.94276 q -0.126638,0.0836 -0.314062,0.12917 -0.184892,0.0481 -0.352054,0.0481 -0.260875,0 -0.455898,-0.0962 -0.19249,-0.0962 -0.296333,-0.26594 -0.101311,-0.1697 -0.101311,-0.38498 V 196.6734 H 69.898732 V 196.41 h 0.628125 v -0.61293 l 0.314063,-0.038 V 196.41 h 0.937123 l -0.04306,0.2634 H 70.84092 v 1.69189 q 0,0.23808 0.129171,0.35965 0.129171,0.12157 0.417906,0.12157 0.276071,0 0.521749,-0.12917 z" />
+      </g>
+    </g>
+    <g
+       transform="matrix(1.2840056,0,0,1.2840056,-234.7989,-23.653332)"
+       id="g864">
+      <path
+         id="rect821"
+         d="m 256.28557,166.70274 h 58.4083 c 1.13065,0 2.04088,0.91024 2.04088,2.04089 v 7.0643 c 0,1.13065 -0.91023,2.04089 -2.04088,2.04089 h -58.4083 c -1.13065,0 -2.04088,-0.91024 -2.04088,-2.04089 v -7.0643 c 0,-1.13065 0.91023,-2.04089 2.04088,-2.04089 z"
+         style="fill:#dbe9fe;fill-opacity:1;fill-rule:nonzero;stroke:#3b82f6;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" />
+      <g
+         id="text859"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         aria-label="bootstrap_options">
+        <path
+           id="path1259"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 260.52767,171.38551 q 0.1545,-0.20262 0.35206,-0.309 0.19755,-0.10638 0.43057,-0.10638 0.51921,0 0.75983,0.36472 0.24061,0.36219 0.24061,1.01311 0,0.40524 -0.12157,0.71677 -0.12158,0.31153 -0.35712,0.48882 -0.23555,0.17476 -0.56988,0.17476 -0.24314,0 -0.4255,-0.0811 -0.18236,-0.081 -0.31913,-0.2558 l -0.0304,0.2862 h -0.27354 v -3.73583 l 0.31406,-0.0431 z m 0.66612,2.06926 q 0.37232,0 0.56734,-0.2786 0.19502,-0.28114 0.19502,-0.83328 0,-0.53441 -0.17476,-0.81808 -0.17476,-0.2862 -0.51668,-0.2862 -0.22795,0 -0.41538,0.13423 -0.18742,0.13171 -0.32166,0.32926 v 1.37783 q 0.11651,0.17222 0.29127,0.27353 0.17729,0.10131 0.37485,0.10131 z" />
+        <path
+           id="path1261"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 264.22477,170.97013 q 0.35712,0 0.60279,0.16717 0.24568,0.16716 0.36725,0.47616 0.12158,0.30899 0.12158,0.7345 0,0.40017 -0.12664,0.71424 -0.12411,0.31153 -0.37232,0.48882 -0.24821,0.17729 -0.60026,0.17729 -0.35712,0 -0.60533,-0.16969 -0.24568,-0.17223 -0.36979,-0.48123 -0.1241,-0.30899 -0.1241,-0.72437 0,-0.41284 0.1241,-0.72437 0.12664,-0.31153 0.37485,-0.48376 0.25075,-0.17476 0.60787,-0.17476 z m 0,0.27608 q -0.76237,0 -0.76237,1.10681 0,1.09669 0.75477,1.09669 0.75476,0 0.75476,-1.10175 0,-1.10175 -0.74716,-1.10175 z" />
+        <path
+           id="path1263"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 267.26334,170.97013 q 0.35712,0 0.6028,0.16717 0.24568,0.16716 0.36725,0.47616 0.12157,0.30899 0.12157,0.7345 0,0.40017 -0.12664,0.71424 -0.1241,0.31153 -0.37231,0.48882 -0.24821,0.17729 -0.60027,0.17729 -0.35712,0 -0.60533,-0.16969 -0.24568,-0.17223 -0.36978,-0.48123 -0.12411,-0.30899 -0.12411,-0.72437 0,-0.41284 0.12411,-0.72437 0.12664,-0.31153 0.37485,-0.48376 0.25074,-0.17476 0.60786,-0.17476 z m 0,0.27608 q -0.76236,0 -0.76236,1.10681 0,1.09669 0.75476,1.09669 0.75476,0 0.75476,-1.10175 0,-1.10175 -0.74716,-1.10175 z" />
+        <path
+           id="path1265"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 271.35808,173.55102 q -0.12664,0.0836 -0.31407,0.12917 -0.18489,0.0481 -0.35205,0.0481 -0.26088,0 -0.4559,-0.0962 -0.19249,-0.0962 -0.29633,-0.26594 -0.10131,-0.1697 -0.10131,-0.38498 v -1.69949 h -0.62813 v -0.2634 h 0.62813 v -0.61293 l 0.31406,-0.038 v 0.65092 h 0.93712 l -0.043,0.2634 h -0.89407 v 1.69189 q 0,0.23808 0.12917,0.35965 0.12917,0.12157 0.41791,0.12157 0.27607,0 0.52175,-0.12917 z" />
+        <path
+           id="path1267"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 273.22398,173.44211 q 0.22288,0 0.38751,-0.0583 0.16463,-0.0608 0.25075,-0.16716 0.0886,-0.10638 0.0886,-0.24822 0,-0.14436 -0.0456,-0.23554 -0.0456,-0.0937 -0.18489,-0.1697 -0.13677,-0.076 -0.41537,-0.14437 -0.32166,-0.0785 -0.51922,-0.16209 -0.19502,-0.0861 -0.30393,-0.22795 -0.10891,-0.14184 -0.10891,-0.36219 0,-0.21528 0.12411,-0.37231 0.1241,-0.15703 0.34192,-0.24062 0.22035,-0.0836 0.49896,-0.0836 0.29126,0 0.52428,0.0785 0.23301,0.0785 0.40777,0.20769 l -0.1469,0.23301 q -0.16716,-0.11651 -0.34699,-0.17729 -0.17982,-0.0633 -0.43563,-0.0633 -0.33433,0 -0.48629,0.10637 -0.14944,0.10385 -0.14944,0.28621 0,0.1317 0.0684,0.21781 0.0684,0.0836 0.22035,0.1469 0.15197,0.0633 0.4407,0.13931 0.2862,0.076 0.47363,0.17222 0.18742,0.0963 0.29127,0.25328 0.10384,0.1545 0.10384,0.39005 0,0.26594 -0.15197,0.43816 -0.15196,0.17223 -0.39764,0.25075 -0.24315,0.0785 -0.53188,0.0785 -0.5952,0 -0.99538,-0.34699 l 0.19502,-0.23048 q 0.15957,0.13677 0.36472,0.21529 0.20769,0.076 0.43817,0.076 z" />
+        <path
+           id="path1269"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 277.43522,173.55102 q -0.12663,0.0836 -0.31406,0.12917 -0.18489,0.0481 -0.35205,0.0481 -0.26088,0 -0.4559,-0.0962 -0.19249,-0.0962 -0.29633,-0.26594 -0.10131,-0.1697 -0.10131,-0.38498 v -1.69949 h -0.62813 v -0.2634 h 0.62813 v -0.61293 l 0.31406,-0.038 v 0.65092 h 0.93712 l -0.0431,0.2634 h -0.89406 v 1.69189 q 0,0.23808 0.12917,0.35965 0.12917,0.12157 0.41791,0.12157 0.27607,0 0.52175,-0.12917 z" />
+        <path
+           id="path1271"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 280.16987,170.96507 q 0.0937,0 0.16969,0.0127 0.0785,0.0127 0.18996,0.0405 l -0.0355,0.83581 h -0.30393 v -0.51922 l 0.005,-0.0658 q -0.0203,-0.003 -0.0633,-0.003 -0.3242,0 -0.54961,0.22288 -0.22289,0.22035 -0.36472,0.68891 v 1.23599 h 0.54708 v 0.26341 h -1.29425 v -0.26341 h 0.43311 v -2.13005 h -0.43311 v -0.26594 h 0.67372 l 0.0583,0.63825 q 0.16716,-0.34699 0.39005,-0.51921 0.22288,-0.17223 0.57747,-0.17223 z" />
+        <path
+           id="path1273"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 283.28949,173.15338 q 0,0.15703 0.0532,0.23554 0.0532,0.076 0.17476,0.11144 l -0.0861,0.23049 q -0.16209,-0.0253 -0.2786,-0.11651 -0.11397,-0.0937 -0.15956,-0.26594 -0.13931,0.18489 -0.34952,0.28367 -0.20769,0.0962 -0.4711,0.0962 -0.26087,0 -0.45336,-0.0988 -0.18996,-0.10131 -0.29127,-0.28621 -0.10131,-0.18489 -0.10131,-0.4331 0,-0.40524 0.31659,-0.62053 0.3166,-0.21528 0.91686,-0.21528 h 0.40271 v -0.25834 q 0,-0.29887 -0.17222,-0.43057 -0.1697,-0.13171 -0.49389,-0.13171 -0.30647,0 -0.68132,0.13424 l -0.0912,-0.25834 q 0.23049,-0.0861 0.42804,-0.12157 0.19756,-0.038 0.39005,-0.038 0.30646,0 0.51921,0.10385 0.21276,0.10384 0.31913,0.29126 0.10891,0.18743 0.10891,0.44071 z m -1.05616,0.32419 q 0.21528,0 0.40524,-0.10638 0.18996,-0.10637 0.32419,-0.29633 v -0.75983 h -0.4407 q -0.45083,0 -0.65092,0.15703 -0.19755,0.15703 -0.19755,0.4483 0,0.27861 0.13677,0.41791 0.1393,0.1393 0.42297,0.1393 z" />
+        <path
+           id="path1275"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 285.62649,170.97013 q 0.51162,0 0.7345,0.35966 0.22542,0.35965 0.22542,1.01817 0,0.4103 -0.11145,0.72183 -0.11144,0.309 -0.34192,0.48376 -0.23048,0.17476 -0.5724,0.17476 -0.45337,0 -0.72437,-0.31659 v 1.28158 l -0.31407,0.043 v -3.71809 h 0.25835 l 0.0354,0.39257 q 0.1469,-0.20768 0.35206,-0.32419 0.20769,-0.11651 0.45843,-0.11651 z m -0.0557,0.26848 q -0.22542,0 -0.41284,0.13423 -0.18743,0.13171 -0.32166,0.32926 v 1.37783 q 0.11144,0.16716 0.28873,0.26594 0.17983,0.0962 0.38498,0.0962 0.36979,0 0.54961,-0.271 0.18236,-0.27354 0.18236,-0.82822 0,-1.10428 -0.67118,-1.10428 z" />
+        <path
+           id="path1277"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 289.79214,174.58945 h -2.53276 v -0.29633 h 2.53276 z" />
+        <path
+           id="path1279"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 291.57193,170.97013 q 0.35712,0 0.6028,0.16717 0.24568,0.16716 0.36725,0.47616 0.12157,0.30899 0.12157,0.7345 0,0.40017 -0.12663,0.71424 -0.12411,0.31153 -0.37232,0.48882 -0.24821,0.17729 -0.60026,0.17729 -0.35712,0 -0.60534,-0.16969 -0.24567,-0.17223 -0.36978,-0.48123 -0.1241,-0.30899 -0.1241,-0.72437 0,-0.41284 0.1241,-0.72437 0.12664,-0.31153 0.37485,-0.48376 0.25074,-0.17476 0.60786,-0.17476 z m 0,0.27608 q -0.76236,0 -0.76236,1.10681 0,1.09669 0.75477,1.09669 0.75476,0 0.75476,-1.10175 0,-1.10175 -0.74717,-1.10175 z" />
+        <path
+           id="path1281"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 294.74221,170.97013 q 0.51162,0 0.7345,0.35966 0.22542,0.35965 0.22542,1.01817 0,0.4103 -0.11144,0.72183 -0.11144,0.309 -0.34193,0.48376 -0.23048,0.17476 -0.5724,0.17476 -0.45337,0 -0.72437,-0.31659 v 1.28158 l -0.31406,0.043 v -3.71809 h 0.25834 l 0.0355,0.39257 q 0.1469,-0.20768 0.35205,-0.32419 0.20769,-0.11651 0.45843,-0.11651 z m -0.0557,0.26848 q -0.22542,0 -0.41284,0.13423 -0.18742,0.13171 -0.32166,0.32926 v 1.37783 q 0.11144,0.16716 0.28873,0.26594 0.17983,0.0962 0.38498,0.0962 0.36979,0 0.54961,-0.271 0.18236,-0.27354 0.18236,-0.82822 0,-1.10428 -0.67118,-1.10428 z" />
+        <path
+           id="path1283"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 298.70524,173.55102 q -0.12663,0.0836 -0.31406,0.12917 -0.18489,0.0481 -0.35205,0.0481 -0.26088,0 -0.4559,-0.0962 -0.19249,-0.0962 -0.29633,-0.26594 -0.10131,-0.1697 -0.10131,-0.38498 v -1.69949 h -0.62813 v -0.2634 h 0.62813 v -0.61293 l 0.31406,-0.038 v 0.65092 h 0.93712 l -0.0431,0.2634 h -0.89406 v 1.69189 q 0,0.23808 0.12917,0.35965 0.12917,0.12157 0.41791,0.12157 0.27607,0 0.52175,-0.12917 z" />
+        <path
+           id="path1285"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 300.68259,169.81519 q 0.11904,0 0.18996,0.0735 0.0735,0.0709 0.0735,0.1773 0,0.11397 -0.0735,0.18742 -0.0709,0.0735 -0.18996,0.0735 -0.11397,0 -0.18489,-0.0735 -0.0709,-0.0734 -0.0709,-0.18742 0,-0.10638 0.0709,-0.1773 0.0734,-0.0735 0.18489,-0.0735 z m -0.83328,1.20307 h 1.12961 v 2.38586 h 0.7725 v 0.27354 h -1.92744 v -0.27354 h 0.84088 v -2.11233 h -0.81555 z" />
+        <path
+           id="path1287"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 303.72623,170.97013 q 0.35712,0 0.6028,0.16717 0.24568,0.16716 0.36725,0.47616 0.12157,0.30899 0.12157,0.7345 0,0.40017 -0.12664,0.71424 -0.1241,0.31153 -0.37231,0.48882 -0.24821,0.17729 -0.60027,0.17729 -0.35712,0 -0.60533,-0.16969 -0.24568,-0.17223 -0.36978,-0.48123 -0.12411,-0.30899 -0.12411,-0.72437 0,-0.41284 0.12411,-0.72437 0.12664,-0.31153 0.37485,-0.48376 0.25074,-0.17476 0.60786,-0.17476 z m 0,0.27608 q -0.76236,0 -0.76236,1.10681 0,1.09669 0.75476,1.09669 0.75477,0 0.75477,-1.10175 0,-1.10175 -0.74717,-1.10175 z" />
+        <path
+           id="path1289"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 305.79222,173.67766 v -2.6594 h 0.26341 l 0.0253,0.38751 q 0.10131,-0.13424 0.25327,-0.23302 0.15197,-0.0988 0.31913,-0.14943 0.1697,-0.0532 0.32166,-0.0532 0.39512,0 0.57494,0.20009 0.17983,0.20009 0.17983,0.58254 v 1.9249 h -0.31407 v -1.58804 q 0,-0.33433 -0.0355,-0.50909 -0.0329,-0.17729 -0.14437,-0.26341 -0.10891,-0.0861 -0.33686,-0.0861 -0.16716,0 -0.32419,0.0735 -0.1545,0.0735 -0.27354,0.18489 -0.11904,0.11144 -0.19502,0.22795 v 1.96036 z" />
+        <path
+           id="path1291"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           d="m 309.68687,173.44211 q 0.22288,0 0.38751,-0.0583 0.16463,-0.0608 0.25075,-0.16716 0.0886,-0.10638 0.0886,-0.24822 0,-0.14436 -0.0456,-0.23554 -0.0456,-0.0937 -0.1849,-0.1697 -0.13677,-0.076 -0.41537,-0.14437 -0.32166,-0.0785 -0.51922,-0.16209 -0.19502,-0.0861 -0.30393,-0.22795 -0.10891,-0.14184 -0.10891,-0.36219 0,-0.21528 0.12411,-0.37231 0.1241,-0.15703 0.34192,-0.24062 0.22035,-0.0836 0.49896,-0.0836 0.29126,0 0.52428,0.0785 0.23301,0.0785 0.40777,0.20769 l -0.1469,0.23301 q -0.16716,-0.11651 -0.34699,-0.17729 -0.17982,-0.0633 -0.43563,-0.0633 -0.33433,0 -0.48629,0.10637 -0.14943,0.10385 -0.14943,0.28621 0,0.1317 0.0684,0.21781 0.0684,0.0836 0.22035,0.1469 0.15197,0.0633 0.4407,0.13931 0.2862,0.076 0.47363,0.17222 0.18742,0.0963 0.29127,0.25328 0.10384,0.1545 0.10384,0.39005 0,0.26594 -0.15197,0.43816 -0.15196,0.17223 -0.39764,0.25075 -0.24315,0.0785 -0.53188,0.0785 -0.5952,0 -0.99538,-0.34699 l 0.19503,-0.23048 q 0.15956,0.13677 0.36471,0.21529 0.20769,0.076 0.43817,0.076 z" />
+      </g>
+    </g>
+    <g
+       transform="matrix(1.2840056,0,0,1.2840056,178.45418,-55.047496)"
+       id="g1005">
+      <g
+         id="g993">
+        <g
+           id="g948"
+           transform="matrix(0.16927449,0,0,0.16927449,12.460139,166.4818)">
+          <path
+             id="rect815-3"
+             transform="scale(0.26458333)"
+             d="M 80,82.519531 V 490.33203 H 370 V 142.51953 H 310 V 82.519531 h -76.96428 z"
+             style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:15.11811066;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             id="path2983"
+             d="m 84.02057,19.833597 -2.883851,2.885153 15.875,15.875 2.883936,-2.884969 z"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        </g>
+        <g
+           transform="translate(51.971726,-8.3154762)"
+           id="g953">
+          <path
+             id="rect948"
+             d="m -43.65625,185.875 h 27.59226 v 7.74852 h -27.59226 z"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" />
+          <g
+             id="text926"
+             style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+             aria-label="setup.cfg">
+            <path
+               id="path1295"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -40.427882,190.66323 q 0.262684,0 0.41465,-0.0977 0.154136,-0.0977 0.154136,-0.26485 0,-0.11289 -0.04125,-0.18453 -0.03908,-0.0738 -0.158478,-0.1346 -0.117231,-0.0608 -0.353863,-0.1194 -0.262684,-0.0651 -0.429847,-0.14111 -0.164991,-0.0782 -0.258341,-0.2019 -0.09118,-0.12374 -0.09118,-0.31479 0,-0.18887 0.108547,-0.32998 0.108547,-0.14111 0.303932,-0.21709 0.197555,-0.076 0.455897,-0.076 0.258342,0 0.464581,0.0695 0.208411,0.0673 0.364718,0.18236 l -0.160649,0.24749 q -0.143282,-0.0977 -0.301761,-0.14979 -0.156308,-0.0543 -0.362547,-0.0543 -0.258342,0 -0.377744,0.0803 -0.11723,0.0781 -0.11723,0.21926 0,0.10204 0.05427,0.16716 0.05644,0.0651 0.180188,0.11723 0.125915,0.0499 0.373402,0.11724 0.247487,0.0673 0.405966,0.14979 0.158478,0.0825 0.247487,0.21709 0.08901,0.13243 0.08901,0.33867 0,0.23229 -0.134598,0.38643 -0.134598,0.15196 -0.353863,0.2236 -0.217094,0.0717 -0.475436,0.0717 -0.538393,0 -0.894427,-0.30828 l 0.20841,-0.24097 q 0.13894,0.11723 0.314786,0.18236 0.175846,0.0651 0.371231,0.0651 z" />
+            <path
+               id="path1297"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -38.314023,189.90123 q 0.0087,0.25617 0.09986,0.42767 0.09118,0.16933 0.238803,0.25183 0.147624,0.0803 0.329983,0.0803 0.169333,0 0.310444,-0.0499 0.143282,-0.0499 0.29959,-0.1563 l 0.171504,0.24097 q -0.160649,0.12591 -0.369059,0.19755 -0.20624,0.0717 -0.416821,0.0717 -0.327812,0 -0.564444,-0.14763 -0.236633,-0.14762 -0.360376,-0.41682 -0.121573,-0.2692 -0.121573,-0.62523 0,-0.34518 0.123744,-0.61655 0.123743,-0.27136 0.349521,-0.42333 0.225778,-0.15414 0.525367,-0.15414 0.286565,0 0.494975,0.1346 0.210581,0.1346 0.321299,0.3886 0.112889,0.25183 0.112889,0.59701 0,0.0999 -0.0087,0.19973 z m 0.620889,-1.02035 q -0.264854,0 -0.432017,0.1867 -0.164991,0.18453 -0.186701,0.55142 h 1.191846 q -0.0065,-0.36037 -0.158478,-0.54924 -0.151966,-0.18888 -0.41465,-0.18888 z" />
+            <path
+               id="path1299"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -34.181189,190.79999 q -0.11506,0.076 -0.284393,0.11941 -0.167162,0.0456 -0.327812,0.0456 -0.240974,0 -0.414649,-0.0868 -0.171505,-0.089 -0.262684,-0.24532 -0.09118,-0.15631 -0.09118,-0.3582 v -1.36335 h -0.525367 v -0.28223 h 0.525367 v -0.51885 l 0.364718,-0.0434 v 0.56227 h 0.790222 l -0.04342,0.28223 h -0.746804 v 1.35901 q 0,0.19538 0.102034,0.29307 0.104206,0.0977 0.334325,0.0977 0.232291,0 0.43853,-0.10854 z" />
+            <path
+               id="path1301"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -33.026885,190.24858 q 0,0.2236 0.09118,0.32564 0.09335,0.0999 0.293077,0.0999 0.180188,0 0.349522,-0.10421 0.171504,-0.1042 0.269196,-0.25834 v -1.68248 h 0.364718 v 2.286 h -0.310444 l -0.03039,-0.30827 q -0.132428,0.16933 -0.329983,0.26486 -0.195385,0.0933 -0.401624,0.0933 -0.327812,0 -0.494975,-0.17368 -0.164991,-0.17585 -0.164991,-0.49932 v -1.66294 h 0.364718 z" />
+            <path
+               id="path1303"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -29.764598,188.58129 q 0.43853,0 0.631744,0.31045 0.195384,0.31044 0.195384,0.87923 0,0.35386 -0.09769,0.62306 -0.09769,0.26702 -0.297419,0.41899 -0.197555,0.15197 -0.486291,0.15197 -0.377743,0 -0.603521,-0.26486 v 1.08981 l -0.364718,0.0456 v -3.20648 h 0.310445 l 0.03039,0.31913 q 0.125914,-0.17801 0.29959,-0.27136 0.175846,-0.0955 0.382085,-0.0955 z m -0.08684,0.29308 q -0.175846,0 -0.321299,0.10421 -0.143282,0.1042 -0.249658,0.26268 v 1.13323 q 0.09118,0.1346 0.225778,0.21058 0.136769,0.076 0.297419,0.076 0.286564,0 0.427675,-0.21926 0.143282,-0.21927 0.143282,-0.67299 0,-0.45156 -0.128086,-0.67299 -0.128085,-0.22144 -0.395111,-0.22144 z" />
+            <path
+               id="path1305"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -27.70067,190.58073 q 0,-0.10421 0.04993,-0.19104 0.04993,-0.0868 0.136769,-0.13677 0.08684,-0.0521 0.193214,-0.0521 0.108547,0 0.195384,0.0521 0.08901,0.0499 0.13894,0.13677 0.04993,0.0868 0.04993,0.19104 0,0.10638 -0.04993,0.19538 -0.04993,0.0868 -0.13894,0.13894 -0.08684,0.0499 -0.195384,0.0499 -0.106376,0 -0.193214,-0.0499 -0.08684,-0.0521 -0.136769,-0.13894 -0.04993,-0.089 -0.04993,-0.19538 z" />
+            <path
+               id="path1307"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -24.54476,190.6502 q 0.306103,0 0.594838,-0.19973 l 0.178017,0.23881 q -0.149795,0.12591 -0.360376,0.20189 -0.210581,0.0738 -0.412479,0.0738 -0.336496,0 -0.579641,-0.14546 -0.240974,-0.14545 -0.366889,-0.41248 -0.125914,-0.26702 -0.125914,-0.62523 0,-0.34518 0.128085,-0.61654 0.128086,-0.27354 0.371231,-0.42768 0.243145,-0.15631 0.57747,-0.15631 0.436359,0 0.764171,0.26486 l -0.178017,0.24314 q -0.295248,-0.20406 -0.590496,-0.20406 -0.201897,0 -0.353863,0.0999 -0.151966,0.0999 -0.238804,0.30176 -0.08467,0.2019 -0.08467,0.49497 0,0.43853 0.182359,0.65346 0.18453,0.21492 0.494974,0.21492 z" />
+            <path
+               id="path1309"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -21.62331,187.66299 q 0.178017,0 0.327811,0.0326 0.149795,0.0304 0.290906,0.0912 l -0.11723,0.27137 q -0.212752,-0.0955 -0.490633,-0.0955 -0.479778,0 -0.479778,0.37991 v 0.46458 h 0.775026 l -0.03908,0.28657 h -0.735949 v 1.82141 h -0.364717 v -1.82141 h -0.544906 v -0.28657 h 0.544906 v -0.4559 q 0,-0.20624 0.108547,-0.36254 0.108547,-0.15631 0.297418,-0.24098 0.188872,-0.0847 0.427676,-0.0847 z" />
+            <path
+               id="path1311"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -18.397929,188.72892 q -0.134599,0.0413 -0.288735,0.0543 -0.151966,0.013 -0.379915,0.013 0.397282,0.18236 0.397282,0.5753 0,0.22577 -0.104205,0.40379 -0.102034,0.17585 -0.297419,0.27571 -0.193213,0.0977 -0.458068,0.0977 -0.112889,0 -0.191043,-0.009 -0.07598,-0.0109 -0.149795,-0.0347 -0.0521,0.0369 -0.08684,0.0977 -0.03256,0.0586 -0.03256,0.12374 0,0.089 0.06947,0.14111 0.06947,0.0499 0.236632,0.0499 h 0.412479 q 0.225777,0 0.410307,0.0825 0.186701,0.0803 0.290906,0.2236 0.106376,0.14112 0.106376,0.31479 0,0.3365 -0.284393,0.51668 -0.284393,0.18019 -0.807589,0.18019 -0.360377,0 -0.573129,-0.0738 -0.210581,-0.0738 -0.30176,-0.22578 -0.09118,-0.14979 -0.09118,-0.3886 h 0.329983 q 0,0.14112 0.0521,0.22361 0.05427,0.0847 0.191042,0.12592 0.138941,0.0412 0.39077,0.0412 0.373401,0 0.549247,-0.0933 0.175847,-0.0934 0.175847,-0.28222 0,-0.15848 -0.143282,-0.24314 -0.143283,-0.0847 -0.373402,-0.0847 h -0.408137 q -0.188872,0 -0.319128,-0.0586 -0.130256,-0.0586 -0.193214,-0.1563 -0.06296,-0.0977 -0.06296,-0.21493 0,-0.11071 0.06513,-0.21492 0.06513,-0.1042 0.186701,-0.18453 -0.197556,-0.1042 -0.290906,-0.25834 -0.09335,-0.15414 -0.09335,-0.3734 0,-0.22795 0.115059,-0.40814 0.117231,-0.18236 0.323471,-0.28439 0.20841,-0.10204 0.473264,-0.10204 0.27571,0 0.455898,-0.0217 0.180188,-0.0239 0.301761,-0.063 0.123743,-0.0391 0.284393,-0.10855 z m -1.154941,0.11723 q -0.267025,0 -0.403794,0.14328 -0.134599,0.14328 -0.134599,0.38426 0,0.24314 0.13677,0.3886 0.13894,0.14328 0.410307,0.14328 0.238804,0 0.366889,-0.13894 0.130257,-0.14111 0.130257,-0.39511 0,-0.25835 -0.128086,-0.39077 -0.128085,-0.1346 -0.377744,-0.1346 z" />
+          </g>
+        </g>
+      </g>
+      <g
+         id="text944"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light,  Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         aria-label="Pre-existing">
+        <path
+           id="path1314"
+           style=""
+           d="m 13.458904,163.24627 q 0,0.62287 -0.286632,0.91502 -0.283876,0.29214 -0.843359,0.29214 h -0.286632 v 1.66467 h -0.270096 v -4.02938 h 0.551216 q 0.5898,0 0.862651,0.27836 0.272852,0.27837 0.272852,0.87919 z m -1.416623,0.95912 h 0.270095 q 0.474045,0 0.672483,-0.22325 0.198437,-0.22324 0.198437,-0.73587 0,-0.48782 -0.206705,-0.69729 -0.20395,-0.21221 -0.633898,-0.21221 h -0.300412 z" />
+        <path
+           id="path1316"
+           style=""
+           d="m 14.875527,163.06988 q 0.14056,0 0.261828,0.0386 l -0.06339,0.26182 q -0.09922,-0.0413 -0.20395,-0.0413 -0.151584,0 -0.283876,0.1571 -0.129535,0.15434 -0.203949,0.4327 -0.07441,0.27837 -0.07441,0.61461 v 1.58474 h -0.261828 v -2.99034 h 0.214974 l 0.02756,0.52365 h 0.01929 q 0.209461,-0.58153 0.567751,-0.58153 z" />
+        <path
+           id="path1318"
+           style=""
+           d="m 16.438223,166.17322 q -0.474045,0 -0.73036,-0.40238 -0.25356,-0.40515 -0.25356,-1.12724 0,-0.76619 0.225999,-1.16857 0.228754,-0.40515 0.655946,-0.40515 0.37207,0 0.587044,0.35554 0.214974,0.35277 0.214974,0.9536 v 0.24253 h -1.416623 q 0.0055,0.65319 0.184657,0.97841 0.179145,0.32522 0.542947,0.32522 0.28112,0 0.592556,-0.18466 v 0.25356 q -0.286631,0.17914 -0.60358,0.17914 z m -0.118512,-2.86631 q -0.54019,0 -0.592556,1.07762 h 1.149284 q 0,-0.49334 -0.151584,-0.78548 -0.148828,-0.29214 -0.405144,-0.29214 z" />
+        <path
+           id="path1320"
+           style=""
+           d="m 17.551677,164.73455 v -0.28112 h 1.129992 v 0.28112 z" />
+        <path
+           id="path1322"
+           style=""
+           d="m 20.076243,166.17322 q -0.474045,0 -0.73036,-0.40238 -0.253559,-0.40515 -0.253559,-1.12724 0,-0.76619 0.225998,-1.16857 0.228755,-0.40515 0.655946,-0.40515 0.372071,0 0.587045,0.35554 0.214974,0.35277 0.214974,0.9536 v 0.24253 h -1.416624 q 0.0055,0.65319 0.184658,0.97841 0.179144,0.32522 0.542947,0.32522 0.281119,0 0.592556,-0.18466 v 0.25356 q -0.286632,0.17914 -0.603581,0.17914 z m -0.118511,-2.86631 q -0.540191,0 -0.592556,1.07762 h 1.149283 q 0,-0.49334 -0.151584,-0.78548 -0.148828,-0.29214 -0.405143,-0.29214 z" />
+        <path
+           id="path1324"
+           style=""
+           d="m 21.851157,164.56643 -0.655946,-1.43867 h 0.283876 l 0.501606,1.21267 0.523654,-1.21267 h 0.272852 l -0.666971,1.47174 0.700044,1.5186 h -0.275608 l -0.559483,-1.2926 -0.564996,1.2926 h -0.270096 z" />
+        <path
+           id="path1326"
+           style=""
+           d="m 23.568193,166.1181 h -0.261827 v -2.99034 h 0.261827 z m -0.300413,-3.81992 q 0,-0.12402 0.04961,-0.19292 0.05237,-0.0689 0.132292,-0.0689 0.07441,0 0.118511,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.118511,0.0689 -0.07993,0 -0.132292,-0.0689 -0.04961,-0.0717 -0.04961,-0.19017 z" />
+        <path
+           id="path1328"
+           style=""
+           d="m 25.538787,165.36845 q 0,0.37758 -0.198438,0.59256 -0.198437,0.21221 -0.573264,0.21221 -0.20395,0 -0.35829,-0.0524 -0.15434,-0.0524 -0.239778,-0.11576 v -0.30592 q 0.101974,0.10197 0.270095,0.16536 0.168121,0.0606 0.34451,0.0606 0.23151,0 0.363802,-0.15159 0.132291,-0.15158 0.132291,-0.40514 0,-0.19844 -0.09646,-0.33348 -0.09371,-0.13781 -0.361046,-0.31144 -0.305925,-0.19293 -0.418924,-0.30868 -0.110243,-0.11576 -0.173633,-0.25907 -0.06063,-0.14332 -0.06063,-0.34176 0,-0.32246 0.21773,-0.53192 0.21773,-0.21222 0.553971,-0.21222 0.361046,0 0.603581,0.17088 l -0.135048,0.22875 q -0.225998,-0.15158 -0.479557,-0.15158 -0.231511,0 -0.369315,0.1378 -0.137803,0.13505 -0.137803,0.35829 0,0.19844 0.09371,0.33349 0.09371,0.13229 0.396875,0.32246 0.297656,0.19568 0.407899,0.31419 0.110244,0.11576 0.162609,0.25907 0.05512,0.14056 0.05512,0.32522 z" />
+        <path
+           id="path1330"
+           style=""
+           d="m 26.688071,165.93069 q 0.121267,0 0.214974,-0.0331 v 0.22048 q -0.121267,0.0551 -0.311437,0.0551 -0.463021,0 -0.463021,-0.69177 v -2.12218 h -0.270095 v -0.15434 l 0.264583,-0.0772 0.08544,-0.71107 h 0.181901 v 0.71107 h 0.474045 v 0.23151 h -0.474045 v 2.04777 q 0,0.30316 0.06615,0.41341 0.06614,0.11024 0.23151,0.11024 z" />
+        <path
+           id="path1332"
+           style=""
+           d="m 27.636161,166.1181 h -0.261827 v -2.99034 h 0.261827 z m -0.300412,-3.81992 q 0,-0.12402 0.04961,-0.19292 0.05237,-0.0689 0.132292,-0.0689 0.07441,0 0.118511,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.118511,0.0689 -0.07993,0 -0.132292,-0.0689 -0.04961,-0.0717 -0.04961,-0.19017 z" />
+        <path
+           id="path1334"
+           style=""
+           d="m 29.783146,166.1181 v -2.06154 q 0,-0.74414 -0.440973,-0.74414 -0.336241,0 -0.493337,0.27836 -0.15434,0.27836 -0.15434,0.8847 v 1.64262 h -0.261828 v -2.99034 h 0.220486 l 0.02205,0.41617 h 0.02481 q 0.09371,-0.226 0.270095,-0.35002 0.176389,-0.12403 0.377583,-0.12403 0.347265,0 0.520898,0.23427 0.173633,0.23151 0.173633,0.7469 v 2.06705 z" />
+        <path
+           id="path1336"
+           style=""
+           d="m 32.401417,163.12776 v 0.18466 l -0.407899,0.0469 q 0.08268,0.10749 0.135048,0.30868 0.05237,0.19844 0.05237,0.4079 0,0.43546 -0.198438,0.70556 -0.195681,0.27009 -0.518142,0.27009 h -0.06615 l -0.05788,-0.006 q -0.132292,0.0937 -0.209462,0.18741 -0.07441,0.0937 -0.07441,0.21773 0,0.12678 0.09922,0.19844 0.09922,0.0689 0.267339,0.0689 h 0.187413 q 0.399631,0 0.620117,0.20671 0.220486,0.2067 0.220486,0.59807 0,0.43821 -0.297656,0.69453 -0.2949,0.25631 -0.779969,0.25631 -0.405144,0 -0.622874,-0.2067 -0.21773,-0.20395 -0.21773,-0.5898 0,-0.28112 0.143316,-0.48232 0.143316,-0.19843 0.449241,-0.31419 -0.137804,-0.0606 -0.223242,-0.16812 -0.08268,-0.10749 -0.08268,-0.25632 0,-0.13504 0.08819,-0.23977 0.09095,-0.10749 0.256315,-0.22876 -0.228755,-0.10473 -0.347266,-0.339 -0.115755,-0.23426 -0.115755,-0.55121 0,-0.4768 0.201194,-0.75241 0.201193,-0.27561 0.551215,-0.27561 0.187413,0 0.314193,0.0579 z m -1.609549,3.52778 q 0,0.28387 0.146073,0.44373 0.148828,0.15985 0.446484,0.15985 0.369314,0 0.584288,-0.19293 0.21773,-0.19292 0.21773,-0.52916 0,-0.2701 -0.148828,-0.41893 -0.146072,-0.14607 -0.427192,-0.14607 h -0.192925 q -0.270096,0 -0.449241,0.18741 -0.176389,0.19017 -0.176389,0.4961 z m 0.162609,-2.55213 q 0,0.36656 0.135048,0.55673 0.135047,0.18741 0.35829,0.18741 0.479557,0 0.479557,-0.7717 0,-0.37207 -0.124023,-0.58153 -0.121268,-0.20946 -0.355534,-0.20946 -0.239779,0 -0.366559,0.21497 -0.126779,0.21497 -0.126779,0.60358 z" />
+      </g>
+    </g>
+    <g
+       transform="matrix(1.2840056,0,0,1.2840056,170.32501,-55.53282)"
+       id="g1018">
+      <g
+         id="g984">
+        <g
+           transform="matrix(0.16927449,0,0,0.16927449,18.129782,197.28686)"
+           id="g969">
+          <path
+             style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:15.11811066;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="M 80,82.519531 V 490.33203 H 370 V 142.51953 H 310 V 82.519531 h -76.96428 z"
+             transform="scale(0.26458333)"
+             id="path965" />
+          <path
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             d="m 84.02057,19.833597 -2.883851,2.885153 15.875,15.875 2.883936,-2.884969 z"
+             id="path967" />
+        </g>
+        <g
+           id="g961"
+           transform="translate(55.373512,22.86756)">
+          <path
+             id="rect955"
+             d="m -43.65625,185.875 h 33.45089 v 7.93751 h -33.45089 z"
+             style="fill:#005ca0;fill-opacity:1;fill-rule:nonzero;stroke:#005ca0;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" />
+          <g
+             id="text959"
+             style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+             aria-label="default.cfg">
+            <path
+               id="path1340"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -39.500625,187.75748 0.364718,0.0456 v 3.20648 h -0.319128 l -0.03473,-0.30176 q -0.125915,0.17802 -0.290906,0.26486 -0.164992,0.0868 -0.358205,0.0868 -0.434188,0 -0.653453,-0.31912 -0.217094,-0.31913 -0.217094,-0.87055 0,-0.34518 0.106376,-0.61655 0.108547,-0.27137 0.310444,-0.42333 0.204069,-0.15414 0.479778,-0.15414 0.195385,0 0.34518,0.0673 0.151965,0.0673 0.267025,0.2019 z m -0.516684,1.21139 q -0.288735,0 -0.442871,0.22795 -0.151966,0.22577 -0.151966,0.67299 0,0.44287 0.13894,0.66865 0.141111,0.22578 0.410308,0.22578 0.32347,0 0.562273,-0.36038 v -1.14191 q -0.09335,-0.13894 -0.227949,-0.21493 -0.132427,-0.0781 -0.288735,-0.0781 z" />
+            <path
+               id="path1342"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -37.977261,189.99572 q 0.0087,0.25617 0.09986,0.42768 0.09118,0.16933 0.238804,0.25183 0.147624,0.0803 0.329982,0.0803 0.169334,0 0.310445,-0.0499 0.143282,-0.0499 0.29959,-0.15631 l 0.171504,0.24098 q -0.16065,0.12591 -0.36906,0.19755 -0.206239,0.0716 -0.41682,0.0716 -0.327812,0 -0.564445,-0.14762 -0.236632,-0.14762 -0.360376,-0.41682 -0.121573,-0.2692 -0.121573,-0.62523 0,-0.34518 0.123744,-0.61655 0.123744,-0.27137 0.349521,-0.42333 0.225778,-0.15414 0.525368,-0.15414 0.286564,0 0.494974,0.1346 0.210581,0.1346 0.321299,0.3886 0.112889,0.25183 0.112889,0.59701 0,0.0999 -0.0087,0.19972 z m 0.620889,-1.02034 q -0.264855,0 -0.432017,0.1867 -0.164992,0.18453 -0.186701,0.55142 h 1.191846 q -0.0065,-0.36038 -0.158479,-0.54925 -0.151965,-0.18887 -0.414649,-0.18887 z" />
+            <path
+               id="path1344"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -34.309008,187.75748 q 0.178017,0 0.327811,0.0326 0.149795,0.0304 0.290906,0.0912 l -0.11723,0.27136 q -0.212752,-0.0955 -0.490633,-0.0955 -0.479778,0 -0.479778,0.37992 v 0.46458 h 0.775026 l -0.03908,0.28656 h -0.735949 v 1.82142 h -0.364717 v -1.82142 h -0.544906 v -0.28656 h 0.544906 v -0.4559 q 0,-0.20624 0.108547,-0.36255 0.108547,-0.1563 0.297418,-0.24097 0.188872,-0.0847 0.427676,-0.0847 z" />
+            <path
+               id="path1346"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -31.417953,190.51024 q 0,0.13459 0.04342,0.19972 0.04342,0.063 0.143282,0.0934 l -0.08901,0.25617 q -0.329983,-0.0434 -0.418992,-0.3213 -0.121572,0.15848 -0.308273,0.24098 -0.18453,0.0803 -0.408137,0.0803 -0.225778,0 -0.39294,-0.0868 -0.167163,-0.0868 -0.256171,-0.24532 -0.08901,-0.16065 -0.08901,-0.3734 0,-0.35387 0.27571,-0.54274 0.275709,-0.18887 0.796735,-0.18887 h 0.336495 v -0.19104 q 0,-0.2388 -0.13894,-0.34518 -0.13894,-0.10855 -0.405966,-0.10855 -0.258341,0 -0.594837,0.11723 l -0.09552,-0.27571 q 0.382085,-0.14328 0.746803,-0.14328 0.418991,0 0.636085,0.19756 0.219265,0.19538 0.219265,0.54056 z m -0.944359,0.27136 q 0.169334,0 0.3213,-0.0847 0.154136,-0.0868 0.25617,-0.23881 v -0.58832 h -0.329982 q -0.362547,0 -0.525368,0.12374 -0.16282,0.12375 -0.16282,0.35604 0,0.43201 0.4407,0.43201 z" />
+            <path
+               id="path1348"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -30.085631,190.34307 q 0,0.22361 0.09118,0.32564 0.09335,0.0999 0.293077,0.0999 0.180188,0 0.349521,-0.10421 0.171505,-0.1042 0.269197,-0.25834 v -1.68248 h 0.364718 v 2.286 h -0.310445 l -0.03039,-0.30827 q -0.132427,0.16933 -0.329983,0.26485 -0.195384,0.0934 -0.401624,0.0934 -0.327811,0 -0.494974,-0.17367 -0.164991,-0.17585 -0.164991,-0.49932 v -1.66294 h 0.364718 z" />
+            <path
+               id="path1350"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -26.955772,190.44511 q 0,0.16065 0.09986,0.23663 0.102034,0.0738 0.27788,0.0738 0.18453,0 0.384256,-0.0803 l 0.09769,0.26702 q -0.104206,0.0521 -0.243146,0.0847 -0.13894,0.0326 -0.299589,0.0326 -0.201898,0 -0.358206,-0.076 -0.154136,-0.076 -0.238803,-0.21926 -0.08467,-0.14329 -0.08467,-0.33867 v -2.33376 h -0.701213 v -0.28874 h 1.065931 z" />
+            <path
+               id="path1352"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -23.42646,190.89449 q -0.11506,0.076 -0.284393,0.1194 -0.167163,0.0456 -0.327812,0.0456 -0.240974,0 -0.41465,-0.0868 -0.171504,-0.089 -0.262683,-0.24532 -0.09118,-0.15631 -0.09118,-0.35821 v -1.36335 h -0.525367 v -0.28222 h 0.525367 v -0.51885 l 0.364718,-0.0434 v 0.56227 h 0.790222 l -0.04342,0.28222 h -0.746803 v 1.35901 q 0,0.19539 0.102034,0.29308 0.104205,0.0977 0.334325,0.0977 0.232291,0 0.43853,-0.10854 z" />
+            <path
+               id="path1354"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -22.154925,190.67523 q 0,-0.10421 0.04993,-0.19105 0.04993,-0.0868 0.136769,-0.13676 0.08684,-0.0521 0.193214,-0.0521 0.108547,0 0.195384,0.0521 0.08901,0.0499 0.13894,0.13676 0.04993,0.0868 0.04993,0.19105 0,0.10637 -0.04993,0.19538 -0.04993,0.0868 -0.13894,0.13894 -0.08684,0.0499 -0.195384,0.0499 -0.106377,0 -0.193214,-0.0499 -0.08684,-0.0521 -0.136769,-0.13894 -0.04993,-0.089 -0.04993,-0.19538 z" />
+            <path
+               id="path1356"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -18.999014,190.7447 q 0.306103,0 0.594838,-0.19973 l 0.178017,0.2388 q -0.149795,0.12592 -0.360376,0.2019 -0.210582,0.0738 -0.412479,0.0738 -0.336496,0 -0.579641,-0.14545 -0.240974,-0.14545 -0.366889,-0.41248 -0.125914,-0.26702 -0.125914,-0.62523 0,-0.34518 0.128085,-0.61655 0.128085,-0.27353 0.371231,-0.42767 0.243145,-0.15631 0.57747,-0.15631 0.436359,0 0.764171,0.26486 l -0.178017,0.24314 q -0.295248,-0.20407 -0.590496,-0.20407 -0.201897,0 -0.353863,0.0999 -0.151966,0.0999 -0.238804,0.30176 -0.08467,0.20189 -0.08467,0.49497 0,0.43853 0.182359,0.65345 0.18453,0.21493 0.494974,0.21493 z" />
+            <path
+               id="path1358"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -16.077565,187.75748 q 0.178017,0 0.327812,0.0326 0.149795,0.0304 0.290906,0.0912 l -0.11723,0.27136 q -0.212753,-0.0955 -0.490633,-0.0955 -0.479778,0 -0.479778,0.37992 v 0.46458 h 0.775026 l -0.03908,0.28656 h -0.735949 v 1.82142 h -0.364718 v -1.82142 h -0.544906 v -0.28656 h 0.544906 v -0.4559 q 0,-0.20624 0.108547,-0.36255 0.108547,-0.1563 0.297419,-0.24097 0.188872,-0.0847 0.427675,-0.0847 z" />
+            <path
+               id="path1360"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               d="m -12.852184,188.82342 q -0.134598,0.0412 -0.288735,0.0543 -0.151965,0.013 -0.379914,0.013 0.397282,0.18236 0.397282,0.5753 0,0.22578 -0.104205,0.4038 -0.102034,0.17584 -0.297419,0.27571 -0.193214,0.0977 -0.458068,0.0977 -0.112889,0 -0.191043,-0.009 -0.07598,-0.0109 -0.149795,-0.0347 -0.0521,0.0369 -0.08684,0.0977 -0.03256,0.0586 -0.03256,0.12375 0,0.089 0.06947,0.14111 0.06947,0.0499 0.236633,0.0499 h 0.412479 q 0.225777,0 0.410307,0.0825 0.186701,0.0803 0.290906,0.2236 0.106376,0.14111 0.106376,0.31479 0,0.33649 -0.284393,0.51668 -0.284393,0.18019 -0.80759,0.18019 -0.360376,0 -0.573128,-0.0738 -0.210581,-0.0738 -0.30176,-0.22578 -0.09118,-0.14979 -0.09118,-0.3886 h 0.329983 q 0,0.14111 0.0521,0.22361 0.05427,0.0847 0.191042,0.12591 0.13894,0.0412 0.390769,0.0412 0.373402,0 0.549248,-0.0933 0.175846,-0.0934 0.175846,-0.28222 0,-0.15848 -0.143282,-0.24315 -0.143282,-0.0847 -0.373401,-0.0847 h -0.408137 q -0.188872,0 -0.319128,-0.0586 -0.130257,-0.0586 -0.193214,-0.15631 -0.06296,-0.0977 -0.06296,-0.21492 0,-0.11072 0.06513,-0.21492 0.06513,-0.10421 0.186701,-0.18453 -0.197556,-0.10421 -0.290906,-0.25834 -0.09335,-0.15414 -0.09335,-0.37341 0,-0.22794 0.115059,-0.40813 0.117231,-0.18236 0.32347,-0.2844 0.208411,-0.10203 0.473265,-0.10203 0.27571,0 0.455898,-0.0217 0.180188,-0.0239 0.30176,-0.063 0.123744,-0.0391 0.284394,-0.10854 z m -1.15494,0.11723 q -0.267025,0 -0.403795,0.14328 -0.134598,0.14328 -0.134598,0.38425 0,0.24315 0.136769,0.3886 0.138941,0.14328 0.410308,0.14328 0.238803,0 0.366889,-0.13894 0.130256,-0.14111 0.130256,-0.39511 0,-0.25834 -0.128085,-0.39077 -0.128086,-0.13459 -0.377744,-0.13459 z" />
+          </g>
+        </g>
+      </g>
+      <g
+         id="text973"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light,  Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         aria-label="PyScaffold's own
+config file">
+        <path
+           id="path1363"
+           style="text-align:center;text-anchor:middle"
+           d="m 15.349967,223.91145 q 0,0.62287 -0.286632,0.91502 -0.283876,0.29214 -0.84336,0.29214 h -0.286632 v 1.66467 h -0.270095 v -4.02938 h 0.551215 q 0.589801,0 0.862652,0.27836 0.272852,0.27836 0.272852,0.87919 z m -1.416624,0.95911 h 0.270096 q 0.474045,0 0.672483,-0.22324 0.198437,-0.22324 0.198437,-0.73587 0,-0.48783 -0.206706,-0.69729 -0.203949,-0.21222 -0.633897,-0.21222 h -0.300413 z" />
+        <path
+           id="path1365"
+           style="text-align:center;text-anchor:middle"
+           d="m 16.311837,226.77777 -0.746896,-2.98483 h 0.264583 l 0.451997,1.86586 q 0.07993,0.33624 0.15434,0.75792 h 0.02205 q 0.05237,-0.36656 0.146072,-0.76343 l 0.440972,-1.86035 h 0.264583 l -0.873676,3.55534 q -0.09646,0.39411 -0.253559,0.59255 -0.15434,0.19844 -0.413412,0.19844 -0.10473,0 -0.237022,-0.0469 v -0.23703 q 0.110243,0.0386 0.214974,0.0386 0.165364,0 0.261827,-0.14332 0.09646,-0.14056 0.170877,-0.45475 z" />
+        <path
+           id="path1367"
+           style="text-align:center;text-anchor:middle"
+           d="m 19.321473,225.7277 q 0,0.4961 -0.275608,0.80478 -0.275607,0.30592 -0.700043,0.30592 -0.482313,0 -0.774457,-0.14056 v -0.29214 q 0.143316,0.0799 0.355533,0.12678 0.212218,0.0469 0.418924,0.0469 0.308681,0 0.507118,-0.23427 0.198438,-0.23426 0.198438,-0.59531 0,-0.33348 -0.14056,-0.52917 -0.14056,-0.19568 -0.537435,-0.39136 -0.311437,-0.1571 -0.465777,-0.30317 -0.15434,-0.14883 -0.228754,-0.34451 -0.07441,-0.19568 -0.07441,-0.46853 0,-0.29766 0.121268,-0.52917 0.121267,-0.23151 0.338997,-0.35829 0.21773,-0.12953 0.476801,-0.12953 0.234267,0 0.424436,0.0524 0.192926,0.0524 0.303169,0.113 l -0.104731,0.25907 q -0.305925,-0.15709 -0.622874,-0.15709 -0.297656,0 -0.485069,0.20395 -0.184657,0.20119 -0.184657,0.53468 0,0.33899 0.135048,0.52641 0.135047,0.18741 0.529166,0.3886 0.4079,0.19844 0.595313,0.46578 0.190169,0.26458 0.190169,0.64492 z" />
+        <path
+           id="path1369"
+           style="text-align:center;text-anchor:middle"
+           d="m 20.729828,226.8384 q -0.44924,0 -0.677995,-0.38861 -0.225998,-0.39136 -0.225998,-1.14652 0,-0.76619 0.228754,-1.16582 0.231511,-0.40239 0.680751,-0.40239 0.278364,0 0.463021,0.10197 l -0.101975,0.23151 q -0.184657,-0.0854 -0.338997,-0.0854 -0.658702,0 -0.658702,1.31464 0,1.30363 0.658702,1.30363 0.195681,0 0.424436,-0.0882 v 0.22049 q -0.09095,0.0496 -0.223243,0.0772 -0.132291,0.0276 -0.228754,0.0276 z" />
+        <path
+           id="path1371"
+           style="text-align:center;text-anchor:middle"
+           d="m 22.8713,226.78328 -0.03307,-0.41892 h -0.01103 q -0.214974,0.47404 -0.650434,0.47404 -0.292144,0 -0.471289,-0.23151 -0.176389,-0.23427 -0.176389,-0.62563 0,-0.42719 0.256316,-0.67524 0.256315,-0.2508 0.719335,-0.27285 l 0.322461,-0.0165 v -0.24804 q 0,-0.41893 -0.10473,-0.6091 -0.104731,-0.19292 -0.347266,-0.19292 -0.256315,0 -0.523655,0.16812 l -0.112999,-0.20671 q 0.311437,-0.19292 0.65319,-0.19292 0.369315,0 0.531923,0.23427 0.162609,0.23151 0.162609,0.77721 v 2.03674 z m -0.636654,-0.16812 q 0.28112,0 0.43546,-0.27561 0.157096,-0.27836 0.157096,-0.78548 v -0.31144 l -0.311436,0.0165 q -0.361046,0.0193 -0.537435,0.20119 -0.173633,0.17915 -0.173633,0.52641 0,0.32522 0.115755,0.4768 0.115756,0.15159 0.314193,0.15159 z" />
+        <path
+           id="path1373"
+           style="text-align:center;text-anchor:middle"
+           d="m 24.637944,224.02445 h -0.468533 v 2.75883 H 23.91034 v -2.75883 h -0.380338 v -0.14883 l 0.380338,-0.113 v -0.226 q 0,-0.57051 0.135048,-0.82131 0.135048,-0.2508 0.468533,-0.2508 0.192925,0 0.350022,0.0689 l -0.09095,0.24253 q -0.146072,-0.0689 -0.264583,-0.0689 -0.135048,0 -0.20395,0.0799 -0.0689,0.0799 -0.101975,0.25907 -0.03307,0.17914 -0.03307,0.49609 v 0.25081 h 0.468533 z m 1.276064,0 h -0.468533 v 2.75883 h -0.259071 v -2.75883 h -0.380339 v -0.14883 l 0.380339,-0.113 v -0.226 q 0,-0.57051 0.135047,-0.82131 0.135048,-0.2508 0.468533,-0.2508 0.192926,0 0.350022,0.0689 l -0.09095,0.24253 q -0.146072,-0.0689 -0.264584,-0.0689 -0.135047,0 -0.203949,0.0799 -0.0689,0.0799 -0.101975,0.25907 -0.03307,0.17914 -0.03307,0.49609 v 0.25081 h 0.468533 z" />
+        <path
+           id="path1375"
+           style="text-align:center;text-anchor:middle"
+           d="m 28.08304,225.28122 q 0,0.75516 -0.239779,1.15755 -0.237023,0.39963 -0.680751,0.39963 -0.438216,0 -0.672482,-0.39963 -0.231511,-0.40239 -0.231511,-1.15755 0,-1.54616 0.915017,-1.54616 0.429948,0 0.669727,0.40514 0.239779,0.40515 0.239779,1.14102 z m -1.551671,0 q 0,0.64768 0.15434,0.9784 0.15434,0.33073 0.482313,0.33073 0.642166,0 0.642166,-1.30913 0,-1.29811 -0.642166,-1.29811 -0.336241,0 -0.487825,0.32521 -0.148828,0.32522 -0.148828,0.9729 z" />
+        <path
+           id="path1377"
+           style="text-align:center;text-anchor:middle"
+           d="m 29.009081,226.78328 h -0.261827 v -4.28846 h 0.261827 z" />
+        <path
+           id="path1379"
+           style="text-align:center;text-anchor:middle"
+           d="m 30.535949,226.8384 q -0.870921,0 -0.870921,-1.54616 0,-0.76067 0.21773,-1.15755 0.21773,-0.39963 0.642166,-0.39963 0.201194,0 0.380339,0.11575 0.181901,0.11576 0.289388,0.31971 h 0.02205 l -0.01102,-0.33349 v -1.34221 h 0.261827 v 4.28846 h -0.214974 l -0.02205,-0.41892 h -0.02481 q -0.107487,0.22875 -0.278364,0.35277 -0.170876,0.12127 -0.391362,0.12127 z m 0.01654,-0.22875 q 0.314193,0 0.482313,-0.28939 0.170877,-0.29215 0.170877,-0.85714 v -0.17088 q 0,-0.67799 -0.165364,-0.99219 -0.162609,-0.31694 -0.49885,-0.31694 -0.322461,0 -0.463021,0.33899 -0.14056,0.33624 -0.14056,0.97565 0,0.64493 0.146072,0.97841 0.146072,0.33349 0.468533,0.33349 z" />
+        <path
+           id="path1381"
+           style="text-align:center;text-anchor:middle"
+           d="m 32.569933,222.7539 -0.07993,1.4552 h -0.16812 l -0.09095,-1.4552 z" />
+        <path
+           id="path1383"
+           style="text-align:center;text-anchor:middle"
+           d="m 34.507454,226.03363 q 0,0.37758 -0.198438,0.59255 -0.198437,0.21222 -0.573264,0.21222 -0.203949,0 -0.35829,-0.0524 -0.15434,-0.0524 -0.239778,-0.11576 v -0.30592 q 0.101974,0.10197 0.270095,0.16536 0.168121,0.0606 0.34451,0.0606 0.23151,0 0.363802,-0.15158 0.132291,-0.15158 0.132291,-0.40514 0,-0.19844 -0.09646,-0.33349 -0.09371,-0.1378 -0.361046,-0.31144 -0.305925,-0.19292 -0.418924,-0.30868 -0.110243,-0.11575 -0.173633,-0.25907 -0.06063,-0.14331 -0.06063,-0.34175 0,-0.32246 0.21773,-0.53192 0.21773,-0.21222 0.553971,-0.21222 0.361046,0 0.603581,0.17088 l -0.135048,0.22875 q -0.225998,-0.15158 -0.479557,-0.15158 -0.231511,0 -0.369315,0.1378 -0.137803,0.13505 -0.137803,0.35829 0,0.19844 0.09371,0.33348 0.09371,0.1323 0.396875,0.32247 0.297656,0.19568 0.4079,0.31419 0.110243,0.11575 0.162608,0.25907 0.05512,0.14056 0.05512,0.32522 z" />
+        <path
+           id="path1385"
+           style="text-align:center;text-anchor:middle"
+           d="m 37.850574,225.28122 q 0,0.75516 -0.239779,1.15755 -0.237022,0.39963 -0.680751,0.39963 -0.438216,0 -0.672482,-0.39963 -0.231511,-0.40239 -0.231511,-1.15755 0,-1.54616 0.915018,-1.54616 0.429948,0 0.669726,0.40514 0.239779,0.40515 0.239779,1.14102 z m -1.551671,0 q 0,0.64768 0.15434,0.9784 0.15434,0.33073 0.482314,0.33073 0.642165,0 0.642165,-1.30913 0,-1.29811 -0.642165,-1.29811 -0.336242,0 -0.487826,0.32521 -0.148828,0.32522 -0.148828,0.9729 z" />
+        <path
+           id="path1387"
+           style="text-align:center;text-anchor:middle"
+           d="m 40.176702,226.78328 -0.413411,-2.02572 q -0.0055,-0.0221 -0.01102,-0.0469 -0.0028,-0.0248 -0.08544,-0.52917 h -0.0055 l -0.03858,0.23427 -0.06339,0.34175 -0.427192,2.02572 h -0.311436 l -0.650434,-2.99034 h 0.261827 l 0.37207,1.74184 0.173633,0.9095 h 0.01654 q 0.04961,-0.39412 0.159852,-0.91502 l 0.37207,-1.73632 h 0.275608 l 0.374826,1.74184 q 0.0441,0.19568 0.157097,0.9095 h 0.01654 q 0.0083,-0.0909 0.07993,-0.45751 0.07441,-0.36655 0.468533,-2.19383 h 0.259071 l -0.672482,2.99034 z" />
+        <path
+           id="path1389"
+           style="text-align:center;text-anchor:middle"
+           d="m 42.963095,226.78328 v -2.06155 q 0,-0.74414 -0.440972,-0.74414 -0.336241,0 -0.493337,0.27837 -0.154341,0.27836 -0.154341,0.8847 v 1.64262 h -0.261827 v -2.99034 h 0.220486 l 0.02205,0.41616 h 0.0248 q 0.09371,-0.22599 0.270096,-0.35002 0.176389,-0.12402 0.377582,-0.12402 0.347266,0 0.520899,0.23427 0.173633,0.23151 0.173633,0.74689 v 2.06706 z" />
+        <path
+           id="path1391"
+           style="text-align:center;text-anchor:middle"
+           d="m 20.834559,233.89396 q -0.449241,0 -0.677995,-0.38861 -0.225998,-0.39136 -0.225998,-1.14653 0,-0.76619 0.228754,-1.16582 0.23151,-0.40239 0.680751,-0.40239 0.278364,0 0.463021,0.10198 l -0.101975,0.23151 q -0.184657,-0.0854 -0.338997,-0.0854 -0.658703,0 -0.658703,1.31465 0,1.30362 0.658703,1.30362 0.195681,0 0.424435,-0.0882 v 0.22049 q -0.09095,0.0496 -0.223242,0.0772 -0.132292,0.0276 -0.228754,0.0276 z" />
+        <path
+           id="path1393"
+           style="text-align:center;text-anchor:middle"
+           d="m 23.502441,232.33677 q 0,0.75517 -0.239779,1.15756 -0.237022,0.39963 -0.680751,0.39963 -0.438216,0 -0.672482,-0.39963 -0.231511,-0.40239 -0.231511,-1.15756 0,-1.54616 0.915018,-1.54616 0.429947,0 0.669726,0.40515 0.239779,0.40514 0.239779,1.14101 z m -1.551671,0 q 0,0.64768 0.15434,0.97841 0.15434,0.33073 0.482313,0.33073 0.642166,0 0.642166,-1.30914 0,-1.29811 -0.642166,-1.29811 -0.336241,0 -0.487825,0.32522 -0.148828,0.32522 -0.148828,0.97289 z" />
+        <path
+           id="path1395"
+           style="text-align:center;text-anchor:middle"
+           d="m 25.517133,233.83884 v -2.06155 q 0,-0.74414 -0.440973,-0.74414 -0.336241,0 -0.493337,0.27836 -0.154341,0.27837 -0.154341,0.8847 v 1.64263 h -0.261827 v -2.99035 h 0.220486 l 0.02205,0.41617 h 0.02481 q 0.09371,-0.226 0.270095,-0.35002 0.176389,-0.12403 0.377583,-0.12403 0.347265,0 0.520898,0.23427 0.173633,0.23151 0.173633,0.7469 v 2.06706 z" />
+        <path
+           id="path1397"
+           style="text-align:center;text-anchor:middle"
+           d="m 27.333387,231.08 h -0.468533 v 2.75884 H 26.605783 V 231.08 h -0.380339 v -0.14883 l 0.380339,-0.11299 v -0.226 q 0,-0.57051 0.135047,-0.82131 0.135048,-0.25081 0.468533,-0.25081 0.192926,0 0.350022,0.0689 l -0.09095,0.24253 q -0.146073,-0.0689 -0.264584,-0.0689 -0.135048,0 -0.203949,0.0799 -0.0689,0.0799 -0.101975,0.25908 -0.03307,0.17914 -0.03307,0.49609 v 0.2508 h 0.468533 z m 0.746896,2.75884 h -0.261827 v -2.99035 h 0.261827 z m -0.300412,-3.81993 q 0,-0.12402 0.04961,-0.19292 0.05236,-0.0689 0.132291,-0.0689 0.07441,0 0.118511,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.118511,0.0689 -0.07993,0 -0.132291,-0.0689 -0.04961,-0.0717 -0.04961,-0.19017 z" />
+        <path
+           id="path1399"
+           style="text-align:center;text-anchor:middle"
+           d="m 30.450509,230.84849 v 0.18466 L 30.04261,231.08 q 0.08268,0.10749 0.135048,0.30868 0.05236,0.19844 0.05236,0.4079 0,0.43546 -0.198437,0.70556 -0.195682,0.27009 -0.518142,0.27009 h -0.06615 l -0.05788,-0.006 q -0.132292,0.0937 -0.209462,0.18741 -0.07441,0.0937 -0.07441,0.21773 0,0.12678 0.09922,0.19844 0.09922,0.0689 0.267339,0.0689 h 0.187414 q 0.399631,0 0.620117,0.20671 0.220486,0.20671 0.220486,0.59807 0,0.43821 -0.297656,0.69453 -0.294901,0.25631 -0.77997,0.25631 -0.405143,0 -0.622873,-0.2067 -0.21773,-0.20395 -0.21773,-0.5898 0,-0.28112 0.143316,-0.48231 0.143316,-0.19844 0.44924,-0.3142 -0.137804,-0.0606 -0.223242,-0.16812 -0.08268,-0.10749 -0.08268,-0.25631 0,-0.13505 0.08819,-0.23978 0.09095,-0.10749 0.256315,-0.22876 -0.228754,-0.10473 -0.347265,-0.33899 -0.115756,-0.23427 -0.115756,-0.55122 0,-0.4768 0.201194,-0.75241 0.201194,-0.27561 0.551215,-0.27561 0.187413,0 0.314193,0.0579 z m -1.609548,3.52778 q 0,0.28388 0.146072,0.44373 0.148828,0.15985 0.446484,0.15985 0.369315,0 0.584288,-0.19292 0.217731,-0.19293 0.217731,-0.52917 0,-0.2701 -0.148829,-0.41892 -0.146072,-0.14608 -0.427191,-0.14608 H 29.46659 q -0.270095,0 -0.44924,0.18742 -0.176389,0.19017 -0.176389,0.49609 z m 0.162608,-2.55213 q 0,0.36656 0.135048,0.55673 0.135048,0.18741 0.35829,0.18741 0.479557,0 0.479557,-0.7717 0,-0.37207 -0.124023,-0.58153 -0.121267,-0.20946 -0.355534,-0.20946 -0.239779,0 -0.366558,0.21497 -0.12678,0.21498 -0.12678,0.60358 z" />
+        <path
+           id="path1401"
+           style="text-align:center;text-anchor:middle"
+           d="m 32.746321,231.08 h -0.468533 v 2.75884 H 32.018717 V 231.08 h -0.380339 v -0.14883 l 0.380339,-0.11299 v -0.226 q 0,-0.57051 0.135048,-0.82131 0.135047,-0.25081 0.468533,-0.25081 0.192925,0 0.350021,0.0689 l -0.09095,0.24253 q -0.146072,-0.0689 -0.264584,-0.0689 -0.135047,0 -0.203949,0.0799 -0.0689,0.0799 -0.101975,0.25908 -0.03307,0.17914 -0.03307,0.49609 v 0.2508 h 0.468533 z m 0.746897,2.75884 h -0.261827 v -2.99035 h 0.261827 z m -0.300413,-3.81993 q 0,-0.12402 0.04961,-0.19292 0.05237,-0.0689 0.132291,-0.0689 0.07441,0 0.118512,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.118512,0.0689 -0.07993,0 -0.132291,-0.0689 -0.04961,-0.0717 -0.04961,-0.19017 z" />
+        <path
+           id="path1403"
+           style="text-align:center;text-anchor:middle"
+           d="m 34.55982,233.83884 h -0.261828 v -4.28846 h 0.261828 z" />
+        <path
+           id="path1405"
+           style="text-align:center;text-anchor:middle"
+           d="m 36.205197,233.89396 q -0.474045,0 -0.73036,-0.40239 -0.253559,-0.40514 -0.253559,-1.12724 0,-0.76619 0.225998,-1.16857 0.228755,-0.40515 0.655947,-0.40515 0.37207,0 0.587044,0.35554 0.214974,0.35278 0.214974,0.9536 v 0.24254 h -1.416624 q 0.0055,0.65319 0.184658,0.9784 0.179145,0.32522 0.542947,0.32522 0.281119,0 0.592556,-0.18466 v 0.25356 q -0.286632,0.17915 -0.603581,0.17915 z m -0.118511,-2.86632 q -0.540191,0 -0.592556,1.07762 h 1.149283 q 0,-0.49333 -0.151584,-0.78548 -0.148828,-0.29214 -0.405143,-0.29214 z" />
+      </g>
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4782)"
+       d="m 128.72091,147.80019 v 39.29677"
+       id="path4778" />
+    <g
+       transform="matrix(1.2840056,0,0,1.2840056,-56.685115,-0.73911601)"
+       id="g6777" />
+    <g
+       transform="matrix(1.2840056,0,0,1.2840056,-8.152768,-79.556336)"
+       id="g12869">
+      <path
+         id="rect4716"
+         d="m 59.208752,210.24072 h 7.192522 c 1.130649,0 2.040883,0.91024 2.040883,2.04089 v 7.0643 c 0,1.13065 -0.910234,2.04089 -2.040883,2.04089 h -7.192522 c -1.130649,0 -2.040882,-0.91024 -2.040882,-2.04089 v -7.0643 c 0,-1.13065 0.910233,-2.04089 2.040882,-2.04089 z"
+         style="fill:#dafcf1;fill-opacity:1;fill-rule:nonzero;stroke:#10b981;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" />
+      <g
+         id="text4720"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         aria-label="{}">
+        <path
+           id="path1409"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           d="m 62.200562,213.63052 q -0.324193,0 -0.516683,0.10131 -0.19249,0.0988 -0.169696,0.32673 l 0.113975,1.12708 q 0.0076,0.0684 0.0076,0.12664 0,0.22035 -0.09625,0.34192 -0.09371,0.11904 -0.291268,0.15957 0.200089,0.038 0.293801,0.14943 0.09371,0.11144 0.09371,0.33686 0,0.0659 -0.0076,0.14183 l -0.113975,1.12708 q -0.0025,0.0152 -0.0025,0.0456 0,0.20515 0.187424,0.2938 0.189957,0.0887 0.501487,0.0887 v 0.26847 q -0.400176,0 -0.691444,-0.14943 -0.288735,-0.1469 -0.288735,-0.50655 0,-0.0253 0.0051,-0.0912 l 0.111442,-1.03337 q 0.0076,-0.0608 0.0076,-0.11904 0,-0.14184 -0.06585,-0.23302 -0.06332,-0.0937 -0.238079,-0.14436 -0.172228,-0.0507 -0.491357,-0.0507 v -0.24821 q 0.319129,0 0.491357,-0.0481 0.17476,-0.0507 0.238079,-0.14184 0.06585,-0.0912 0.06585,-0.23301 0,-0.0557 -0.0076,-0.11904 l -0.111442,-1.04097 q -0.0051,-0.0608 -0.0051,-0.0886 0,-0.35712 0.288735,-0.50656 0.288735,-0.14943 0.691444,-0.14943 z" />
+        <path
+           id="path1411"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
+           d="m 63.749872,213.36205 q 0.400176,0 0.688911,0.14943 0.291268,0.1469 0.291268,0.50656 0,0.0253 -0.0051,0.0912 l -0.111442,1.03843 q -0.0051,0.0608 -0.0051,0.0887 0,0.14943 0.07092,0.24821 0.07345,0.0988 0.245678,0.15196 0.174761,0.0532 0.476159,0.0532 v 0.24821 q -0.4407,0 -0.617994,0.11651 -0.174761,0.11651 -0.174761,0.34192 0,0.0279 0.0051,0.0887 l 0.111442,1.0359 q 0.0051,0.0608 0.0051,0.0887 0,0.35711 -0.288735,0.50655 -0.288735,0.14943 -0.691444,0.14943 v -0.26847 q 0.329259,0 0.519216,-0.0988 0.189957,-0.0988 0.167162,-0.32926 l -0.113974,-1.12708 q -0.0076,-0.0811 -0.0076,-0.1469 0,-0.22795 0.103843,-0.33179 0.103843,-0.10638 0.35712,-0.14184 -0.240613,-0.043 -0.349522,-0.16716 -0.108908,-0.1241 -0.108908,-0.35205 0,-0.076 0.0051,-0.11651 l 0.113974,-1.12708 q 0.0025,-0.0152 0.0025,-0.0431 0,-0.20515 -0.189957,-0.2938 -0.187425,-0.0912 -0.498954,-0.0912 z" />
+      </g>
+    </g>
+    <g
+       id="g9228"
+       transform="matrix(1.2840056,0,0,1.2840056,-282.72951,-12.694343)">
+      <g
+         id="text8853"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         aria-label="Project Structure">
+        <path
+           id="path1414"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 247.16019,176.35029 q 0,0.62287 -0.28663,0.91502 -0.28388,0.29214 -0.84336,0.29214 h -0.28663 v 1.66467 h -0.2701 v -4.02938 h 0.55122 q 0.5898,0 0.86265,0.27836 0.27285,0.27837 0.27285,0.87919 z m -1.41662,0.95912 h 0.27009 q 0.47405,0 0.67249,-0.22325 0.19843,-0.22324 0.19843,-0.73587 0,-0.48782 -0.2067,-0.69729 -0.20395,-0.21221 -0.6339,-0.21221 h -0.30041 z" />
+        <path
+           id="path1416"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 248.57681,176.1739 q 0.14056,0 0.26183,0.0386 l -0.0634,0.26182 q -0.0992,-0.0413 -0.20395,-0.0413 -0.15158,0 -0.28387,0.1571 -0.12954,0.15434 -0.20395,0.4327 -0.0744,0.27837 -0.0744,0.61461 v 1.58474 h -0.26182 v -2.99034 h 0.21497 l 0.0276,0.52365 h 0.0193 q 0.20946,-0.58153 0.56775,-0.58153 z" />
+        <path
+           id="path1418"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 250.9746,177.72006 q 0,0.75517 -0.23978,1.15755 -0.23702,0.39963 -0.68075,0.39963 -0.43821,0 -0.67248,-0.39963 -0.23151,-0.40238 -0.23151,-1.15755 0,-1.54616 0.91502,-1.54616 0.42994,0 0.66972,0.40514 0.23978,0.40515 0.23978,1.14102 z m -1.55167,0 q 0,0.64768 0.15434,0.97841 0.15434,0.33073 0.48231,0.33073 0.64217,0 0.64217,-1.30914 0,-1.29811 -0.64217,-1.29811 -0.33624,0 -0.48782,0.32522 -0.14883,0.32521 -0.14883,0.97289 z" />
+        <path
+           id="path1420"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 251.41282,180.57811 q -0.11576,0 -0.18466,-0.0469 v -0.24805 q 0.0882,0.0441 0.17363,0.0441 0.12954,0 0.1819,-0.12678 0.0551,-0.12402 0.0551,-0.38585 v -3.5829 h 0.26183 v 3.54431 q 0,0.41066 -0.11851,0.60634 -0.11851,0.19568 -0.36931,0.19568 z m 0.18741,-5.17591 q 0,-0.12402 0.0496,-0.19293 0.0524,-0.0689 0.13229,-0.0689 0.0744,0 0.11851,0.0689 0.0441,0.0689 0.0441,0.19293 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.11851,0.0689 -0.0799,0 -0.13229,-0.0689 -0.0496,-0.0717 -0.0496,-0.19017 z" />
+        <path
+           id="path1422"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 253.54602,179.27724 q -0.47405,0 -0.73036,-0.40238 -0.25356,-0.40515 -0.25356,-1.12724 0,-0.76619 0.226,-1.16858 0.22875,-0.40514 0.65595,-0.40514 0.37207,0 0.58704,0.35554 0.21497,0.35277 0.21497,0.9536 v 0.24253 h -1.41662 q 0.006,0.65319 0.18466,0.97841 0.17914,0.32522 0.54294,0.32522 0.28112,0 0.59256,-0.18466 v 0.25356 q -0.28663,0.17914 -0.60358,0.17914 z m -0.11851,-2.86632 q -0.54019,0 -0.59256,1.07763 h 1.14929 q 0,-0.49334 -0.15159,-0.78548 -0.14883,-0.29215 -0.40514,-0.29215 z" />
+        <path
+           id="path1424"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 255.68198,179.27724 q -0.44924,0 -0.678,-0.3886 -0.22599,-0.39137 -0.22599,-1.14653 0,-0.76619 0.22875,-1.16582 0.23151,-0.40239 0.68075,-0.40239 0.27836,0 0.46302,0.10198 l -0.10197,0.23151 q -0.18466,-0.0854 -0.339,-0.0854 -0.6587,0 -0.6587,1.31465 0,1.30362 0.6587,1.30362 0.19568,0 0.42444,-0.0882 v 0.22048 q -0.091,0.0496 -0.22325,0.0772 -0.13229,0.0276 -0.22875,0.0276 z" />
+        <path
+           id="path1426"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 257.21436,179.03471 q 0.12126,0 0.21497,-0.0331 v 0.22048 q -0.12127,0.0551 -0.31144,0.0551 -0.46302,0 -0.46302,-0.69177 v -2.12218 h -0.27009 v -0.15434 l 0.26458,-0.0772 0.0854,-0.71107 h 0.1819 v 0.71107 h 0.47405 v 0.23151 h -0.47405 v 2.04776 q 0,0.30317 0.0661,0.41342 0.0661,0.11024 0.23151,0.11024 z" />
+        <path
+           id="path1428"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 260.54645,178.16654 q 0,0.4961 -0.2756,0.80478 -0.27561,0.30592 -0.70005,0.30592 -0.48231,0 -0.77445,-0.14056 v -0.29214 q 0.14331,0.0799 0.35553,0.12678 0.21222,0.0469 0.41892,0.0469 0.30868,0 0.50712,-0.23426 0.19844,-0.23427 0.19844,-0.59532 0,-0.33348 -0.14056,-0.52916 -0.14056,-0.19568 -0.53744,-0.39137 -0.31143,-0.15709 -0.46577,-0.30316 -0.15434,-0.14883 -0.22876,-0.34451 -0.0744,-0.19569 -0.0744,-0.46854 0,-0.29765 0.12127,-0.52916 0.12126,-0.23151 0.33899,-0.35829 0.21773,-0.12954 0.4768,-0.12954 0.23427,0 0.42444,0.0524 0.19293,0.0524 0.30317,0.113 l -0.10473,0.25907 q -0.30593,-0.1571 -0.62288,-0.1571 -0.29765,0 -0.48507,0.20395 -0.18465,0.20119 -0.18465,0.53468 0,0.339 0.13505,0.52641 0.13504,0.18741 0.52916,0.38861 0.4079,0.19843 0.59531,0.46577 0.19017,0.26459 0.19017,0.64492 z" />
+        <path
+           id="path1430"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 261.73432,179.03471 q 0.12127,0 0.21498,-0.0331 v 0.22048 q -0.12127,0.0551 -0.31144,0.0551 -0.46302,0 -0.46302,-0.69177 v -2.12218 h -0.2701 v -0.15434 l 0.26459,-0.0772 0.0854,-0.71107 h 0.1819 v 0.71107 h 0.47404 v 0.23151 h -0.47404 v 2.04776 q 0,0.30317 0.0661,0.41342 0.0661,0.11024 0.23151,0.11024 z" />
+        <path
+           id="path1432"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 263.25016,176.1739 q 0.14056,0 0.26183,0.0386 l -0.0634,0.26182 q -0.0992,-0.0413 -0.20395,-0.0413 -0.15158,0 -0.28387,0.1571 -0.12954,0.15434 -0.20395,0.4327 -0.0744,0.27837 -0.0744,0.61461 v 1.58474 h -0.26182 v -2.99034 h 0.21497 l 0.0276,0.52365 h 0.0193 q 0.20946,-0.58153 0.56775,-0.58153 z" />
+        <path
+           id="path1434"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 264.21479,176.23178 v 1.9513 q 0,0.44373 0.10473,0.64768 0.10749,0.20395 0.32798,0.20395 0.33899,0 0.49609,-0.27285 0.15985,-0.27561 0.15985,-0.88746 v -1.64262 h 0.25907 v 2.99034 h -0.22048 l -0.0331,-0.41892 h -0.022 q -0.0965,0.22875 -0.26734,0.35278 -0.17088,0.12126 -0.37207,0.12126 -0.36105,0 -0.52917,-0.25631 -0.16536,-0.25632 -0.16536,-0.83785 v -1.9513 z" />
+        <path
+           id="path1436"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 267.13623,179.27724 q -0.44924,0 -0.67799,-0.3886 -0.226,-0.39137 -0.226,-1.14653 0,-0.76619 0.22875,-1.16582 0.23151,-0.40239 0.68075,-0.40239 0.27837,0 0.46303,0.10198 l -0.10198,0.23151 q -0.18466,-0.0854 -0.339,-0.0854 -0.6587,0 -0.6587,1.31465 0,1.30362 0.6587,1.30362 0.19568,0 0.42444,-0.0882 v 0.22048 q -0.091,0.0496 -0.22324,0.0772 -0.1323,0.0276 -0.22876,0.0276 z" />
+        <path
+           id="path1438"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 268.66861,179.03471 q 0.12127,0 0.21497,-0.0331 v 0.22048 q -0.12126,0.0551 -0.31143,0.0551 -0.46302,0 -0.46302,-0.69177 v -2.12218 h -0.2701 v -0.15434 l 0.26459,-0.0772 0.0854,-0.71107 h 0.1819 v 0.71107 h 0.47405 v 0.23151 h -0.47405 v 2.04776 q 0,0.30317 0.0661,0.41342 0.0661,0.11024 0.23151,0.11024 z" />
+        <path
+           id="path1440"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 269.60568,176.23178 v 1.9513 q 0,0.44373 0.10473,0.64768 0.10748,0.20395 0.32797,0.20395 0.339,0 0.49609,-0.27285 0.15986,-0.27561 0.15986,-0.88746 v -1.64262 h 0.25907 v 2.99034 h -0.22049 l -0.0331,-0.41892 h -0.022 q -0.0965,0.22875 -0.26734,0.35278 -0.17088,0.12126 -0.37207,0.12126 -0.36105,0 -0.52917,-0.25631 -0.16536,-0.25632 -0.16536,-0.83785 v -1.9513 z" />
+        <path
+           id="path1442"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 272.58775,176.1739 q 0.14056,0 0.26183,0.0386 l -0.0634,0.26182 q -0.0992,-0.0413 -0.20395,-0.0413 -0.15158,0 -0.28388,0.1571 -0.12953,0.15434 -0.20395,0.4327 -0.0744,0.27837 -0.0744,0.61461 v 1.58474 h -0.26183 v -2.99034 h 0.21498 l 0.0276,0.52365 h 0.0193 q 0.20946,-0.58153 0.56775,-0.58153 z" />
+        <path
+           id="path1444"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
+           d="m 274.15045,179.27724 q -0.47405,0 -0.73036,-0.40238 -0.25356,-0.40515 -0.25356,-1.12724 0,-0.76619 0.226,-1.16858 0.22875,-0.40514 0.65594,-0.40514 0.37207,0 0.58705,0.35554 0.21497,0.35277 0.21497,0.9536 v 0.24253 h -1.41662 q 0.006,0.65319 0.18466,0.97841 0.17914,0.32522 0.54294,0.32522 0.28112,0 0.59256,-0.18466 v 0.25356 q -0.28663,0.17914 -0.60358,0.17914 z m -0.11851,-2.86632 q -0.54019,0 -0.59256,1.07763 h 1.14928 q 0,-0.49334 -0.15158,-0.78548 -0.14883,-0.29215 -0.40514,-0.29215 z" />
+      </g>
+      <g
+         id="text9148"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3b82f6;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         aria-label="Scaffold Options">
+        <path
+           id="path1447"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 315.04738,178.16654 q 0,0.4961 -0.27561,0.80478 -0.27561,0.30592 -0.70004,0.30592 -0.48232,0 -0.77446,-0.14056 v -0.29214 q 0.14331,0.0799 0.35553,0.12678 0.21222,0.0469 0.41893,0.0469 0.30868,0 0.50711,-0.23426 0.19844,-0.23427 0.19844,-0.59532 0,-0.33348 -0.14056,-0.52916 -0.14056,-0.19568 -0.53743,-0.39137 -0.31144,-0.15709 -0.46578,-0.30316 -0.15434,-0.14883 -0.22875,-0.34451 -0.0744,-0.19569 -0.0744,-0.46854 0,-0.29765 0.12127,-0.52916 0.12127,-0.23151 0.339,-0.35829 0.21773,-0.12954 0.4768,-0.12954 0.23426,0 0.42443,0.0524 0.19293,0.0524 0.30317,0.113 l -0.10473,0.25907 q -0.30592,-0.1571 -0.62287,-0.1571 -0.29766,0 -0.48507,0.20395 -0.18466,0.20119 -0.18466,0.53468 0,0.339 0.13505,0.52641 0.13505,0.18741 0.52917,0.38861 0.40789,0.19843 0.59531,0.46577 0.19017,0.26459 0.19017,0.64492 z" />
+        <path
+           id="path1449"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 316.45573,179.27724 q -0.44924,0 -0.67799,-0.3886 -0.226,-0.39137 -0.226,-1.14653 0,-0.76619 0.22875,-1.16582 0.23151,-0.40239 0.68075,-0.40239 0.27837,0 0.46302,0.10198 l -0.10197,0.23151 q -0.18466,-0.0854 -0.339,-0.0854 -0.6587,0 -0.6587,1.31465 0,1.30362 0.6587,1.30362 0.19568,0 0.42444,-0.0882 v 0.22048 q -0.091,0.0496 -0.22324,0.0772 -0.1323,0.0276 -0.22876,0.0276 z" />
+        <path
+           id="path1451"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 318.5972,179.22212 -0.0331,-0.41892 h -0.011 q -0.21498,0.47404 -0.65044,0.47404 -0.29214,0 -0.47129,-0.23151 -0.17639,-0.23426 -0.17639,-0.62563 0,-0.42719 0.25632,-0.67523 0.25631,-0.25081 0.71933,-0.27286 l 0.32247,-0.0165 v -0.24805 q 0,-0.41892 -0.10474,-0.60909 -0.10473,-0.19293 -0.34726,-0.19293 -0.25632,0 -0.52366,0.16812 l -0.11299,-0.2067 q 0.31143,-0.19293 0.65319,-0.19293 0.36931,0 0.53192,0.23427 0.16261,0.23151 0.16261,0.77721 v 2.03674 z m -0.63665,-0.16812 q 0.28112,0 0.43546,-0.27561 0.1571,-0.27836 0.1571,-0.78548 v -0.31143 l -0.31144,0.0165 q -0.36105,0.0193 -0.53744,0.2012 -0.17363,0.17914 -0.17363,0.52641 0,0.32521 0.11576,0.4768 0.11575,0.15158 0.31419,0.15158 z" />
+        <path
+           id="path1453"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 320.36385,176.46329 h -0.46853 v 2.75883 h -0.25908 v -2.75883 h -0.38033 v -0.14883 l 0.38033,-0.113 v -0.226 q 0,-0.5705 0.13505,-0.82131 0.13505,-0.2508 0.46853,-0.2508 0.19293,0 0.35003,0.0689 l -0.091,0.24254 q -0.14608,-0.0689 -0.26459,-0.0689 -0.13505,0 -0.20395,0.0799 -0.0689,0.0799 -0.10197,0.25907 -0.0331,0.17915 -0.0331,0.4961 v 0.2508 h 0.46853 z m 1.27606,0 h -0.46853 v 2.75883 h -0.25907 v -2.75883 h -0.38034 v -0.14883 l 0.38034,-0.113 v -0.226 q 0,-0.5705 0.13505,-0.82131 0.13504,-0.2508 0.46853,-0.2508 0.19292,0 0.35002,0.0689 l -0.0909,0.24254 q -0.14607,-0.0689 -0.26458,-0.0689 -0.13505,0 -0.20395,0.0799 -0.0689,0.0799 -0.10198,0.25907 -0.0331,0.17915 -0.0331,0.4961 v 0.2508 h 0.46853 z" />
+        <path
+           id="path1455"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 323.80894,177.72006 q 0,0.75517 -0.23978,1.15755 -0.23702,0.39963 -0.68075,0.39963 -0.43821,0 -0.67248,-0.39963 -0.23151,-0.40238 -0.23151,-1.15755 0,-1.54616 0.91502,-1.54616 0.42995,0 0.66972,0.40514 0.23978,0.40515 0.23978,1.14102 z m -1.55167,0 q 0,0.64768 0.15434,0.97841 0.15434,0.33073 0.48232,0.33073 0.64216,0 0.64216,-1.30914 0,-1.29811 -0.64216,-1.29811 -0.33625,0 -0.48783,0.32522 -0.14883,0.32521 -0.14883,0.97289 z" />
+        <path
+           id="path1457"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 324.73498,179.22212 h -0.26182 v -4.28845 h 0.26182 z" />
+        <path
+           id="path1459"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 326.26185,179.27724 q -0.87092,0 -0.87092,-1.54616 0,-0.76067 0.21773,-1.15755 0.21773,-0.39963 0.64217,-0.39963 0.20119,0 0.38034,0.11576 0.1819,0.11575 0.28938,0.3197 h 0.0221 l -0.011,-0.33348 v -1.34221 h 0.26183 v 4.28845 h -0.21498 l -0.022,-0.41892 h -0.0248 q -0.10749,0.22875 -0.27836,0.35278 -0.17088,0.12126 -0.39137,0.12126 z m 0.0165,-0.22875 q 0.31419,0 0.48231,-0.28939 0.17088,-0.29214 0.17088,-0.85714 v -0.17088 q 0,-0.67799 -0.16537,-0.99218 -0.1626,-0.31695 -0.49885,-0.31695 -0.32246,0 -0.46302,0.339 -0.14056,0.33624 -0.14056,0.97565 0,0.64492 0.14608,0.9784 0.14607,0.33349 0.46853,0.33349 z" />
+        <path
+           id="path1461"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 331.27791,177.20192 q 0,1.00045 -0.30041,1.53789 -0.29766,0.53743 -0.86265,0.53743 -0.57051,0 -0.86541,-0.54019 -0.2949,-0.54294 -0.2949,-1.54064 0,-1.0418 0.29214,-1.55167 0.29215,-0.50988 0.87644,-0.50988 0.56223,0 0.85713,0.53744 0.29766,0.53467 0.29766,1.52962 z m -2.04225,0 q 0,0.89848 0.22324,1.35874 0.226,0.45751 0.65595,0.45751 0.4327,0 0.65594,-0.45475 0.226,-0.45475 0.226,-1.3615 0,-0.89573 -0.22048,-1.35048 -0.22049,-0.45751 -0.65319,-0.45751 -0.44373,0 -0.66698,0.46302 -0.22048,0.46027 -0.22048,1.34497 z" />
+        <path
+           id="path1463"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 332.94258,179.27724 q -0.226,0 -0.41341,-0.12402 -0.18466,-0.12678 -0.28112,-0.34451 h -0.0248 l 0.0193,0.32797 v 1.44143 h -0.26183 v -4.34633 h 0.21497 l 0.0276,0.41065 h 0.0248 q 0.11024,-0.22599 0.28112,-0.34726 0.17363,-0.12127 0.37758,-0.12127 0.87643,0 0.87643,1.54616 0,0.7469 -0.21497,1.15204 -0.21497,0.40514 -0.62563,0.40514 z m -0.0524,-2.85529 q -0.32798,0 -0.48783,0.28939 -0.15985,0.28938 -0.15985,0.90675 v 0.0854 q 0,0.68902 0.16261,1.01424 0.16261,0.32246 0.49609,0.32246 0.30868,0 0.45751,-0.3197 0.15158,-0.32246 0.15158,-1.00046 0,-0.64768 -0.14056,-0.97289 -0.14056,-0.32522 -0.47955,-0.32522 z" />
+        <path
+           id="path1465"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 334.98759,179.03471 q 0.12127,0 0.21497,-0.0331 v 0.22048 q -0.12126,0.0551 -0.31143,0.0551 -0.46302,0 -0.46302,-0.69177 v -2.12218 h -0.2701 v -0.15434 l 0.26458,-0.0772 0.0854,-0.71107 h 0.1819 v 0.71107 h 0.47405 v 0.23151 h -0.47405 v 2.04776 q 0,0.30317 0.0661,0.41342 0.0661,0.11024 0.23151,0.11024 z" />
+        <path
+           id="path1467"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 335.93568,179.22212 h -0.26183 v -2.99034 h 0.26183 z m -0.30041,-3.81992 q 0,-0.12402 0.0496,-0.19293 0.0524,-0.0689 0.13229,-0.0689 0.0744,0 0.11851,0.0689 0.0441,0.0689 0.0441,0.19293 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.11851,0.0689 -0.0799,0 -0.13229,-0.0689 -0.0496,-0.0717 -0.0496,-0.19017 z" />
+        <path
+           id="path1469"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 338.41615,177.72006 q 0,0.75517 -0.23978,1.15755 -0.23702,0.39963 -0.68075,0.39963 -0.43822,0 -0.67248,-0.39963 -0.23151,-0.40238 -0.23151,-1.15755 0,-1.54616 0.91501,-1.54616 0.42995,0 0.66973,0.40514 0.23978,0.40515 0.23978,1.14102 z m -1.55167,0 q 0,0.64768 0.15434,0.97841 0.15434,0.33073 0.48231,0.33073 0.64217,0 0.64217,-1.30914 0,-1.29811 -0.64217,-1.29811 -0.33624,0 -0.48783,0.32522 -0.14882,0.32521 -0.14882,0.97289 z" />
+        <path
+           id="path1471"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 340.43084,179.22212 v -2.06154 q 0,-0.74414 -0.44097,-0.74414 -0.33624,0 -0.49334,0.27836 -0.15434,0.27836 -0.15434,0.8847 v 1.64262 h -0.26183 v -2.99034 h 0.22049 l 0.022,0.41617 h 0.0248 q 0.0937,-0.226 0.2701,-0.35002 0.17639,-0.12403 0.37758,-0.12403 0.34727,0 0.5209,0.23427 0.17363,0.23151 0.17363,0.74689 v 2.06706 z" />
+        <path
+           id="path1473"
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           d="m 342.65775,178.47247 q 0,0.37758 -0.19844,0.59256 -0.19844,0.21221 -0.57326,0.21221 -0.20395,0 -0.35829,-0.0524 -0.15434,-0.0524 -0.23978,-0.11576 v -0.30592 q 0.10197,0.10197 0.2701,0.16536 0.16812,0.0606 0.34451,0.0606 0.23151,0 0.3638,-0.15159 0.13229,-0.15158 0.13229,-0.40514 0,-0.19844 -0.0965,-0.33349 -0.0937,-0.1378 -0.36105,-0.31143 -0.30592,-0.19293 -0.41892,-0.30868 -0.11025,-0.11576 -0.17364,-0.25907 -0.0606,-0.14332 -0.0606,-0.34176 0,-0.32246 0.21773,-0.53192 0.21773,-0.21222 0.55397,-0.21222 0.36105,0 0.60358,0.17088 l -0.13505,0.22875 q -0.22599,-0.15158 -0.47955,-0.15158 -0.23151,0 -0.36932,0.1378 -0.1378,0.13505 -0.1378,0.35829 0,0.19844 0.0937,0.33349 0.0937,0.13229 0.39687,0.32246 0.29766,0.19568 0.4079,0.31419 0.11024,0.11576 0.16261,0.25907 0.0551,0.14056 0.0551,0.32522 z" />
+      </g>
+    </g>
+    <g
+       transform="matrix(1.2840056,0,0,1.2840056,-105.16895,-147.0163)"
+       id="g7801">
+      <path
+         id="rect7730"
+         d="m 132.98797,289.61523 h 45.91823 c 1.13065,0 2.04088,0.91024 2.04088,2.04089 v 7.06429 c 0,1.13065 -0.91023,2.04088 -2.04088,2.04088 h -45.91823 c -1.13065,0 -2.04089,-0.91023 -2.04089,-2.04088 v -7.06429 c 0,-1.13065 0.91024,-2.04089 2.04089,-2.04089 z"
+         style="fill:#fffbeb;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" />
+      <g
+         id="text973-4"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         aria-label="Actions Pipeline">
+        <path
+           id="path1477"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           d="m 143.71975,297.18369 -0.35554,-1.46073 h -0.9784 l -0.35003,1.46073 h -0.28112 l 0.97014,-4.02939 h 0.27837 l 0.99218,4.02939 z m -0.41893,-1.73358 -0.35553,-1.50206 q -0.0551,-0.25356 -0.0854,-0.47956 -0.0248,0.23978 -0.0772,0.47956 l -0.34451,1.50206 z" />
+        <path
+           id="path1479"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           d="m 145.16117,297.23881 q -0.44924,0 -0.67799,-0.38861 -0.226,-0.39136 -0.226,-1.14653 0,-0.76619 0.22876,-1.16582 0.23151,-0.40239 0.68075,-0.40239 0.27836,0 0.46302,0.10198 l -0.10198,0.23151 q -0.18465,-0.0854 -0.33899,-0.0854 -0.65871,0 -0.65871,1.31465 0,1.30362 0.65871,1.30362 0.19568,0 0.42443,-0.0882 v 0.22049 q -0.0909,0.0496 -0.22324,0.0772 -0.13229,0.0276 -0.22876,0.0276 z" />
+        <path
+           id="path1481"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           d="m 146.69355,296.99627 q 0.12127,0 0.21498,-0.0331 v 0.22049 q -0.12127,0.0551 -0.31144,0.0551 -0.46302,0 -0.46302,-0.69178 v -2.12218 h -0.2701 v -0.15434 l 0.26459,-0.0772 0.0854,-0.71107 h 0.1819 v 0.71107 h 0.47404 v 0.23151 h -0.47404 v 2.04777 q 0,0.30317 0.0661,0.41341 0.0661,0.11024 0.23151,0.11024 z" />
+        <path
+           id="path1483"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           d="m 147.64164,297.18369 h -0.26182 v -2.99035 h 0.26182 z m -0.30041,-3.81993 q 0,-0.12402 0.0496,-0.19292 0.0524,-0.0689 0.13229,-0.0689 0.0744,0 0.11851,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.11851,0.0689 -0.0799,0 -0.13229,-0.0689 -0.0496,-0.0717 -0.0496,-0.19017 z" />
+        <path
+           id="path1485"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           d="m 150.12211,295.68162 q 0,0.75517 -0.23978,1.15756 -0.23702,0.39963 -0.68075,0.39963 -0.43821,0 -0.67248,-0.39963 -0.23151,-0.40239 -0.23151,-1.15756 0,-1.54616 0.91502,-1.54616 0.42995,0 0.66972,0.40515 0.23978,0.40514 0.23978,1.14101 z m -1.55167,0 q 0,0.64768 0.15434,0.97841 0.15434,0.33073 0.48232,0.33073 0.64216,0 0.64216,-1.30914 0,-1.29811 -0.64216,-1.29811 -0.33625,0 -0.48783,0.32522 -0.14883,0.32522 -0.14883,0.97289 z" />
+        <path
+           id="path1487"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           d="m 152.1368,297.18369 v -2.06155 q 0,-0.74414 -0.44097,-0.74414 -0.33624,0 -0.49334,0.27836 -0.15434,0.27837 -0.15434,0.8847 v 1.64263 h -0.26182 v -2.99035 h 0.22048 l 0.0221,0.41617 h 0.0248 q 0.0937,-0.226 0.27009,-0.35002 0.17639,-0.12403 0.37758,-0.12403 0.34727,0 0.5209,0.23427 0.17364,0.23151 0.17364,0.7469 v 2.06706 z" />
+        <path
+           id="path1489"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           d="m 154.36371,296.43403 q 0,0.37758 -0.19843,0.59256 -0.19844,0.21222 -0.57327,0.21222 -0.20395,0 -0.35829,-0.0524 -0.15434,-0.0524 -0.23978,-0.11575 v -0.30593 q 0.10198,0.10198 0.2701,0.16537 0.16812,0.0606 0.34451,0.0606 0.23151,0 0.3638,-0.15158 0.13229,-0.15159 0.13229,-0.40515 0,-0.19843 -0.0965,-0.33348 -0.0937,-0.13781 -0.36105,-0.31144 -0.30592,-0.19292 -0.41892,-0.30868 -0.11024,-0.11576 -0.17363,-0.25907 -0.0606,-0.14332 -0.0606,-0.34175 0,-0.32247 0.21773,-0.53193 0.21773,-0.21222 0.55398,-0.21222 0.36104,0 0.60358,0.17088 l -0.13505,0.22876 q -0.226,-0.15159 -0.47956,-0.15159 -0.23151,0 -0.36931,0.13781 -0.13781,0.13504 -0.13781,0.35829 0,0.19843 0.0937,0.33348 0.0937,0.13229 0.39687,0.32246 0.29766,0.19568 0.4079,0.31419 0.11025,0.11576 0.16261,0.25908 0.0551,0.14056 0.0551,0.32521 z" />
+        <path
+           id="path1491"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           d="m 157.75093,294.31185 q 0,0.62288 -0.28663,0.91502 -0.28388,0.29215 -0.84336,0.29215 h -0.28663 v 1.66467 h -0.2701 v -4.02939 h 0.55122 q 0.5898,0 0.86265,0.27837 0.27285,0.27836 0.27285,0.87918 z m -1.41662,0.95912 h 0.27009 q 0.47405,0 0.67249,-0.22324 0.19843,-0.22325 0.19843,-0.73588 0,-0.48782 -0.2067,-0.69728 -0.20395,-0.21222 -0.6339,-0.21222 h -0.30041 z" />
+        <path
+           id="path1493"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           d="m 158.5998,297.18369 h -0.26182 v -2.99035 h 0.26182 z m -0.30041,-3.81993 q 0,-0.12402 0.0496,-0.19292 0.0524,-0.0689 0.13229,-0.0689 0.0744,0 0.11851,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.11851,0.0689 -0.0799,0 -0.13229,-0.0689 -0.0496,-0.0717 -0.0496,-0.19017 z" />
+        <path
+           id="path1495"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           d="m 160.35818,297.23881 q -0.226,0 -0.41341,-0.12403 -0.18466,-0.12678 -0.28112,-0.34451 h -0.0248 l 0.0193,0.32798 v 1.44142 h -0.26183 v -4.34633 h 0.21497 l 0.0276,0.41066 h 0.0248 q 0.11024,-0.226 0.28112,-0.34727 0.17363,-0.12127 0.37758,-0.12127 0.87643,0 0.87643,1.54616 0,0.7469 -0.21497,1.15204 -0.21497,0.40515 -0.62563,0.40515 z m -0.0524,-2.8553 q -0.32797,0 -0.48782,0.28939 -0.15985,0.28939 -0.15985,0.90675 v 0.0854 q 0,0.68902 0.16261,1.01423 0.1626,0.32246 0.49609,0.32246 0.30868,0 0.45751,-0.3197 0.15158,-0.32246 0.15158,-1.00046 0,-0.64767 -0.14056,-0.97289 -0.14056,-0.32522 -0.47956,-0.32522 z" />
+        <path
+           id="path1497"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           d="m 162.7036,297.23881 q -0.47404,0 -0.73036,-0.40239 -0.25356,-0.40514 -0.25356,-1.12724 0,-0.76618 0.226,-1.16857 0.22875,-0.40515 0.65595,-0.40515 0.37207,0 0.58704,0.35554 0.21497,0.35278 0.21497,0.9536 v 0.24254 h -1.41662 q 0.006,0.65319 0.18466,0.9784 0.17914,0.32522 0.54295,0.32522 0.28111,0 0.59255,-0.18466 v 0.25356 q -0.28663,0.17915 -0.60358,0.17915 z m -0.11851,-2.86632 q -0.54019,0 -0.59256,1.07762 h 1.14929 q 0,-0.49333 -0.15159,-0.78548 -0.14883,-0.29214 -0.40514,-0.29214 z" />
+        <path
+           id="path1499"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           d="m 164.33244,297.18369 h -0.26182 v -4.28846 h 0.26182 z" />
+        <path
+           id="path1501"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           d="m 165.39078,297.18369 h -0.26183 v -2.99035 h 0.26183 z m -0.30042,-3.81993 q 0,-0.12402 0.0496,-0.19292 0.0524,-0.0689 0.13229,-0.0689 0.0744,0 0.11852,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.11852,0.0689 -0.0799,0 -0.13229,-0.0689 -0.0496,-0.0717 -0.0496,-0.19017 z" />
+        <path
+           id="path1503"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           d="m 167.53776,297.18369 v -2.06155 q 0,-0.74414 -0.44097,-0.74414 -0.33624,0 -0.49334,0.27836 -0.15434,0.27837 -0.15434,0.8847 v 1.64263 h -0.26183 v -2.99035 h 0.22049 l 0.0221,0.41617 h 0.0248 q 0.0937,-0.226 0.2701,-0.35002 0.17638,-0.12403 0.37758,-0.12403 0.34726,0 0.5209,0.23427 0.17363,0.23151 0.17363,0.7469 v 2.06706 z" />
+        <path
+           id="path1505"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
+           d="m 169.43945,297.23881 q -0.47404,0 -0.73036,-0.40239 -0.25356,-0.40514 -0.25356,-1.12724 0,-0.76618 0.226,-1.16857 0.22876,-0.40515 0.65595,-0.40515 0.37207,0 0.58704,0.35554 0.21498,0.35278 0.21498,0.9536 v 0.24254 h -1.41663 q 0.006,0.65319 0.18466,0.9784 0.17914,0.32522 0.54295,0.32522 0.28112,0 0.59255,-0.18466 v 0.25356 q -0.28663,0.17915 -0.60358,0.17915 z m -0.11851,-2.86632 q -0.54019,0 -0.59256,1.07762 h 1.14929 q 0,-0.49333 -0.15159,-0.78548 -0.14882,-0.29214 -0.40514,-0.29214 z" />
+      </g>
+    </g>
+    <path
+       id="path7645-9"
+       d="m 72.216799,204.80631 v 17.55427"
+       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker6805-2)" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker7249-4)"
+       d="m 117.84961,204.80631 v 17.55427"
+       id="path7647-9" />
+    <g
+       id="text973-5-6"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:7.24749851px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.33972648"
+       aria-label="User's Options">
+      <path
+         id="path1508"
+         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
+         d="m 134.21232,152.08635 v 3.49281 q 0,1.75172 -1.25274,1.75172 -0.62637,0 -0.95548,-0.45297 -0.32911,-0.45297 -0.32911,-1.29875 v -3.49281 h 0.35034 v 3.53528 q 0,0.67237 0.24064,1.02626 0.24418,0.35034 0.69361,0.35034 0.44589,0 0.67591,-0.35034 0.23003,-0.35389 0.23003,-1.04042 v -3.52112 z" />
+      <path
+         id="path1510"
+         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
+         d="m 136.75673,156.29754 q 0,0.48482 -0.25479,0.76085 -0.2548,0.27249 -0.73608,0.27249 -0.26187,0 -0.46004,-0.0672 -0.19818,-0.0672 -0.30788,-0.14863 v -0.39281 q 0.13094,0.13094 0.3468,0.21233 0.21587,0.0779 0.44236,0.0779 0.29726,0 0.46712,-0.19463 0.16986,-0.19464 0.16986,-0.52021 0,-0.25479 -0.12386,-0.42819 -0.12032,-0.17694 -0.46358,-0.39989 -0.39281,-0.24772 -0.5379,-0.39635 -0.14155,-0.14863 -0.22295,-0.33265 -0.0779,-0.18402 -0.0779,-0.43881 0,-0.41404 0.27957,-0.68299 0.27956,-0.27249 0.7113,-0.27249 0.46358,0 0.775,0.21941 l -0.1734,0.29372 q -0.29019,-0.19464 -0.61576,-0.19464 -0.29726,0 -0.4742,0.17694 -0.17694,0.17341 -0.17694,0.46005 0,0.25479 0.12032,0.4282 0.12032,0.16986 0.50959,0.41404 0.38219,0.25125 0.52375,0.40342 0.14155,0.14863 0.20879,0.33265 0.0708,0.18048 0.0708,0.41758 z" />
+      <path
+         id="path1512"
+         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
+         d="m 138.61815,157.33088 q -0.60868,0 -0.93779,-0.51667 -0.32557,-0.52021 -0.32557,-1.44738 0,-0.98379 0.29019,-1.50045 0.29372,-0.52021 0.84223,-0.52021 0.47774,0 0.75377,0.45651 0.27603,0.45297 0.27603,1.22443 v 0.31141 h -1.81895 q 0.007,0.8387 0.2371,1.25628 0.23002,0.41758 0.69715,0.41758 0.36095,0 0.76084,-0.2371 v 0.32557 q -0.36804,0.23003 -0.775,0.23003 z m -0.15217,-3.68037 q -0.69361,0 -0.76084,1.38368 h 1.47568 q 0,-0.63345 -0.19463,-1.00857 -0.1911,-0.37511 -0.52021,-0.37511 z" />
+      <path
+         id="path1514"
+         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
+         d="m 141.43859,153.34617 q 0.18048,0 0.33619,0.0495 l -0.0814,0.33619 q -0.1274,-0.0531 -0.26187,-0.0531 -0.19464,0 -0.3645,0.20171 -0.16632,0.19817 -0.26187,0.55559 -0.0956,0.35743 -0.0956,0.78916 v 2.03482 h -0.33619 v -3.83962 h 0.27603 l 0.0354,0.67238 h 0.0248 q 0.26895,-0.74669 0.729,-0.74669 z" />
+      <path
+         id="path1516"
+         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
+         d="m 142.74795,152.08635 -0.10263,1.8685 h -0.21586 l -0.11678,-1.8685 z" />
+      <path
+         id="path1518"
+         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
+         d="m 145.23574,156.29754 q 0,0.48482 -0.2548,0.76085 -0.25479,0.27249 -0.73607,0.27249 -0.26187,0 -0.46005,-0.0672 -0.19817,-0.0672 -0.30787,-0.14863 v -0.39281 q 0.13093,0.13094 0.3468,0.21233 0.21587,0.0779 0.44235,0.0779 0.29726,0 0.46713,-0.19463 0.16986,-0.19464 0.16986,-0.52021 0,-0.25479 -0.12386,-0.42819 -0.12032,-0.17694 -0.46358,-0.39989 -0.39281,-0.24772 -0.5379,-0.39635 -0.14156,-0.14863 -0.22295,-0.33265 -0.0779,-0.18402 -0.0779,-0.43881 0,-0.41404 0.27956,-0.68299 0.27957,-0.27249 0.71131,-0.27249 0.46358,0 0.775,0.21941 l -0.17341,0.29372 q -0.29018,-0.19464 -0.61575,-0.19464 -0.29726,0 -0.4742,0.17694 -0.17694,0.17341 -0.17694,0.46005 0,0.25479 0.12032,0.4282 0.12032,0.16986 0.50959,0.41404 0.38219,0.25125 0.52374,0.40342 0.14156,0.14863 0.20879,0.33265 0.0708,0.18048 0.0708,0.41758 z" />
+      <path
+         id="path1520"
+         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
+         d="m 150.22901,154.66615 q 0,1.28459 -0.38573,1.97466 -0.38219,0.69007 -1.10765,0.69007 -0.73254,0 -1.11119,-0.69361 -0.37865,-0.69715 -0.37865,-1.9782 0,-1.33767 0.37511,-1.99235 0.37512,-0.65469 1.12535,-0.65469 0.72192,0 1.10057,0.69007 0.38219,0.68653 0.38219,1.96405 z m -2.62226,0 q 0,1.15365 0.28664,1.74464 0.29018,0.58744 0.84224,0.58744 0.55559,0 0.84224,-0.58391 0.29018,-0.5839 0.29018,-1.74817 0,-1.15012 -0.2831,-1.73402 -0.28311,-0.58745 -0.8387,-0.58745 -0.56975,0 -0.8564,0.59452 -0.2831,0.59099 -0.2831,1.72695 z" />
+      <path
+         id="path1522"
+         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
+         d="m 152.36646,157.33088 q -0.29019,0 -0.53083,-0.15925 -0.2371,-0.16278 -0.36096,-0.44235 h -0.0318 l 0.0248,0.42112 v 1.8508 h -0.33619 v -5.58072 h 0.27603 l 0.0354,0.52729 h 0.0318 q 0.14156,-0.29019 0.36096,-0.44589 0.22295,-0.15571 0.48482,-0.15571 1.12535,0 1.12535,1.98528 0,0.95902 -0.27603,1.47922 -0.27603,0.52021 -0.80331,0.52021 z m -0.0672,-3.66622 q -0.42112,0 -0.62637,0.37158 -0.20525,0.37157 -0.20525,1.16427 v 0.1097 q 0,0.88471 0.20879,1.30229 0.20879,0.41404 0.63698,0.41404 0.39635,0 0.58745,-0.4105 0.19463,-0.41405 0.19463,-1.28459 0,-0.83163 -0.18048,-1.24921 -0.18048,-0.41758 -0.61575,-0.41758 z" />
+      <path
+         id="path1524"
+         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
+         d="m 154.99226,157.01946 q 0.15571,0 0.27603,-0.0425 v 0.2831 q -0.15571,0.0708 -0.39989,0.0708 -0.59452,0 -0.59452,-0.88825 v -2.72489 h -0.3468 v -0.19817 l 0.33972,-0.0991 0.10971,-0.91301 h 0.23356 v 0.91301 h 0.60867 v 0.29726 h -0.60867 v 2.62935 q 0,0.38927 0.0849,0.53082 0.0849,0.14155 0.29726,0.14155 z" />
+      <path
+         id="path1526"
+         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
+         d="m 156.20961,157.2601 h -0.33618 v -3.83962 h 0.33618 z m -0.38573,-4.9048 q 0,-0.15925 0.0637,-0.24772 0.0672,-0.0885 0.16986,-0.0885 0.0955,0 0.15217,0.0885 0.0566,0.0885 0.0566,0.24772 0,0.15217 -0.0566,0.24418 -0.0566,0.0885 -0.15217,0.0885 -0.10262,0 -0.16986,-0.0885 -0.0637,-0.092 -0.0637,-0.24418 z" />
+      <path
+         id="path1528"
+         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
+         d="m 159.39455,155.33145 q 0,0.96963 -0.30788,1.4863 -0.30434,0.51313 -0.87409,0.51313 -0.56267,0 -0.86347,-0.51313 -0.29726,-0.51667 -0.29726,-1.4863 0,-1.98528 1.17489,-1.98528 0.55205,0 0.85993,0.52021 0.30788,0.5202 0.30788,1.46507 z m -1.99236,0 q 0,0.83162 0.19818,1.25628 0.19817,0.42465 0.61929,0.42465 0.82455,0 0.82455,-1.68093 0,-1.66679 -0.82455,-1.66679 -0.43173,0 -0.62637,0.41758 -0.1911,0.41758 -0.1911,1.24921 z" />
+      <path
+         id="path1530"
+         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
+         d="m 161.98142,157.2601 v -2.64703 q 0,-0.95549 -0.56621,-0.95549 -0.43173,0 -0.63345,0.35743 -0.19817,0.35742 -0.19817,1.13596 v 2.10913 h -0.33619 v -3.83962 h 0.28311 l 0.0283,0.53437 h 0.0318 q 0.12032,-0.29019 0.3468,-0.44943 0.22649,-0.15925 0.48482,-0.15925 0.44589,0 0.66884,0.3008 0.22294,0.29726 0.22294,0.95902 v 2.65411 z" />
+      <path
+         id="path1532"
+         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
+         d="m 164.84079,156.29754 q 0,0.48482 -0.2548,0.76085 -0.25479,0.27249 -0.73607,0.27249 -0.26187,0 -0.46005,-0.0672 -0.19817,-0.0672 -0.30787,-0.14863 v -0.39281 q 0.13093,0.13094 0.3468,0.21233 0.21587,0.0779 0.44235,0.0779 0.29726,0 0.46713,-0.19463 0.16986,-0.19464 0.16986,-0.52021 0,-0.25479 -0.12386,-0.42819 -0.12032,-0.17694 -0.46358,-0.39989 -0.39281,-0.24772 -0.5379,-0.39635 -0.14156,-0.14863 -0.22295,-0.33265 -0.0779,-0.18402 -0.0779,-0.43881 0,-0.41404 0.27956,-0.68299 0.27957,-0.27249 0.71131,-0.27249 0.46358,0 0.775,0.21941 l -0.17341,0.29372 q -0.29018,-0.19464 -0.61575,-0.19464 -0.29726,0 -0.4742,0.17694 -0.17694,0.17341 -0.17694,0.46005 0,0.25479 0.12032,0.4282 0.12032,0.16986 0.50959,0.41404 0.38219,0.25125 0.52374,0.40342 0.14156,0.14863 0.20879,0.33265 0.0708,0.18048 0.0708,0.41758 z" />
+    </g>
+    <path
+       id="path8415"
+       d="M 95.067976,239.47786 V 259.2161"
+       style="fill:none;stroke:#be185d;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.7704034, 0.7704034;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker8419)" />
+    <g
+       id="text8741"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:7.24749851px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#be185d;fill-opacity:1;stroke:none;stroke-width:0.33972648"
+       aria-label="Created/updated
+project in the file system">
+      <path
+         id="path1535"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 77.968885,264.3995 q -0.583905,0 -0.930709,0.61929 -0.343266,0.61575 -0.343266,1.70925 0,0.7113 0.159247,1.23858 0.159247,0.52729 0.456508,0.81039 0.29726,0.28311 0.690069,0.28311 0.403425,0 0.693608,-0.14509 v 0.31849 q -0.276027,0.15925 -0.725457,0.15925 -0.491896,0 -0.863472,-0.3185 -0.368037,-0.31849 -0.569749,-0.92009 -0.201713,-0.60514 -0.201713,-1.43322 0,-1.23859 0.438813,-1.94635 0.442353,-0.70776 1.203198,-0.70776 0.474202,0 0.828084,0.2194 l -0.159247,0.30434 q -0.297261,-0.19109 -0.675914,-0.19109 z" />
+      <path
+         id="path1537"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 80.562838,265.40806 q 0.18048,0 0.336188,0.0495 l -0.08139,0.33619 q -0.127398,-0.0531 -0.261873,-0.0531 -0.194635,0 -0.364498,0.20171 -0.166324,0.19817 -0.261872,0.55559 -0.09555,0.35743 -0.09555,0.78916 v 2.03482 h -0.336188 v -3.83962 h 0.276028 l 0.03539,0.67238 h 0.02477 q 0.26895,-0.74669 0.728996,-0.74669 z" />
+      <path
+         id="path1539"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 82.569347,269.39277 q -0.608676,0 -0.937786,-0.51667 -0.325572,-0.52021 -0.325572,-1.44738 0,-0.98379 0.290183,-1.50046 0.293722,-0.5202 0.842239,-0.5202 0.47774,0 0.753768,0.45651 0.276028,0.45296 0.276028,1.22443 v 0.31141 h -1.818952 q 0.0071,0.8387 0.2371,1.25628 0.230024,0.41758 0.697148,0.41758 0.360959,0 0.760845,-0.2371 v 0.32557 q -0.368037,0.23003 -0.775001,0.23003 z m -0.152169,-3.68037 q -0.693608,0 -0.760846,1.38367 h 1.475687 q 0,-0.63344 -0.194635,-1.00856 -0.191096,-0.37511 -0.520206,-0.37511 z" />
+      <path
+         id="path1541"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 85.810904,269.32199 -0.04246,-0.5379 h -0.01416 q -0.276027,0.60868 -0.835161,0.60868 -0.375114,0 -0.605137,-0.29726 -0.226485,-0.3008 -0.226485,-0.80331 0,-0.54852 0.32911,-0.86702 0.32911,-0.32203 0.923632,-0.35034 l 0.414041,-0.0212 v -0.31849 q 0,-0.53791 -0.134475,-0.78208 -0.134475,-0.24772 -0.445891,-0.24772 -0.32911,0 -0.672375,0.21587 l -0.145092,-0.26541 q 0.399887,-0.24772 0.8387,-0.24772 0.474202,0 0.682992,0.3008 0.20879,0.29726 0.20879,0.99794 v 2.61519 z m -0.817466,-0.21587 q 0.360959,0 0.559133,-0.35388 0.201712,-0.35742 0.201712,-1.00856 v -0.39989 l -0.399886,0.0212 q -0.463585,0.0248 -0.690069,0.25834 -0.222946,0.23002 -0.222946,0.67591 0,0.41758 0.14863,0.61222 0.148631,0.19463 0.403426,0.19463 z" />
+      <path
+         id="path1543"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 87.803259,269.08135 q 0.155708,0 0.276028,-0.0425 v 0.2831 q -0.155708,0.0708 -0.399886,0.0708 -0.594522,0 -0.594522,-0.88825 v -2.72489 h -0.346804 v -0.19817 l 0.339727,-0.0991 0.109703,-0.91301 h 0.233562 v 0.91301 h 0.608677 v 0.29726 h -0.608677 v 2.62935 q 0,0.38927 0.08493,0.53082 0.08493,0.14155 0.29726,0.14155 z" />
+      <path
+         id="path1545"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 89.774381,269.39277 q -0.608677,0 -0.937787,-0.51667 -0.325571,-0.52021 -0.325571,-1.44738 0,-0.98379 0.290183,-1.50046 0.293722,-0.5202 0.842238,-0.5202 0.477741,0 0.753768,0.45651 0.276028,0.45296 0.276028,1.22443 v 0.31141 h -1.818952 q 0.0071,0.8387 0.237101,1.25628 0.230023,0.41758 0.697147,0.41758 0.360959,0 0.760846,-0.2371 v 0.32557 q -0.368037,0.23003 -0.775001,0.23003 z m -0.15217,-3.68037 q -0.693608,0 -0.760845,1.38367 h 1.475687 q 0,-0.63344 -0.194635,-1.00856 -0.191097,-0.37511 -0.520207,-0.37511 z" />
+      <path
+         id="path1547"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 92.467421,269.39277 q -1.118267,0 -1.118267,-1.98528 0,-0.97671 0.279567,-1.4863 0.279566,-0.51313 0.824544,-0.51313 0.258334,0 0.488357,0.14863 0.233562,0.14863 0.371576,0.4105 h 0.02831 l -0.01416,-0.4282 v -1.7234 h 0.336188 v 5.5064 h -0.276028 l -0.02831,-0.5379 h -0.03185 q -0.138014,0.29372 -0.35742,0.45297 -0.219407,0.15571 -0.502512,0.15571 z m 0.02123,-0.29372 q 0.403426,0 0.619294,-0.37158 0.219406,-0.37512 0.219406,-1.10057 v -0.21941 q 0,-0.87055 -0.212329,-1.27397 -0.20879,-0.40697 -0.640526,-0.40697 -0.414041,0 -0.594521,0.43528 -0.18048,0.43173 -0.18048,1.25274 0,0.82808 0.187557,1.25628 0.187558,0.4282 0.601599,0.4282 z" />
+      <path
+         id="path1549"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 96.558294,264.14824 -1.847263,5.17375 h -0.35742 l 1.864957,-5.17375 z" />
+      <path
+         id="path1551"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 97.52793,265.48237 v 2.50549 q 0,0.56975 0.134475,0.83162 0.138014,0.26187 0.421119,0.26187 0.435275,0 0.636988,-0.35034 0.205251,-0.35388 0.205251,-1.1395 v -2.10914 h 0.332649 v 3.83962 h -0.283105 l -0.04247,-0.5379 h -0.02831 q -0.123858,0.29372 -0.343265,0.45297 -0.219407,0.15571 -0.477741,0.15571 -0.463585,0 -0.679453,-0.32911 -0.212329,-0.32911 -0.212329,-1.0758 v -2.50549 z" />
+      <path
+         id="path1553"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 101.52679,269.39277 q -0.29018,0 -0.53082,-0.15925 -0.2371,-0.16279 -0.36096,-0.44235 h -0.0318 l 0.0248,0.42112 v 1.8508 h -0.33618 v -5.58072 h 0.27602 l 0.0354,0.52729 h 0.0318 q 0.14155,-0.29019 0.36096,-0.44589 0.22295,-0.15571 0.48482,-0.15571 1.12534,0 1.12534,1.98528 0,0.95901 -0.27603,1.47922 -0.27602,0.52021 -0.80331,0.52021 z m -0.0672,-3.66622 q -0.42112,0 -0.62638,0.37158 -0.20525,0.37157 -0.20525,1.16427 v 0.1097 q 0,0.88471 0.20879,1.30229 0.20879,0.41404 0.63699,0.41404 0.39635,0 0.58744,-0.4105 0.19464,-0.41405 0.19464,-1.28459 0,-0.83163 -0.18048,-1.24921 -0.18048,-0.41758 -0.61575,-0.41758 z" />
+      <path
+         id="path1555"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 104.38616,269.39277 q -1.11827,0 -1.11827,-1.98528 0,-0.97671 0.27957,-1.4863 0.27956,-0.51313 0.82454,-0.51313 0.25834,0 0.48836,0.14863 0.23356,0.14863 0.37158,0.4105 h 0.0283 l -0.0142,-0.4282 v -1.7234 h 0.33619 v 5.5064 h -0.27603 l -0.0283,-0.5379 h -0.0319 q -0.13801,0.29372 -0.35742,0.45297 -0.21941,0.15571 -0.50251,0.15571 z m 0.0212,-0.29372 q 0.40343,0 0.61929,-0.37158 0.21941,-0.37512 0.21941,-1.10057 v -0.21941 q 0,-0.87055 -0.21233,-1.27397 -0.20879,-0.40697 -0.64052,-0.40697 -0.41405,0 -0.59453,0.43528 -0.18048,0.43173 -0.18048,1.25274 0,0.82808 0.18756,1.25628 0.18756,0.4282 0.6016,0.4282 z" />
+      <path
+         id="path1557"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 108.0913,269.32199 -0.0425,-0.5379 h -0.0142 q -0.27603,0.60868 -0.83516,0.60868 -0.37512,0 -0.60514,-0.29726 -0.22648,-0.3008 -0.22648,-0.80331 0,-0.54852 0.32911,-0.86702 0.32911,-0.32203 0.92363,-0.35034 l 0.41404,-0.0212 v -0.31849 q 0,-0.53791 -0.13448,-0.78208 -0.13447,-0.24772 -0.44589,-0.24772 -0.32911,0 -0.67237,0.21587 l -0.14509,-0.26541 q 0.39988,-0.24772 0.8387,-0.24772 0.4742,0 0.68299,0.3008 0.20879,0.29726 0.20879,0.99794 v 2.61519 z m -0.81747,-0.21587 q 0.36096,0 0.55914,-0.35388 0.20171,-0.35742 0.20171,-1.00856 v -0.39989 l -0.39989,0.0212 q -0.46358,0.0248 -0.69007,0.25834 -0.22294,0.23002 -0.22294,0.67591 0,0.41758 0.14863,0.61222 0.14863,0.19463 0.40342,0.19463 z" />
+      <path
+         id="path1559"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 110.08365,269.08135 q 0.15571,0 0.27603,-0.0425 v 0.2831 q -0.15571,0.0708 -0.39988,0.0708 -0.59453,0 -0.59453,-0.88825 v -2.72489 h -0.3468 v -0.19817 l 0.33973,-0.0991 0.1097,-0.91301 h 0.23356 v 0.91301 h 0.60868 v 0.29726 h -0.60868 v 2.62935 q 0,0.38927 0.0849,0.53082 0.0849,0.14155 0.29726,0.14155 z" />
+      <path
+         id="path1561"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 112.05478,269.39277 q -0.60868,0 -0.93779,-0.51667 -0.32557,-0.52021 -0.32557,-1.44738 0,-0.98379 0.29018,-1.50046 0.29373,-0.5202 0.84224,-0.5202 0.47774,0 0.75377,0.45651 0.27603,0.45296 0.27603,1.22443 v 0.31141 h -1.81895 q 0.007,0.8387 0.2371,1.25628 0.23002,0.41758 0.69714,0.41758 0.36096,0 0.76085,-0.2371 v 0.32557 q -0.36804,0.23003 -0.775,0.23003 z m -0.15217,-3.68037 q -0.69361,0 -0.76085,1.38367 h 1.47569 q 0,-0.63344 -0.19463,-1.00856 -0.1911,-0.37511 -0.52021,-0.37511 z" />
+      <path
+         id="path1563"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 114.74782,269.39277 q -1.11827,0 -1.11827,-1.98528 0,-0.97671 0.27957,-1.4863 0.27956,-0.51313 0.82454,-0.51313 0.25833,0 0.48836,0.14863 0.23356,0.14863 0.37157,0.4105 h 0.0283 l -0.0142,-0.4282 v -1.7234 h 0.33619 v 5.5064 h -0.27603 l -0.0283,-0.5379 h -0.0319 q -0.13802,0.29372 -0.35742,0.45297 -0.21941,0.15571 -0.50251,0.15571 z m 0.0212,-0.29372 q 0.40342,0 0.61929,-0.37158 0.21941,-0.37512 0.21941,-1.10057 v -0.21941 q 0,-0.87055 -0.21233,-1.27397 -0.20879,-0.40697 -0.64053,-0.40697 -0.41404,0 -0.59452,0.43528 -0.18048,0.43173 -0.18048,1.25274 0,0.82808 0.18756,1.25628 0.18756,0.4282 0.6016,0.4282 z" />
+      <path
+         id="path1565"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 69.606659,278.45214 q -0.290183,0 -0.530823,-0.15925 -0.237101,-0.16278 -0.360959,-0.44235 h -0.03185 l 0.02477,0.42112 v 1.8508 h -0.336188 v -5.58071 h 0.276028 l 0.03539,0.52728 h 0.03185 q 0.141552,-0.29018 0.360959,-0.44589 0.222945,-0.15571 0.484818,-0.15571 1.125344,0 1.125344,1.98528 0,0.95902 -0.276028,1.47922 -0.276028,0.52021 -0.803311,0.52021 z m -0.06724,-3.66621 q -0.421119,0 -0.626371,0.37157 -0.205251,0.37158 -0.205251,1.16427 v 0.10971 q 0,0.8847 0.20879,1.30228 0.20879,0.41404 0.636987,0.41404 0.396348,0 0.587444,-0.4105 0.194635,-0.41404 0.194635,-1.28459 0,-0.83162 -0.18048,-1.2492 -0.180479,-0.41758 -0.615754,-0.41758 z" />
+      <path
+         id="path1567"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 72.593421,274.46743 q 0.180479,0 0.336187,0.0496 l -0.08139,0.33618 q -0.127397,-0.0531 -0.261872,-0.0531 -0.194635,0 -0.364498,0.20171 -0.166325,0.19818 -0.261873,0.5556 -0.09555,0.35742 -0.09555,0.78915 v 2.03482 h -0.336187 v -3.83961 h 0.276027 l 0.03539,0.67237 h 0.02477 q 0.26895,-0.74669 0.728997,-0.74669 z" />
+      <path
+         id="path1569"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 75.672192,276.45271 q 0,0.96963 -0.307877,1.4863 -0.304339,0.51313 -0.874088,0.51313 -0.562672,0 -0.863472,-0.51313 -0.297261,-0.51667 -0.297261,-1.4863 0,-1.98528 1.174888,-1.98528 0.552055,0 0.859933,0.52021 0.307877,0.5202 0.307877,1.46507 z m -1.992355,0 q 0,0.83162 0.198174,1.25628 0.198174,0.42466 0.619293,0.42466 0.824545,0 0.824545,-1.68094 0,-1.66678 -0.824545,-1.66678 -0.431736,0 -0.62637,0.41758 -0.191097,0.41758 -0.191097,1.2492 z" />
+      <path
+         id="path1571"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 76.234864,280.12246 q -0.14863,0 -0.237101,-0.0602 v -0.31849 q 0.113242,0.0566 0.222946,0.0566 0.166324,0 0.233562,-0.16279 0.07078,-0.15924 0.07078,-0.49543 v -4.60046 h 0.336188 v 4.55092 q 0,0.52728 -0.15217,0.77854 -0.152169,0.25125 -0.474201,0.25125 z m 0.24064,-6.6459 q 0,-0.15924 0.0637,-0.24771 0.06724,-0.0885 0.169863,-0.0885 0.09555,0 0.15217,0.0885 0.05662,0.0885 0.05662,0.24771 0,0.15217 -0.05662,0.24418 -0.05662,0.0885 -0.15217,0.0885 -0.102625,0 -0.169863,-0.0885 -0.0637,-0.092 -0.0637,-0.24418 z" />
+      <path
+         id="path1573"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 78.973909,278.45214 q -0.608677,0 -0.937787,-0.51667 -0.325571,-0.5202 -0.325571,-1.44737 0,-0.98379 0.290183,-1.50046 0.293722,-0.52021 0.842238,-0.52021 0.477741,0 0.753768,0.45651 0.276028,0.45297 0.276028,1.22443 v 0.31142 h -1.818952 q 0.0071,0.8387 0.237101,1.25628 0.230023,0.41758 0.697147,0.41758 0.360959,0 0.760846,-0.2371 v 0.32557 q -0.368037,0.23002 -0.775001,0.23002 z m -0.15217,-3.68037 q -0.693608,0 -0.760845,1.38368 h 1.475687 q 0,-0.63345 -0.194635,-1.00857 -0.191097,-0.37511 -0.520207,-0.37511 z" />
+      <path
+         id="path1575"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 81.716493,278.45214 q -0.576827,0 -0.870549,-0.49897 -0.290183,-0.50251 -0.290183,-1.47215 0,-0.98379 0.293722,-1.49692 0.29726,-0.51667 0.874088,-0.51667 0.35742,0 0.594521,0.13094 l -0.130936,0.29726 q -0.237101,-0.1097 -0.435275,-0.1097 -0.845777,0 -0.845777,1.68801 0,1.67386 0.845777,1.67386 0.251256,0 0.544978,-0.11324 v 0.28311 q -0.116781,0.0637 -0.286644,0.0991 -0.169863,0.0354 -0.293722,0.0354 z" />
+      <path
+         id="path1577"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 83.684075,278.14072 q 0.155708,0 0.276028,-0.0425 v 0.2831 q -0.155708,0.0708 -0.399886,0.0708 -0.594522,0 -0.594522,-0.88824 v -2.72489 h -0.346804 v -0.19818 l 0.339727,-0.0991 0.109703,-0.91302 h 0.233562 v 0.91302 h 0.608676 v 0.29726 h -0.608676 v 2.62934 q 0,0.38927 0.08493,0.53082 0.08493,0.14155 0.297261,0.14155 z" />
+      <path
+         id="path1579"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 86.260335,278.38136 h -0.336188 v -3.83961 h 0.336188 z m -0.385731,-4.9048 q 0,-0.15924 0.0637,-0.24771 0.06724,-0.0885 0.169863,-0.0885 0.09555,0 0.152169,0.0885 0.05662,0.0885 0.05662,0.24771 0,0.15217 -0.05662,0.24418 -0.05662,0.0885 -0.152169,0.0885 -0.102626,0 -0.169863,-0.0885 -0.0637,-0.092 -0.0637,-0.24418 z" />
+      <path
+         id="path1581"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 89.017074,278.38136 v -2.64703 q 0,-0.95548 -0.566211,-0.95548 -0.431736,0 -0.633448,0.35742 -0.198174,0.35742 -0.198174,1.13596 v 2.10913 h -0.336188 v -3.83961 h 0.283105 l 0.02831,0.53436 h 0.03185 q 0.12032,-0.29018 0.346804,-0.44943 0.226485,-0.15925 0.484818,-0.15925 0.445892,0 0.668837,0.3008 0.222946,0.29726 0.222946,0.95902 v 2.65411 z" />
+      <path
+         id="path1583"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 92.432033,278.14072 q 0.155708,0 0.276028,-0.0425 v 0.2831 q -0.155708,0.0708 -0.399886,0.0708 -0.594522,0 -0.594522,-0.88824 v -2.72489 h -0.346804 v -0.19818 l 0.339727,-0.0991 0.109703,-0.91302 h 0.233562 v 0.91302 h 0.608677 v 0.29726 h -0.608677 v 2.62934 q 0,0.38927 0.08493,0.53082 0.08493,0.14155 0.29726,0.14155 z" />
+      <path
+         id="path1585"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 95.047219,278.38136 v -2.64703 q 0,-0.52021 -0.138014,-0.73608 -0.134475,-0.2194 -0.442352,-0.2194 -0.406964,0 -0.612215,0.36096 -0.205252,0.36096 -0.205252,1.1395 v 2.10205 h -0.336187 v -5.5064 h 0.336187 v 1.78711 q 0,0.24418 -0.01416,0.40696 h 0.02831 q 0.113242,-0.28664 0.339726,-0.44235 0.230023,-0.15925 0.477741,-0.15925 0.488356,0 0.693608,0.3185 0.205251,0.31849 0.205251,0.9484 v 2.64703 z" />
+      <path
+         id="path1587"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 97.489002,278.45214 q -0.608676,0 -0.937786,-0.51667 -0.325572,-0.5202 -0.325572,-1.44737 0,-0.98379 0.290184,-1.50046 0.293721,-0.52021 0.842238,-0.52021 0.477741,0 0.753768,0.45651 0.276028,0.45297 0.276028,1.22443 v 0.31142 H 96.56891 q 0.0071,0.8387 0.237101,1.25628 0.230023,0.41758 0.697147,0.41758 0.360959,0 0.760845,-0.2371 v 0.32557 q -0.368037,0.23002 -0.775001,0.23002 z m -0.152169,-3.68037 q -0.693608,0 -0.760846,1.38368 h 1.475687 q 0,-0.63345 -0.194635,-1.00857 -0.191096,-0.37511 -0.520206,-0.37511 z" />
+      <path
+         id="path1589"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 101.58342,274.83901 h -0.6016 v 3.54235 h -0.33265 v -3.54235 h -0.48836 v -0.1911 l 0.48836,-0.14509 v -0.29018 q 0,-0.73254 0.1734,-1.05457 0.1734,-0.32203 0.6016,-0.32203 0.24772,0 0.44943,0.0885 l -0.11678,0.31141 q -0.18756,-0.0885 -0.33973,-0.0885 -0.1734,0 -0.26187,0.10263 -0.0885,0.10262 -0.13094,0.33265 -0.0425,0.23002 -0.0425,0.63698 v 0.32204 h 0.6016 z m 0.95902,3.54235 h -0.33619 v -3.83961 h 0.33619 z m -0.38574,-4.9048 q 0,-0.15924 0.0637,-0.24771 0.0672,-0.0885 0.16987,-0.0885 0.0955,0 0.15217,0.0885 0.0566,0.0885 0.0566,0.24771 0,0.15217 -0.0566,0.24418 -0.0566,0.0885 -0.15217,0.0885 -0.10263,0 -0.16987,-0.0885 -0.0637,-0.092 -0.0637,-0.24418 z" />
+      <path
+         id="path1591"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 103.91196,278.38136 h -0.33619 v -5.5064 h 0.33619 z" />
+      <path
+         id="path1593"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 106.02463,278.45214 q -0.60867,0 -0.93779,-0.51667 -0.32557,-0.5202 -0.32557,-1.44737 0,-0.98379 0.29019,-1.50046 0.29372,-0.52021 0.84224,-0.52021 0.47774,0 0.75376,0.45651 0.27603,0.45297 0.27603,1.22443 v 0.31142 h -1.81895 q 0.007,0.8387 0.2371,1.25628 0.23002,0.41758 0.69715,0.41758 0.36096,0 0.76084,-0.2371 v 0.32557 q -0.36803,0.23002 -0.775,0.23002 z m -0.15217,-3.68037 q -0.69361,0 -0.76084,1.38368 h 1.47568 q 0,-0.63345 -0.19463,-1.00857 -0.1911,-0.37511 -0.52021,-0.37511 z" />
+      <path
+         id="path1595"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 110.64633,277.41881 q 0,0.48481 -0.2548,0.76084 -0.25479,0.27249 -0.73607,0.27249 -0.26187,0 -0.46005,-0.0672 -0.19817,-0.0672 -0.30787,-0.14863 v -0.39281 q 0.13093,0.13094 0.3468,0.21233 0.21587,0.0779 0.44235,0.0779 0.29726,0 0.46713,-0.19464 0.16986,-0.19463 0.16986,-0.5202 0,-0.2548 -0.12386,-0.4282 -0.12032,-0.17694 -0.46358,-0.39989 -0.39281,-0.24771 -0.5379,-0.39635 -0.14156,-0.14863 -0.22295,-0.33264 -0.0778,-0.18402 -0.0778,-0.43882 0,-0.41404 0.27956,-0.68299 0.27957,-0.27249 0.71131,-0.27249 0.46358,0 0.775,0.21941 l -0.17341,0.29372 q -0.29018,-0.19463 -0.61575,-0.19463 -0.29726,0 -0.4742,0.17694 -0.17694,0.1734 -0.17694,0.46004 0,0.2548 0.12032,0.4282 0.12032,0.16986 0.50959,0.41404 0.38219,0.25126 0.52374,0.40343 0.14156,0.14863 0.20879,0.33265 0.0708,0.18047 0.0708,0.41758 z" />
+      <path
+         id="path1597"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 111.89907,278.37429 -0.95902,-3.83254 h 0.33972 l 0.58037,2.39578 q 0.10263,0.43173 0.19817,0.97317 h 0.0283 q 0.0672,-0.47066 0.18756,-0.98025 l 0.56621,-2.3887 h 0.33973 l -1.12181,4.56507 q -0.12385,0.50605 -0.32557,0.76085 -0.19817,0.25479 -0.53082,0.25479 -0.13447,0 -0.30434,-0.0602 v -0.30434 q 0.14155,0.0495 0.27603,0.0495 0.21233,0 0.33619,-0.18402 0.12386,-0.18048 0.2194,-0.58391 z" />
+      <path
+         id="path1599"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 115.23264,277.41881 q 0,0.48481 -0.2548,0.76084 -0.25479,0.27249 -0.73607,0.27249 -0.26187,0 -0.46005,-0.0672 -0.19817,-0.0672 -0.30788,-0.14863 v -0.39281 q 0.13094,0.13094 0.34681,0.21233 0.21587,0.0779 0.44235,0.0779 0.29726,0 0.46712,-0.19464 0.16987,-0.19463 0.16987,-0.5202 0,-0.2548 -0.12386,-0.4282 -0.12032,-0.17694 -0.46359,-0.39989 -0.3928,-0.24771 -0.5379,-0.39635 -0.14155,-0.14863 -0.22294,-0.33264 -0.0779,-0.18402 -0.0779,-0.43882 0,-0.41404 0.27957,-0.68299 0.27957,-0.27249 0.7113,-0.27249 0.46359,0 0.775,0.21941 l -0.1734,0.29372 q -0.29018,-0.19463 -0.61575,-0.19463 -0.29726,0 -0.4742,0.17694 -0.17694,0.1734 -0.17694,0.46004 0,0.2548 0.12032,0.4282 0.12031,0.16986 0.50958,0.41404 0.3822,0.25126 0.52375,0.40343 0.14155,0.14863 0.20879,0.33265 0.0708,0.18047 0.0708,0.41758 z" />
+      <path
+         id="path1601"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 116.70832,278.14072 q 0.15571,0 0.27603,-0.0425 v 0.2831 q -0.15571,0.0708 -0.39989,0.0708 -0.59452,0 -0.59452,-0.88824 v -2.72489 h -0.3468 v -0.19818 l 0.33972,-0.0991 0.10971,-0.91302 h 0.23356 v 0.91302 h 0.60867 v 0.29726 h -0.60867 v 2.62934 q 0,0.38927 0.0849,0.53082 0.0849,0.14155 0.29726,0.14155 z" />
+      <path
+         id="path1603"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 118.67944,278.45214 q -0.60867,0 -0.93778,-0.51667 -0.32557,-0.5202 -0.32557,-1.44737 0,-0.98379 0.29018,-1.50046 0.29372,-0.52021 0.84224,-0.52021 0.47774,0 0.75377,0.45651 0.27602,0.45297 0.27602,1.22443 v 0.31142 h -1.81895 q 0.007,0.8387 0.2371,1.25628 0.23002,0.41758 0.69715,0.41758 0.36096,0 0.76084,-0.2371 v 0.32557 q -0.36803,0.23002 -0.775,0.23002 z m -0.15217,-3.68037 q -0.6936,0 -0.76084,1.38368 h 1.47569 q 0,-0.63345 -0.19464,-1.00857 -0.1911,-0.37511 -0.52021,-0.37511 z" />
+      <path
+         id="path1605"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         d="m 123.69749,278.38136 v -2.61518 q 0,-0.9661 -0.56621,-0.9661 -0.38927,0 -0.56267,0.33973 -0.16987,0.33618 -0.16987,0.9944 v 2.24715 h -0.33265 v -2.61518 q 0,-0.48836 -0.13801,-0.72546 -0.13801,-0.24064 -0.4282,-0.24064 -0.38219,0 -0.55559,0.3468 -0.1734,0.34681 -0.1734,1.12535 v 2.10913 h -0.33619 v -3.83961 h 0.2831 l 0.0283,0.53436 h 0.0318 q 0.23003,-0.60868 0.78208,-0.60868 0.3185,0 0.50251,0.16987 0.18402,0.16986 0.26542,0.49543 0.13801,-0.35388 0.33972,-0.50959 0.20172,-0.15571 0.52375,-0.15571 0.43527,0 0.63698,0.33619 0.20172,0.33265 0.20172,1.06872 v 2.50902 z" />
+    </g>
+    <g
+       transform="matrix(1.2840056,0,0,1.2840056,-8.327001,-30.150376)"
+       id="g8110">
+      <path
+         id="rect815"
+         d="m 95.476438,118.76987 h 22.516452 c 2.07294,0 3.74177,1.66883 3.74177,3.74177 v 12.51645 c 0,2.07295 -1.66883,3.74178 -3.74177,3.74178 H 95.476438 c -2.072942,0 -3.741773,-1.66883 -3.741773,-3.74178 v -12.51645 c 0,-2.07294 1.668831,-3.74177 3.741773,-3.74177 z"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#fbbf24;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" />
+      <g
+         id="text819"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#fbbf24;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         aria-label="CLI">
+        <path
+           id="path1609"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#fbbf24;fill-opacity:1;stroke-width:0.26458332"
+           d="m 104.1931,131.65502 v 0.60634 q -1.01561,0.14653 -1.82406,0.14653 -1.07625,0 -1.73817,-0.51539 -0.656862,-0.52044 -0.889291,-1.40468 -0.156637,-0.61644 -0.156637,-1.71795 0,-1.10152 0.156637,-1.71796 0.237482,-0.88929 0.874131,-1.40468 0.63666,-0.51539 1.7028,-0.51539 0.80845,0 1.72301,0.14654 v 0.60633 q -0.94993,-0.14653 -1.72301,-0.14653 -1.56637,0 -1.94533,1.45521 -0.14148,0.55076 -0.14148,1.57648 0,1.02572 0.14148,1.57647 0.38907,1.45521 1.99586,1.45521 0.77308,0 1.82406,-0.14653 z" />
+        <path
+           id="path1611"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#fbbf24;fill-opacity:1;stroke-width:0.26458332"
+           d="m 105.48157,132.32704 v -7.11435 h 0.64676 v 6.50801 h 3.23379 v 0.60634 z" />
+        <path
+           id="path1613"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#fbbf24;fill-opacity:1;stroke-width:0.26458332"
+           d="m 113.88438,125.21269 v 0.60634 h -1.29351 v 5.90167 h 1.29351 v 0.60634 h -3.23379 v -0.60634 h 1.29352 v -5.90167 h -1.29352 v -0.60634 z" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docs/gfx/api.svg
+++ b/docs/gfx/api.svg
@@ -1,0 +1,693 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="200mm"
+   height="158.41367mm"
+   viewBox="0 0 199.99999 158.41367"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="api.svg"
+   inkscape:export-filename="C:\Users\ab17624\sharing\pyscaffold-figs\api.png"
+   inkscape:export-xdpi="162.56"
+   inkscape:export-ydpi="162.56">
+  <defs
+     id="defs2">
+    <marker
+       inkscape:stockid="TriangleInM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleInM"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1158"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(-0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Sstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Sstart"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1052"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(0.3,0,0,0.3,-0.69,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker11851"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path11849"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker11008"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path11006"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker10150"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path10148"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker9026"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path9024"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8881"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path8879"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8419"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path8417"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#be185d;fill-opacity:1;fill-rule:evenodd;stroke:#be185d;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker8275"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path8273"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker7249"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path7247"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4782"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path4780"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker4378"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:collect="always">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path4376"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker3232"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM">
+      <path
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path3230"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="TriangleOutM"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         id="path1167"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Send"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Send"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1037"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.2,0,0,-0.2,-1.2,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path1031"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker2125"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutS">
+      <path
+         transform="scale(0.2)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path2123"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="TriangleOutM"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="marker6805-2"
+       style="overflow:visible"
+       inkscape:isstock="true"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         id="path6803-6"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         transform="scale(0.4)" />
+    </marker>
+    <marker
+       inkscape:isstock="true"
+       style="overflow:visible"
+       id="marker7249-4"
+       refX="0"
+       refY="0"
+       orient="auto"
+       inkscape:stockid="TriangleOutM"
+       inkscape:collect="always">
+      <path
+         inkscape:connector-curvature="0"
+         transform="scale(0.4)"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000003pt;stroke-opacity:1"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path7247-7" />
+    </marker>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4"
+     inkscape:cx="166.64994"
+     inkscape:cy="268.59008"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1387"
+     inkscape:window-x="1072"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-28.706368,-121.7088)">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM)"
+       d="m 188.76319,177.55051 c -8.13331,-0.1585 -20.51322,1.86695 -20.76003,9.35231"
+       id="path1020"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path4374"
+       d="m 188.76319,217.54896 c -8.13331,0.1585 -20.51322,-1.86695 -20.76003,-9.35231"
+       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4378)" />
+    <g
+       id="g8257"
+       transform="matrix(1.2840056,0,0,1.2840056,-6.5798686,-79.556336)">
+      <rect
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#005ca0;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+         id="rect827"
+         width="102.17754"
+         height="51.211605"
+         x="27.981373"
+         y="193.03598"
+         ry="3.7417734" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#005ca0;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="27.430321"
+         y="189.62791"
+         id="text831"><tspan
+           sodipodi:role="line"
+           id="tspan829"
+           x="27.430321"
+           y="189.62791"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332">Python API</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="29.961632"
+         y="199.0694"
+         id="text4720-4"><tspan
+           sodipodi:role="line"
+           id="tspan4718-9"
+           x="29.961632"
+           y="199.0694"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">create_project</tspan></text>
+    </g>
+    <g
+       id="g864"
+       transform="matrix(1.2840056,0,0,1.2840056,-234.7989,-23.653332)">
+      <rect
+         style="fill:#dbe9fe;fill-opacity:1;fill-rule:nonzero;stroke:#3b82f6;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+         id="rect821"
+         width="62.490063"
+         height="11.146072"
+         x="254.24469"
+         y="166.70274"
+         ry="2.0408826" />
+      <text
+         id="text859"
+         y="173.67766"
+         x="285.48682"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
+           y="173.67766"
+           x="285.48682"
+           id="tspan857"
+           sodipodi:role="line">bootstrap_options</tspan></text>
+    </g>
+    <g
+       id="g1005"
+       transform="matrix(1.2840056,0,0,1.2840056,178.45418,-55.047496)">
+      <g
+         id="g993">
+        <g
+           transform="matrix(0.16927449,0,0,0.16927449,12.460139,166.4818)"
+           id="g948">
+          <path
+             style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:15.11811066;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+             d="M 80,82.519531 V 490.33203 H 370 V 142.51953 H 310 V 82.519531 h -76.96428 z"
+             transform="scale(0.26458333)"
+             id="rect815-3"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="cccccccc" />
+          <path
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+             d="m 84.02057,19.833597 -2.883851,2.885153 15.875,15.875 2.883936,-2.884969 z"
+             id="path2983"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccc" />
+        </g>
+        <g
+           id="g953"
+           transform="translate(51.971726,-8.3154762)">
+          <rect
+             ry="0"
+             y="185.875"
+             x="-43.65625"
+             height="7.748517"
+             width="27.59226"
+             id="rect948"
+             style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" />
+          <text
+             xml:space="preserve"
+             style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+             x="-41.641438"
+             y="190.91505"
+             id="text926"><tspan
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
+               id="tspan935"
+               sodipodi:role="line"
+               x="-41.641438"
+               y="190.91505">setup.cfg</tspan></text>
+        </g>
+      </g>
+      <text
+         id="text944"
+         y="166.1181"
+         x="11.331213"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light,  Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           y="166.1181"
+           x="11.331213"
+           sodipodi:role="line"
+           id="tspan942">Pre-existing</tspan></text>
+    </g>
+    <g
+       id="g1018"
+       transform="matrix(1.2840056,0,0,1.2840056,170.32501,-55.53282)">
+      <g
+         id="g984">
+        <g
+           id="g969"
+           transform="matrix(0.16927449,0,0,0.16927449,18.129782,197.28686)">
+          <path
+             sodipodi:nodetypes="cccccccc"
+             inkscape:connector-curvature="0"
+             id="path965"
+             transform="scale(0.26458333)"
+             d="M 80,82.519531 V 490.33203 H 370 V 142.51953 H 310 V 82.519531 h -76.96428 z"
+             style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:15.11811066;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="ccccc"
+             inkscape:connector-curvature="0"
+             id="path967"
+             d="m 84.02057,19.833597 -2.883851,2.885153 15.875,15.875 2.883936,-2.884969 z"
+             style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        </g>
+        <g
+           transform="translate(55.373512,22.86756)"
+           id="g961">
+          <rect
+             style="fill:#005ca0;fill-opacity:1;fill-rule:nonzero;stroke:#005ca0;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+             id="rect955"
+             width="33.45089"
+             height="7.9375081"
+             x="-43.65625"
+             y="185.875"
+             ry="0" />
+          <text
+             id="text959"
+             y="191.00955"
+             x="-41.304676"
+             style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+             xml:space="preserve"><tspan
+               y="191.00955"
+               x="-41.304676"
+               sodipodi:role="line"
+               id="tspan957"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff">default.cfg</tspan></text>
+        </g>
+      </g>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light,  Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="28.419281"
+         y="226.78328"
+         id="text973"><tspan
+           style="text-align:center;text-anchor:middle"
+           id="tspan971"
+           sodipodi:role="line"
+           x="28.419281"
+           y="226.78328">PyScaffold's own</tspan><tspan
+           style="text-align:center;text-anchor:middle"
+           id="tspan975"
+           sodipodi:role="line"
+           x="28.419281"
+           y="233.83884">config file</tspan></text>
+    </g>
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path4778"
+       d="m 128.72091,147.80019 v 39.29677"
+       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4782)" />
+    <g
+       id="g6777"
+       transform="matrix(1.2840056,0,0,1.2840056,-56.685115,-0.73911601)" />
+    <g
+       id="g12869"
+       transform="matrix(1.2840056,0,0,1.2840056,-8.152768,-79.556336)">
+      <rect
+         ry="2.0408826"
+         y="210.24072"
+         x="57.16787"
+         height="11.146072"
+         width="11.274287"
+         id="rect4716"
+         style="fill:#dafcf1;fill-opacity:1;fill-rule:nonzero;stroke:#10b981;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="59.936272"
+         y="217.5867"
+         id="text4720"><tspan
+           sodipodi:role="line"
+           id="tspan4718"
+           x="59.936272"
+           y="217.5867"
+           style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">{}</tspan></text>
+    </g>
+    <g
+       transform="matrix(1.2840056,0,0,1.2840056,-282.72951,-12.694343)"
+       id="g9228">
+      <text
+         id="text8853"
+         y="179.22212"
+         x="260.07516"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           id="tspan8851"
+           y="179.22212"
+           x="260.07516"
+           sodipodi:role="line"
+           style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332">Project Structure</tspan></text>
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3b82f6;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         x="327.95959"
+         y="179.22212"
+         id="text9148"><tspan
+           style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
+           sodipodi:role="line"
+           x="327.95959"
+           y="179.22212"
+           id="tspan9146">Scaffold Options</tspan></text>
+    </g>
+    <g
+       id="g7801"
+       transform="matrix(1.2840056,0,0,1.2840056,-105.16895,-147.0163)">
+      <rect
+         ry="2.0408826"
+         y="289.61523"
+         x="130.94708"
+         height="11.146057"
+         width="50"
+         id="rect7730"
+         style="fill:#fffbeb;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" />
+      <text
+         id="text973-4"
+         y="297.18369"
+         x="156.08075"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           y="297.18369"
+           x="156.08075"
+           sodipodi:role="line"
+           id="tspan975-2"
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332">Actions Pipeline</tspan></text>
+    </g>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker6805-2)"
+       d="m 72.216799,204.80631 v 17.55427"
+       id="path7645-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path7647-9"
+       d="m 117.84961,204.80631 v 17.55427"
+       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker7249-4)" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:7.24749851px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.33972648"
+       x="148.12695"
+       y="157.2601"
+       id="text973-5-6"><tspan
+         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
+         sodipodi:role="line"
+         x="148.12695"
+         y="157.2601"
+         id="tspan7982">User's Options</tspan></text>
+    <path
+       style="fill:none;stroke:#be185d;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.7704034, 0.7704034;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker8419)"
+       d="M 95.067976,239.47786 V 259.2161"
+       id="path8415"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <text
+       id="text8741"
+       y="269.32199"
+       x="96.197334"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:7.24749851px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#be185d;fill-opacity:1;stroke:none;stroke-width:0.33972648"
+       xml:space="preserve"><tspan
+         id="tspan8739"
+         y="269.32199"
+         x="96.197334"
+         sodipodi:role="line"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648">Created/updated</tspan><tspan
+         y="278.38138"
+         x="96.197334"
+         sodipodi:role="line"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         id="tspan8743">project in the file system</tspan></text>
+    <g
+       id="g8110"
+       transform="matrix(1.2840056,0,0,1.2840056,-8.327001,-30.150376)">
+      <rect
+         ry="3.7417734"
+         y="118.76987"
+         x="91.734665"
+         height="20"
+         width="30"
+         id="rect815"
+         style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#fbbf24;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke" />
+      <text
+         id="text819"
+         y="132.32704"
+         x="99.019028"
+         style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#fbbf24;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+         xml:space="preserve"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#fbbf24;fill-opacity:1;stroke-width:0.26458332"
+           y="132.32704"
+           x="99.019028"
+           id="tspan817"
+           sodipodi:role="line">CLI</tspan></text>
+    </g>
+  </g>
+</svg>

--- a/docs/project-structure.rst
+++ b/docs/project-structure.rst
@@ -1,0 +1,81 @@
+Project Structure Representation
+================================
+
+Each Python package project is internally represented by PyScaffold as a tree
+data structure, that directly relates to a directory entry in the file system.
+This tree is implemented as a simple (and possibly nested) :obj:`dict` in which
+keys indicate the path where files will be generated, while values indicate
+their content. For instance, the following dict::
+
+    {
+        "folder": {
+            "file.txt": "Hello World!",
+            "another-folder": {
+                "empty-file.txt": ""
+            }
+        }
+    }
+
+represents a project directory in the file system that contains a single
+directory named ``folder``. In turn, ``folder`` contains two entries.
+The first entry is a file named ``file.txt`` with content ``Hello World!``
+while the second entry is a sub-directory named ``another-folder``. Finally,
+``another-folder`` contains an empty file named ``empty-file.txt``.
+
+.. versionchanged:: 4.0
+    Prior to version 4.0, the project structure included the top level
+    directory of the project. Now it considers everything **under** the
+    project folder.
+
+Additionally, tuple values are also allowed in order to specify a
+**file operation** (or simply **file op**) that will be used to produce the file.
+In this case, the first element of the tuple is the file content, while the
+second element will be a function (or more generally a :obj:`callable` object)
+responsible for writing that content to the disk. For example, the dict::
+
+    from pyscaffold.operations import create
+
+    {
+        "src": {
+            "namespace": {
+                "module.py": ('print("Hello World!")', create)
+            }
+        }
+    }
+
+represents a ``src/namespace/module.py`` file, under the project directory,
+with content ``print("Hello World!")``, that will written to the disk.
+When no operation is specified (i.e. when using a simple string instead of a
+tuple), PyScaffold will assume :obj:`~pyscaffold.operations.create` by default.
+
+.. note::
+
+    The :obj:`~pyscaffold.operations.create` function simply creates a text file
+    to the disk using UTF-8 encoding and the default file permissions. This
+    behaviour can be modified by wrapping :obj:`~pyscaffold.operations.create`
+    within other fuctions/callables, for example::
+
+        from pyscaffold.operations import create, no_overwrite
+
+        {"file": ("content", no_overwrite(create))}
+
+    will prevent the ``file`` to be written if it already exists. See
+    :mod:`pyscaffold.operations` for more information on how to write your own
+    file operation and other options.
+
+Finally, while it is simple to represent file contents as a string directly,
+most of the times we want to *customize* them according to the project
+parameters being created (e.g. package or author's name). So PyScaffold also
+accepts :obj:`string.Template` objects and functions (with a single :obj:`dict`
+argument and a :obj:`str` return value) to be used as contents. These templates
+and functions will be called with :obj:`PyScaffold's options
+<pyscaffold.operations.ScaffoldOpts>` when its time to create the file to the
+disk.
+
+.. note::
+
+    :obj:`string.Template` objects will have :obj:`~string.Template.safe_substitute`
+    called (not simply :obj:`~string.Template.substitute`).
+
+This tree representation is often referred in this document as **project
+structure** or simply **structure**.


### PR DESCRIPTION
This is the first pull request designed to address #376.

The main idea is to start by revamping PyScaffold's own contributors guides to use it as a reference for the template.

It is recommended for any contributor's guide to include a reference to the overall description of the project architecture and some guidance about how the project works. Therefore this PR refactors the existing `docs/extensions.rst` into re-usable portions that can be included in the dev guides.
I also added a picture for the internal action pipeline.