### PR TITLE
Add a dev guide to docs, to help potential contributors  (2nd step #376)

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -23,7 +23,7 @@ reference in terms of community guidelines.
 
 .. tip::
    If you are new to open source or have never contributed before to a software
-   community, please have a look at `contribution-guide.org`_ and the
+   project, please have a look at `contribution-guide.org`_ and the
    `How to Contribute to Open Source`_ guide.
    Other resources are also listed in the excellent `guide created by FreeCodeCamp`_.
 
@@ -43,10 +43,10 @@ be done!
 |:beetle:| Issue Reports
 ------------------------
 
-If you experience bugs or in general issues with PyScaffold, please have a look
+If you experience bugs or general issues with PyScaffold, please have a look
 on our `issue tracker`_.
 
-.. tip::
+.. note::
    Please don't forget to include the closed issues in your search_.
    Sometimes another person has already experienced your problem and reported a
    solution. If you don't see anything useful there, feel free to fire a
@@ -225,7 +225,7 @@ Implement your changes
 
          git log --graph --decorate --pretty=oneline --abbrev-commit --all
 
-      to check for recurring communication patterns.
+      to look for recurring communication patterns.
 
 #. Please check that your changes don't break any unit tests with::
 
@@ -391,7 +391,7 @@ upload to PyPI, the following extra steps can be used:
 #. Run ``tox -e publish -- --repository pypi`` and check that everything was
    uploaded to `PyPI`_ correctly.
 
-.. tip::
+.. important::
    When working in a new **external extension**, it is important that the first
    distribution is manually uploaded to PyPI_, to make sure it will have the
    correct ownership.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,19 +5,19 @@ Contributing
 PyScaffold was started by `Blue Yonder`_ developers to help automating and
 standardizing the process of project setups. Nowadays it is a pure community
 project driven by volunteer work.
-Every little gesture is really appreciated (including |:bug:| issue reports!),
+Every little gesture is really appreciated (including issue reports!),
 and if you are interested in joining our continuous effort for making PyScaffold
 better, welcome aboard! We are pleased to help you in this journey |:ship:|.
 
 .. note::
-   This document is an attempt to get any potential contributor familiarised
+   This document is an attempt to get any potential contributor familiarized
    with PyScaffold's community processes, but by no means is intended to be a
    complete reference.
 
    Please feel free to contact us for help and guidance in our `GitHub discussions`_ page.
 
 Please notice, all the members of the PyScaffold community (and in special
-contributors) are expected to be **open, considerate, reasonable and respectful**.
+contributors) are expected to be **open, considerate, reasonable, and respectful**.
 When in doubt, `Python Software Foundation's Code of Conduct`_ is a good
 reference in terms of community guidelines.
 
@@ -25,7 +25,7 @@ reference in terms of community guidelines.
    If you are new to open source or have never contributed before to a software
    community, please have a look at `contribution-guide.org`_ and the
    `How to Contribute to Open Source`_ guide.
-   Other resources are also listed in the excelent `guide created by FreeCodeCamp`_.
+   Other resources are also listed in the excellent `guide created by FreeCodeCamp`_.
 
 
 How to contribute to PyScaffold?
@@ -34,7 +34,7 @@ How to contribute to PyScaffold?
 This guide focus on issue reports, documentation improvements, and code
 contributions, but there are many other ways to contribute to PyScaffold,
 even if you are not an experienced programmer or don't have the time to code.
-Skills like graphical design, event planing, teaching, mentoring, public outreach,
+Skills like graphical design, event planning, teaching, mentoring, public outreach,
 tech evangelism, code review, between `many others`_ are greatly appreciated.
 Please `reach us out`_, we would love to have you on board and discuss what can
 be done!
@@ -44,70 +44,119 @@ be done!
 ------------------------
 
 If you experience bugs or in general issues with PyScaffold, please have a look
-on our `issue tracker`_ (sometimes another person have already experienced your
-problem and reported a solution). If you don't see anything useful there, please feel
-free to fire an issue report.
+on our `issue tracker`_.
+
+.. tip::
+   Please don't forget to include the closed issues in your search_.
+   Sometimes another person has already experienced your problem and reported a
+   solution. If you don't see anything useful there, feel free to fire a
+   new issue report |:wink:|
+
+New issue reports should include information about your programming environment
+(e.g., operating system, Python version) and steps to reproduce the problem.
+Please try also to simplify the reproduction steps to a very minimal example
+that still illustrates the problem you are facing. By removing other factors,
+you help us to identify the root cause of the issue.
 
 
 |:books:| Documentation Improvements
 ------------------------------------
 
-Did you find any problems with our documentation and have some time to spare?
-Any spelling error? Or is there any complicated topic that you didn't find
-particularly well explained?
 You can help us improve our docs by making them more readable and coherent, or
-by adding missing information and correcting mistakes.
+by adding missing information and correcting mistakes (including spelling and
+grammar errors).
+
+Already known and discussed documentation issues that would benefit from
+contributions are marked in our `issue tracker`_ with the **documentation**
+label (we also do the same for all existing extensions under the `PyScaffold
+organization`_ on GitHub). But you are also welcomed to propose completely new
+changes (e.g., if you find new problems or would like to see a complicated topic
+better explained).
 
 PyScaffold's documentation is written in `reStructuredText`_ and uses `Sphinx`_
-as its main documentation compiler. This means that the docs are kept in the
-same repository as the project code, and that any documentation update is done
-via GitHub pull requests, as if it was a code contribution.
+as its main documentation compiler [#contrib1]_. This means that the docs are
+kept in the same repository as the project code, and that any documentation
+update is done via GitHub pull requests, as if it was a code contribution.
 
 While that might be scary for new programmers, it is actually a very nice way
 of getting started in the open source community, since doc contributions are
 not as difficult to make as other code contributions (for example, they don't
 require any automated testing).
 
-Please have a look in the steps described bellow and in case of doubts, contact
+Please have a look in the steps described below and in case of doubts, contact
 us at the `GitHub discussions`_ page for help.
+
+When working on changes to PyScaffold's docs in your local machine, you can
+compile them using |tox|_::
+
+    tox -e docs
+
+and use Python's built-in web server for a preview in your web browser
+(``http://localhost:8000``)::
+
+    python3 -m http.server --directory 'docs/_build/html'
 
 .. tip::
    Please notice that the `GitHub web interface`_ provides a quick way of
    propose changes in PyScaffold's files, that do not require you to have a lot
-   of experience with git_ or programing in general.  While this mechanism can
+   of experience with git_ or programing in general. While this mechanism can
    be tricky for normal code contributions, it works perfectly fine for
    contributing to the docs, and can be quite handy.
 
    If you are interested in trying this method out, please navigate to
-   PyScaffold's `docs` folder in the `main repository`_, find which file you
+   PyScaffold's ``docs`` folder in the `main repository`_, find which file you
    would like to propose changes and click in the little pencil icon at the
    top, to open `GitHub's code editor`_. Once you finish editing the file,
    please write a nice message in the form at the bottom of the page describing
-   which changes have you made and what are the motivations behind them, and
+   which changes have you made and what are the motivations behind them and
    submit your proposal.
 
 
 |:computer:| Code Contributions
 -------------------------------
 
+PyScaffold uses `GitHub's fork and pull request workflow`_ for code
+contributions, which means that anyone can propose changes in the code base.
+
+Once proposed changes are submitted, our continuous integration (CI) service,
+`Cirrus-CI`_, will run a series of automated checks to make sure everything is
+OK and the pull request (PR) itself will be reviewed by one of PyScaffold
+maintainers, before being merged in the code base. In some cases, changes might
+be required to fix problems pointed out by the CI, or the maintainers might
+want to discuss a bit about the PR and suggest adjustments. Please don't worry
+if that happens, this kind of iterative development is very common in the open
+source community and usually makes the software better. Besides, we will do our
+best to provide feedback (and support for eventual doubts) as soon as we can.
+
+If you are unsure about what to contribute, please have a look in our `issue
+tracker`_ (or the issue tracker of any extension under the `PyScaffold
+organization`_ on GitHub). Contributions on issues marked with the **help
+wanted** label are particularly appreciated. Moreover, the **good first issue**
+label marks issues that do not require a huge understanding on how the project
+works and therefore can be tackled by new members of the community. Please also
+notice that some issues are not ready yet for a follow up implementation or bug
+fix, these are usually signed with other labels_, such as **needs discussion**
+and **waiting response**. When in doubt, please engage in the conversation by
+posting a message to the open issue.
+
 Understanding how PyScaffold works
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The main aspects of PyScaffold internals are explained in our
-:doc:`/dev-guide`. Please make sure to check it out for a brief overview of the
-project and how it is organized.
+If you have a change in mind, but don't know how to implement it, please have a
+look in our :doc:`/dev-guide`. It explains the main aspects of PyScaffold
+internals and provide a brief overview of how the project is organized.
 
 Submit an issue
 ~~~~~~~~~~~~~~~
 
 Before you work on any non-trivial code contribution it's best to first create
-an issue report to start a discussion on the subject. This often provides
-additional considerations and avoids unnecessary work.
+an `issue report`_ to start a discussion on the subject.
+This often provides additional considerations and avoids unnecessary work.
 
 Create an environment
 ~~~~~~~~~~~~~~~~~~~~~
 
-Before you start coding we recommend to create an isolated `virtual
+Before you start coding, we recommend creating an isolated `virtual
 environment`_ to avoid any problems with your installed Python packages.
 This can easily be done via either |virtualenv|_::
 
@@ -122,7 +171,7 @@ or Miniconda_::
 Clone the repository
 ~~~~~~~~~~~~~~~~~~~~
 
-#. `Create a Gitub account`_  if you do not already have one.
+#. `Create a GitHub account`_  if you do not already have one.
 #. Fork the `project repository`_: click on the *Fork* button near the top of the
    page. This creates a copy of the code under your account on the GitHub server.
 #. Clone this copy to your local disk::
@@ -144,13 +193,17 @@ Clone the repository
    PyScaffold project comes with a lot of hooks configured to
    automatically help the developer to check the code being written.
 
+Implement your changes
+~~~~~~~~~~~~~~~~~~~~~~
+
 #. Create a branch to hold your changes::
 
     git checkout -b my-feature
 
    and start making changes. Never work on the master branch!
 
-#. Start your work on this branch.
+#. Start your work on this branch. Don't forget to add docstrings_ to new
+   functions, modules and classes, especially if they are part of public APIs.
 
 #. Add yourself to the list of contributors in ``AUTHORS.rst``.
 
@@ -159,18 +212,26 @@ Clone the repository
     git add <MODIFIED FILES>
     git commit
 
-   to record your changes in Git. Please make sure to see the validation
-   messages from |pre-commit|_ and fix any eventual issue.
+   to record your changes in git_. Please make sure to see the validation
+   messages from |pre-commit|_ and fix any eventual issues.
    This should automatically use flake8_/black_ to check/fix the code style
    in a way that is compatible with PyScaffold.
+
+   .. important:: Don't forget to add unit tests and documentation in case your
+      contribution adds an additional feature and is not just a bugfix.
+
+      Moreover, writing a `descriptive commit message`_ is highly recommended.
+      In case of doubt, you can check the commit history with::
+
+         git log --graph --decorate --pretty=oneline --abbrev-commit --all
+
+      to check for recurring communication patterns.
 
 #. Please check that your changes don't break any unit tests with::
 
     tox
 
    (after having installed |tox|_ with ``pip install tox`` or ``pipx``).
-   Don't forget to also add unit tests in case your contribution
-   adds an additional feature and is not just a bugfix.
 
    To speed up running the tests, you can try to run them in parallel, using
    ``pytest-xdist``. This plugin is already added to the test dependencies, so
@@ -192,18 +253,21 @@ Clone the repository
    You can also use |tox|_ to run several other pre-configured tasks in the
    repository. Try ``tox -av`` to see a list of the available checks.
 
+Submit your contribution
+~~~~~~~~~~~~~~~~~~~~~~~~
+
 #. If everything works fine, push your local branch to GitHub with::
 
     git push -u origin my-feature
 
-#. Go to the web page of your PyScaffold fork, and click
+#. Go to the web page of your PyScaffold fork and click
    "Create pull request" to send your changes to the maintainers for review.
    Find more detailed information `creating a PR`_. You might also want to open
    the PR as a draft first and mark it as ready for review after the feedbacks
    from the continuous integration (CI) system or any required fixes.
 
 #. If you are submitting a change related to an existing CI
-   system template (e.g. travis, cirrus, or even tox and pre-commit),
+   system template (e.g., travis, cirrus, or even tox and pre-commit),
    please consider first submitting a companion PR to PyScaffold's
    `ci-tester`_, with the equivalent files changes, so we are sure it works.
 
@@ -224,7 +288,7 @@ Make sure to fetch all the tags from the upstream repository, the command ``git
 describe --abbrev=0 --tags`` should return the version you are expecting. If
 you are trying to run the CI scripts in a fork repository, make sure to push
 all the tags.
-You can also try to remove all the egg files or the complete egg folder, i.e.
+You can also try to remove all the egg files or the complete egg folder, i.e.,
 ``.eggs``, as well as the ``*.egg-info`` folders in the ``src`` folder or
 potentially in the root of your project. Afterwards run ``python setup.py
 egg_info --egg-base .`` again.
@@ -248,7 +312,7 @@ installed. For example::
     I have found a weird error when running |tox|_. It seems like some dependency
     is not being installed.
 
-Sometimes |tox|_ misses out when new dependencies are added, specially to
+Sometimes |tox|_ misses out when new dependencies are added, especially to
 ``setup.cfg`` and ``docs/requirements.txt``. If you find any problems with
 missing dependencies when running a command with |tox|_, try to recreate the
 ``tox`` environment using the ``-r`` flag. For example, instead of::
@@ -264,9 +328,9 @@ Try running::
     I am trying to debug the automatic test suite, but it is very hard to
     understand what is happening.
 
-`Pytest can drop you`_ in a interactive session in the case an error occurs.
+`Pytest can drop you`_ in an interactive session in the case an error occurs.
 In order to do that you need to pass a ``--pdb`` option (for example by running
-``tox -- -k NAME_OF_THE_FALLING_TEST --pdb``).
+``tox -- -k <NAME OF THE FALLING TEST> --pdb``).
 While ``pdb`` does not have the best user interface in the world, if you feel
 courageous, it is possible to use an alternate implementation like `ptpdb`_ and
 `bpdb`_ (please notice some of them might require additional options, such as
@@ -280,12 +344,26 @@ You can also setup breakpoints manually instead of using the ``--pdb`` option.
 
 If you are an experienced developer and wants to help, but do not have the time
 to create complete pull requests, you can still help by `reviewing existing open
-pull requests`_, or going through the open issues and evaluating them according to `our
-labels`_ and even suggesting possible solutions or workarounds.
+pull requests`_, or going through the open issues and evaluating them according to our
+labels_ and even suggesting possible solutions or workarounds.
 
 
 |:hammer_and_wrench:| Maintainer tasks
 --------------------------------------
+
+PyScaffold maintainers not only carry out most of the source code development,
+but also are responsible for planning new releases, reviewing pull requests,
+and managing CI tools between many other tasks. If you are interested in
+becoming a maintainer, the best is to keep "hanging out" in the community,
+helping with the issues, proposing PRs and doing some code review (either in
+the `main repository`_ or the extensions under the `PyScaffold organization`_
+on GitHub).  Eventually, one of the existing maintainers will approach you and
+ask you to join |:wink:|.
+
+This section describes some technical aspects of recurring tasks
+and is meant as a guide for new maintainers (or old ones that need a memory
+refresher).
+
 
 Releases
 ~~~~~~~~
@@ -296,8 +374,8 @@ Therefore, as a PyScaffold maintainer, the following steps are all you need
 to release a new version:
 
 #. Make sure all unit tests on `Cirrus-CI`_ are green.
-#. Tag the current commit on the master branch with a release tag, e.g. ``v1.2.3``.
-#. Push the new tag to the upstream repository, e.g. ``git push upstream v1.2.3``
+#. Tag the current commit on the master branch with a release tag, e.g., ``v1.2.3``.
+#. Push the new tag to the upstream repository, e.g., ``git push upstream v1.2.3``
 #. After a few minutes check if the new version was uploaded to PyPI_
 
 If, for some reason, you need to manually create a new distribution file and
@@ -307,7 +385,7 @@ upload to PyPI, the following extra steps can be used:
    (or ``rm -rf dist build``)
    to avoid confusion with old builds and Sphinx docs.
 #. Run ``tox -e build`` and check that the files in ``dist`` have
-   the correct version (no ``.dirty`` or Git hash) according to the Git tag.
+   the correct version (no ``.dirty`` or git_ hash) according to the git_ tag.
    Also sizes of the distributions should be less than 500KB, otherwise unwanted
    clutter may have been included.
 #. Run ``tox -e publish -- --repository pypi`` and check that everything was
@@ -318,10 +396,60 @@ upload to PyPI, the following extra steps can be used:
    distribution is manually uploaded to PyPI_, to make sure it will have the
    correct ownership.
 
-After successful releases (specially of new major versions), it is a good
+After successful releases (especially of new major versions), it is a good
 practice to re-generate our example repository. To manually do that, please
 visit our `GitHub actions`_ page and run the **Make Demo Repo** workflow
 (please check if it was not automatically triggered already).
+
+
+Working on multiple branches and splitting complex changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+PyScaffold follows `semantic versioning`_. As a consequence, most of the times
+the ``master`` (or ``main``) branch for either the `main repository`_ or the
+extensions under the `PyScaffold organization`_ on GitHub, should be pointing
+out to the latest published minor version, or the next minor version still
+under development. We also tend (but are not committed to) keep some level of
+support for the previous major version, which means that once a major version
+is superseded, the maintainers should create a new branch pointing to this
+previous version.
+
+For this reason, `Read the Docs`_ should always be configured to show the
+**stable** version by default instead of **latest**. The **stable** version
+corresponds to the latest commit that received a git_ tag, while the **latest**
+version points to the **master**/**main** branch.
+
+During the transition period between major versions, it is common practice to
+create a new *development* version that is kept apart from the master branch
+and will only be merged when everything is ready for release. For example, a
+``v4.0.x`` branch was used for all the development related to PyScaffold v4,
+while the ``master`` branch was still being used for bug fixes to v3.
+
+When working in complex features or refactoring, it might also be interesting
+to create a new long-living branch that will receive multiple PRs from other
+short-lived auxiliary branch splitting the changes into smaller steps. Please
+be aware that splitting complex changes into smaller PRs can be very tricky.
+Whenever possible, try to create independent PRs, i.e., PRs that can be merged
+independently into a long-living branch, without causing conflicts between
+themselves. When that is not possible, please coordinate a review and merge
+strategy with the other maintainers reviewing your code.
+
+One possible strategy is to create a single PR, but ask your reviewers to
+consider each commit (that should be small) as if it was an independent PR.
+A different strategy is to use **stacked PRs**, as described by the following
+references:
+
+- `Timothy Andrew's Blog <https://timothyandrew.dev/blog/git-stack>`_
+- `Div's Blog <https://divyanshu013.dev/blog/code-review-stacked-prs>`_
+- `LogRocket's Blog <https://blog.logrocket.com/using-stacked-pull-requests-in-github>`_
+
+Please also notice that independently of the strategy you and the reviewers
+agree on, it might be worthy to ask them to just review the PRs without merging
+(so you are responsible for closing the PRs and bringing their code to the
+long-lived branch via git ``merge``, ``pull`` or ``cherry-pick``).
+This might avoid confusion since GitHub does not provide any special mechanism
+for dealing with dependencies between PRs. Moreover, the merging might be just
+easier via git_ CLI.
 
 
 |:mega:| Spread the Word
@@ -331,9 +459,16 @@ Finally, another way to contribute to PyScaffold is to recommend it. You can
 speak about it with your work colleagues, in a conference, or even writing a
 blog post about the project.
 
-If you need to pitch PyScaffold to you boss or co-workers, please checkout our
-docs. We have enumerated a few :doc:`reasons for using PyScaffold </reasons>`
-in our website, that can be handy to have around |:wink:|.
+If you need to pitch PyScaffold to your boss or co-workers, please check out
+our docs. We have enumerated a few :doc:`reasons for using PyScaffold
+</reasons>` in our website, that can be handy to have around |:wink:|.
+
+
+
+.. [#contrib1] The same is valid for the extensions under the `PyScaffold
+   organization`_ on GitHub, although some extension, like
+   `pyscaffoldext-markdown`_ and `pyscaffoldext-dsproject`_ use CommonMark_
+   with MyST_ extensions as an alternative to reStructuredText_.
 
 
 
@@ -341,11 +476,49 @@ in our website, that can be handy to have around |:wink:|.
 .. |pre-commit| replace:: ``pre-commit``
 .. |tox| replace:: ``tox``
 
+.. _black: https://pypi.org/project/black/
 .. _Blue Yonder: https://blueyonder.com/
+.. _bpdb: https://docs.bpython-interpreter.org/en/latest/bpdb.html?highlight=bpdb
+.. _ci-tester: https://github.com/pyscaffold/ci-tester
 .. _Cirrus-CI: https://cirrus-ci.com/github/pyscaffold/pyscaffold
-.. _Create a Gitub account: https://github.com/join
-.. _Git: https://git-scm.com/
+.. _CommonMark: https://commonmark.org/
+.. _contribution-guide.org: http://www.contribution-guide.org/
+.. _Create a GitHub account: https://github.com/join
+.. _creating a PR: https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
+.. _descriptive commit message: https://chris.beams.io/posts/git-commit
+.. _docstrings: https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
+.. _flake8: https://flake8.pycqa.org/en/stable/
+.. _git: https://git-scm.com/
 .. _GitHub actions: https://github.com/pyscaffold/pyscaffold/actions
+.. _GitHub's fork and pull request workflow: https://guides.github.com/activities/forking/
+.. _guide created by FreeCodeCamp: https://github.com/FreeCodeCamp/how-to-contribute-to-open-source
+.. _issue tracker: https://github.com/pyscaffold/pyscaffold/issues
+.. _issue report: https://github.com/pyscaffold/pyscaffold/issues
+.. _labels: https://github.com/pyscaffold/pyscaffold/labels
+.. _Miniconda: https://docs.conda.io/en/latest/miniconda.html
+.. _MyST: https://myst-parser.readthedocs.io/en/latest/syntax/syntax.html
+.. _pre-commit: https://pre-commit.com/
+.. _ptpdb: https://pypi.org/project/ptpdb/
+.. _PyPI: https://pypi.org
+.. _PyScaffold organization: https://github.com/pyscaffold
+.. _pyscaffoldext-dsproject: https://github.com/pyscaffold/pyscaffoldext-dsproject
+.. _pyscaffoldext-markdown: https://github.com/pyscaffold/pyscaffoldext-markdown
+.. _Pytest can drop you: https://docs.pytest.org/en/stable/usage.html#dropping-to-pdb-python-debugger-at-the-start-of-a-test
+.. _pytest: https://docs.pytest.org/en/stable/
+.. _Python Software Foundation's Code of Conduct: https://www.python.org/psf/conduct/
+.. _Read the Docs: https://docs.readthedocs.io/en/stable/versions.html
+.. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/
+.. _reviewing existing open pull requests: https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews
+.. _search: https://github.com/pyscaffold/pyscaffold/issues?q=
+.. _semantic versioning: https://semver.org
+.. _Sphinx: https://www.sphinx-doc.org/en/master/
+.. _tox: https://tox.readthedocs.io/en/stable/
+.. _Travis: https://travis-ci.org/pyscaffold/pyscaffold
+.. _virtual environment: https://realpython.com/python-virtual-environments-a-primer/
+.. _virtualenv: https://virtualenv.pypa.io/en/stable/
+
+.. _project repository: https://github.com/pyscaffold/pyscaffold
+.. _main repository: https://github.com/pyscaffold/pyscaffold
 
 .. _GitHub discussions: https://github.com/pyscaffold/pyscaffold/discussions
 .. _reach us out: https://github.com/pyscaffold/pyscaffold/discussions
@@ -356,31 +529,3 @@ in our website, that can be handy to have around |:wink:|.
 .. _How to Contribute to Open Source: https://opensource.guide/how-to-contribute
 .. _ways of contributing: https://opensource.guide/how-to-contribute/
 .. _many others: https://opensource.guide/how-to-contribute/
-
-.. _Miniconda: https://docs.conda.io/en/latest/miniconda.html
-.. _PyPI: https://pypi.org/
-.. _Pytest can drop you: https://docs.pytest.org/en/stable/usage.html#dropping-to-pdb-python-debugger-at-the-start-of-a-test
-.. _Python Software Foundation's Code of Conduct: https://www.python.org/psf/conduct/
-.. _Sphinx: https://www.sphinx-doc.org/en/master/
-.. _Travis: https://travis-ci.org/pyscaffold/pyscaffold
-.. _black: https://pypi.org/project/black/
-.. _bpdb: https://docs.bpython-interpreter.org/en/latest/bpdb.html?highlight=bpdb
-.. _ci-tester: https://github.com/pyscaffold/ci-tester
-.. _contribution-guide.org: http://www.contribution-guide.org/
-.. _creating a PR: https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
-.. _flake8: https://flake8.pycqa.org/en/stable/
-.. _guide created by FreeCodeCamp: https://github.com/FreeCodeCamp/how-to-contribute-to-open-source
-.. _issue tracker: https://github.com/pyscaffold/pyscaffold/issues
-.. _our labels: https://github.com/pyscaffold/pyscaffold/labels
-.. _pre-commit: https://pre-commit.com/
-
-.. _project repository: https://github.com/pyscaffold/pyscaffold
-.. _main repository: https://github.com/pyscaffold/pyscaffold
-
-.. _ptpdb: https://pypi.org/project/ptpdb/
-.. _pytest: https://docs.pytest.org/en/stable/
-.. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/
-.. _reviewing existing open pull requests: https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews
-.. _tox: https://tox.readthedocs.io/en/stable/
-.. _virtual environment: https://realpython.com/python-virtual-environments-a-primer/
-.. _virtualenv: https://virtualenv.pypa.io/en/stable/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -440,6 +440,7 @@ A different strategy is to use **stacked PRs**, as described by the following
 references:
 
 - `Timothy Andrew's Blog <https://timothyandrew.dev/blog/git-stack>`_
+- `Doctor McKayla's Blog <https://www.michaelagreiler.com/stacked-pull-requests/>`_
 - `Div's Blog <https://divyanshu013.dev/blog/code-review-stacked-prs>`_
 - `LogRocket's Blog <https://blog.logrocket.com/using-stacked-pull-requests-in-github>`_
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,41 +4,123 @@ Contributing
 
 PyScaffold was started by `Blue Yonder`_ developers to help automating and
 standardizing the process of project setups. Nowadays it is a pure community
-project and you are very welcome to join in our effort if you would like
-to contribute.
+project driven by volunteer work.
+Every little gesture is really appreciated (including |:bug:| issue reports!),
+and if you are interested in joining our continuous effort for making PyScaffold
+better, welcome aboard! We are pleased to help you in this journey |:ship:|.
+
+.. note::
+   This document is an attempt to get any potential contributor familiarised
+   with PyScaffold's community processes, but by no means is intended to be a
+   complete reference.
+
+   Please feel free to contact us for help and guidance in our `GitHub discussions`_ page.
+
+Please notice, all the members of the PyScaffold community (and in special
+contributors) are expected to be **open, considerate, reasonable and respectful**.
+When in doubt, `Python Software Foundation's Code of Conduct`_ is a good
+reference in terms of community guidelines.
+
+.. tip::
+   If you are new to open source or have never contributed before to a software
+   community, please have a look at `contribution-guide.org`_ and the
+   `How to Contribute to Open Source`_ guide.
+   Other resources are also listed in the excelent `guide created by FreeCodeCamp`_.
 
 
-Issue Reports
-=============
+How to contribute to PyScaffold?
+================================
 
-If you experience bugs or in general issues with PyScaffold, please file an
-issue report on our `issue tracker`_.
+This guide focus on issue reports, documentation improvements, and code
+contributions, but there are many other ways to contribute to PyScaffold,
+even if you are not an experienced programmer or don't have the time to code.
+Skills like graphical design, event planing, teaching, mentoring, public outreach,
+tech evangelism, code review, between `many others`_ are greatly appreciated.
+Please `reach us out`_, we would love to have you on board and discuss what can
+be done!
 
 
-Code Contributions
-==================
+|:beetle:| Issue Reports
+------------------------
+
+If you experience bugs or in general issues with PyScaffold, please have a look
+on our `issue tracker`_ (sometimes another person have already experienced your
+problem and reported a solution). If you don't see anything useful there, please feel
+free to fire an issue report.
+
+
+|:books:| Documentation Improvements
+------------------------------------
+
+Did you find any problems with our documentation and have some time to spare?
+Any spelling error? Or is there any complicated topic that you didn't find
+particularly well explained?
+You can help us improve our docs by making them more readable and coherent, or
+by adding missing information and correcting mistakes.
+
+PyScaffold's documentation is written in `reStructuredText`_ and uses `Sphinx`_
+as its main documentation compiler. This means that the docs are kept in the
+same repository as the project code, and that any documentation update is done
+via GitHub pull requests, as if it was a code contribution.
+
+While that might be scary for new programmers, it is actually a very nice way
+of getting started in the open source community, since doc contributions are
+not as difficult to make as other code contributions (for example, they don't
+require any automated testing).
+
+Please have a look in the steps described bellow and in case of doubts, contact
+us at the `GitHub discussions`_ page for help.
+
+.. tip::
+   Please notice that the `GitHub web interface`_ provides a quick way of
+   propose changes in PyScaffold's files, that do not require you to have a lot
+   of experience with git_ or programing in general.  While this mechanism can
+   be tricky for normal code contributions, it works perfectly fine for
+   contributing to the docs, and can be quite handy.
+
+   If you are interested in trying this method out, please navigate to
+   PyScaffold's `docs` folder in the `main repository`_, find which file you
+   would like to propose changes and click in the little pencil icon at the
+   top, to open `GitHub's code editor`_. Once you finish editing the file,
+   please write a nice message in the form at the bottom of the page describing
+   which changes have you made and what are the motivations behind them, and
+   submit your proposal.
+
+
+|:computer:| Code Contributions
+-------------------------------
+
+Understanding how PyScaffold works
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The main aspects of PyScaffold internals are explained in our
+:doc:`/dev-guide`. Please make sure to check it out for a brief overview of the
+project and how it is organized.
 
 Submit an issue
----------------
+~~~~~~~~~~~~~~~
 
 Before you work on any non-trivial code contribution it's best to first create
 an issue report to start a discussion on the subject. This often provides
 additional considerations and avoids unnecessary work.
 
 Create an environment
----------------------
+~~~~~~~~~~~~~~~~~~~~~
 
-Before you start coding we recommend to install Miniconda_ which allows
-to setup a dedicated development environment named ``pyscaffold`` with::
+Before you start coding we recommend to create an isolated `virtual
+environment`_ to avoid any problems with your installed Python packages.
+This can easily be done via either |virtualenv|_::
 
-   conda create -n pyscaffold python=3 six virtualenv pytest pytest-cov
+    virtualenv <PATH TO VENV>
+    source <PATH TO VENV>/bin/activate
 
-Then activate the environment ``pyscaffold`` with::
+or Miniconda_::
 
-   source activate pyscaffold
+    conda create -n pyscaffold python=3 six virtualenv pytest pytest-cov
+    conda activate pyscaffold
 
 Clone the repository
---------------------
+~~~~~~~~~~~~~~~~~~~~
 
 #. `Create a Gitub account`_  if you do not already have one.
 #. Fork the `project repository`_: click on the *Fork* button near the top of the
@@ -50,15 +132,11 @@ Clone the repository
 
 #. You should run::
 
-    pip install -U pip setuptools
-    pip install -e .
+    pip install -U pip setuptools -e .
 
-   to be able run ``putup``.
+   to be able run ``putup --help``.
 
-.. TODO: Remove the manual installation/update of pip, setuptools and setuptools_scm
-   once pip starts supporting editable installs with pyproject.toml
-
-#. Install ``pre-commit``::
+#. Install |pre-commit|_::
 
     pip install pre-commit
     pre-commit install
@@ -72,20 +150,25 @@ Clone the repository
 
    and start making changes. Never work on the master branch!
 
-#. Start your work on this branch. When you’re done editing, do::
+#. Start your work on this branch.
 
-    git add modified_files
+#. Add yourself to the list of contributors in ``AUTHORS.rst``.
+
+#. When you’re done editing, do::
+
+    git add <MODIFIED FILES>
     git commit
 
-   to record your changes in Git, then push them to GitHub with::
-
-    git push -u origin my-feature
+   to record your changes in Git. Please make sure to see the validation
+   messages from |pre-commit|_ and fix any eventual issue.
+   This should automatically use flake8_/black_ to check/fix the code style
+   in a way that is compatible with PyScaffold.
 
 #. Please check that your changes don't break any unit tests with::
 
     tox
 
-   (after having installed `tox`_ with ``pip install tox`` or ``pipx``).
+   (after having installed |tox|_ with ``pip install tox`` or ``pipx``).
    Don't forget to also add unit tests in case your contribution
    adds an additional feature and is not just a bugfix.
 
@@ -102,13 +185,23 @@ Clone the repository
 
     tox -e fast
 
-#. Use `flake8`_/`black`_ to check\fix your code style.
-#. Add yourself to the list of contributors in ``AUTHORS.rst``.
+   or select individual tests using the ``-k`` flag from pytest_::
+
+    tox -- -k <NAME OF THE TEST FUNCTION>
+
+   You can also use |tox|_ to run several other pre-configured tasks in the
+   repository. Try ``tox -av`` to see a list of the available checks.
+
+#. If everything works fine, push your local branch to GitHub with::
+
+    git push -u origin my-feature
+
 #. Go to the web page of your PyScaffold fork, and click
    "Create pull request" to send your changes to the maintainers for review.
    Find more detailed information `creating a PR`_. You might also want to open
    the PR as a draft first and mark it as ready for review after the feedbacks
    from the continuous integration (CI) system or any required fixes.
+
 #. If you are submitting a change related to an existing CI
    system template (e.g. travis, cirrus, or even tox and pre-commit),
    please consider first submitting a companion PR to PyScaffold's
@@ -120,8 +213,82 @@ Clone the repository
 
    This helps us a lot to control breaking changes that might appear in the future.
 
-Release
-========
+
+Troubleshooting
+~~~~~~~~~~~~~~~
+
+    I've got a strange error related to versions in ``test_update.py`` when
+    executing the test suite or about an ``entry_point`` that cannot be found.
+
+Make sure to fetch all the tags from the upstream repository, the command ``git
+describe --abbrev=0 --tags`` should return the version you are expecting. If
+you are trying to run the CI scripts in a fork repository, make sure to push
+all the tags.
+You can also try to remove all the egg files or the complete egg folder, i.e.
+``.eggs``, as well as the ``*.egg-info`` folders in the ``src`` folder or
+potentially in the root of your project. Afterwards run ``python setup.py
+egg_info --egg-base .`` again.
+
+..
+
+    I've got a strange syntax error when running the test suite. It looks
+    like the tests are trying to run with Python 2.7 …
+
+Try to create a dedicated `virtual environment`_ using Python 3.6+ (or the most
+recent version supported by PyScaffold) and use a |tox|_ binary freshly
+installed. For example::
+
+    virtualenv .venv
+    source .venv/bin/activate
+    .venv/bin/pip install tox
+    .venv/bin/tox -e all
+
+..
+
+    I have found a weird error when running |tox|_. It seems like some dependency
+    is not being installed.
+
+Sometimes |tox|_ misses out when new dependencies are added, specially to
+``setup.cfg`` and ``docs/requirements.txt``. If you find any problems with
+missing dependencies when running a command with |tox|_, try to recreate the
+``tox`` environment using the ``-r`` flag. For example, instead of::
+
+    tox -e docs
+
+Try running::
+
+    tox -r -e docs
+
+..
+
+    I am trying to debug the automatic test suite, but it is very hard to
+    understand what is happening.
+
+`Pytest can drop you`_ in a interactive session in the case an error occurs.
+In order to do that you need to pass a ``--pdb`` option (for example by running
+``tox -- -k NAME_OF_THE_FALLING_TEST --pdb``).
+While ``pdb`` does not have the best user interface in the world, if you feel
+courageous, it is possible to use an alternate implementation like `ptpdb`_ and
+`bpdb`_ (please notice some of them might require additional options, such as
+``--pdbcls ptpdb:PtPdb``/``--pdbcls bpdb:BPdb``). You will need to temporarily
+add the respective package as a dependency in your ``tox.ini`` file.
+You can also setup breakpoints manually instead of using the ``--pdb`` option.
+
+
+|:mag:| Code Reviews and Issue Triage
+-------------------------------------
+
+If you are an experienced developer and wants to help, but do not have the time
+to create complete pull requests, you can still help by `reviewing existing open
+pull requests`_, or going through the open issues and evaluating them according to `our
+labels`_ and even suggesting possible solutions or workarounds.
+
+
+|:hammer_and_wrench:| Maintainer tasks
+--------------------------------------
+
+Releases
+~~~~~~~~
 
 New PyScaffold releases should be automatically uploaded to PyPI by one of our
 `GitHub actions`_ every time a new tag is pushed to the repository.
@@ -146,70 +313,74 @@ upload to PyPI, the following extra steps can be used:
 #. Run ``tox -e publish -- --repository pypi`` and check that everything was
    uploaded to `PyPI`_ correctly.
 
+.. tip::
+   When working in a new **external extension**, it is important that the first
+   distribution is manually uploaded to PyPI_, to make sure it will have the
+   correct ownership.
+
 After successful releases (specially of new major versions), it is a good
 practice to re-generate our example repository. To manually do that, please
 visit our `GitHub actions`_ page and run the **Make Demo Repo** workflow
 (please check if it was not automatically triggered already).
 
 
-Troubleshooting
-===============
+|:mega:| Spread the Word
+------------------------
 
-    I've got a strange error related to versions in ``test_update.py`` when
-    executing the test suite or about an *entry_point* that cannot be found.
+Finally, another way to contribute to PyScaffold is to recommend it. You can
+speak about it with your work colleagues, in a conference, or even writing a
+blog post about the project.
 
-Make sure to fetch all the tags from the upstream repository, the command ``git
-describe --abbrev=0 --tags`` should return the version you are expecting. If
-you are trying to run the CI scripts in a fork repository, make sure to push
-all the tags.
-You can also try to remove all the egg files or the complete egg folder, i.e.
-``.eggs``, as well as the ``*.egg-info`` folders in the ``src`` folder or
-potentially in the root of your project. Afterwards run ``python setup.py
-egg_info --egg-base .`` again.
-
-    I've got a strange syntax error when running the test suite. It looks
-    like the tests are trying to run with Python 2.7 …
-
-Try to create a dedicated venv using Python 3.6+ (or the most recent version
-supported by PyScaffold) and use a ``tox`` binary freshly installed in this
-venv. For example::
-
-    python3 -m venv .venv
-    source .venv/bin/activate
-    .venv/bin/pip install tox
-    .venv/bin/tox -e all
-
-..
-
-    I am trying to debug the automatic test suite, but it is very hard to
-    understand what is happening.
-
-`Pytest can drop you`_ in a interactive session in the case an error occurs.
-In order to do that you need to pass a ``--pdb`` option (for example by running
-``tox -- -k NAME_OF_THE_FALLING_TEST --pdb``).
-While ``pdb`` does not have the best user interface in the world, if you feel
-courageous, it is possible to use an alternate implementation like `ptpdb`_ and
-`bpdb`_ (please notice some of them might require additional options, such as
-``--pdbcls ptpdb:PtPdb``/``--pdbcls bpdb:BPdb``). You will need to temporarily
-add the respective package as a dependency in your ``tox.ini`` file.
-You can also setup breakpoints manually instead of using the ``--pdb`` option.
+If you need to pitch PyScaffold to you boss or co-workers, please checkout our
+docs. We have enumerated a few :doc:`reasons for using PyScaffold </reasons>`
+in our website, that can be handy to have around |:wink:|.
 
 
-.. _Travis: https://travis-ci.org/pyscaffold/pyscaffold
-.. _Cirrus-CI: https://cirrus-ci.com/github/pyscaffold/pyscaffold
-.. _PyPI: https://pypi.org/
+
+.. |virtualenv| replace:: ``virtualenv``
+.. |pre-commit| replace:: ``pre-commit``
+.. |tox| replace:: ``tox``
+
 .. _Blue Yonder: https://blueyonder.com/
-.. _project repository: https://github.com/pyscaffold/pyscaffold
-.. _Git: https://git-scm.com/
-.. _Miniconda: https://docs.conda.io/en/latest/miniconda.html
-.. _issue tracker: https://github.com/pyscaffold/pyscaffold/issues
+.. _Cirrus-CI: https://cirrus-ci.com/github/pyscaffold/pyscaffold
 .. _Create a Gitub account: https://github.com/join
-.. _creating a PR: https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
-.. _tox: https://tox.readthedocs.io/en/stable/
-.. _flake8: https://flake8.pycqa.org/en/stable/
-.. _ci-tester: https://github.com/pyscaffold/ci-tester
-.. _Pytest can drop you: https://docs.pytest.org/en/stable/usage.html#dropping-to-pdb-python-debugger-at-the-start-of-a-test
-.. _ptpdb: https://pypi.org/project/ptpdb/
-.. _bpdb: https://docs.bpython-interpreter.org/en/latest/bpdb.html?highlight=bpdb
-.. _black: https://pypi.org/project/black/
+.. _Git: https://git-scm.com/
 .. _GitHub actions: https://github.com/pyscaffold/pyscaffold/actions
+
+.. _GitHub discussions: https://github.com/pyscaffold/pyscaffold/discussions
+.. _reach us out: https://github.com/pyscaffold/pyscaffold/discussions
+
+.. _GitHub web interface: https://docs.github.com/en/github/managing-files-in-a-repository/managing-files-on-github/editing-files-in-your-repository
+.. _GitHub's code editor: https://docs.github.com/en/github/managing-files-in-a-repository/managing-files-on-github/editing-files-in-your-repository
+
+.. _How to Contribute to Open Source: https://opensource.guide/how-to-contribute
+.. _ways of contributing: https://opensource.guide/how-to-contribute/
+.. _many others: https://opensource.guide/how-to-contribute/
+
+.. _Miniconda: https://docs.conda.io/en/latest/miniconda.html
+.. _PyPI: https://pypi.org/
+.. _Pytest can drop you: https://docs.pytest.org/en/stable/usage.html#dropping-to-pdb-python-debugger-at-the-start-of-a-test
+.. _Python Software Foundation's Code of Conduct: https://www.python.org/psf/conduct/
+.. _Sphinx: https://www.sphinx-doc.org/en/master/
+.. _Travis: https://travis-ci.org/pyscaffold/pyscaffold
+.. _black: https://pypi.org/project/black/
+.. _bpdb: https://docs.bpython-interpreter.org/en/latest/bpdb.html?highlight=bpdb
+.. _ci-tester: https://github.com/pyscaffold/ci-tester
+.. _contribution-guide.org: http://www.contribution-guide.org/
+.. _creating a PR: https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
+.. _flake8: https://flake8.pycqa.org/en/stable/
+.. _guide created by FreeCodeCamp: https://github.com/FreeCodeCamp/how-to-contribute-to-open-source
+.. _issue tracker: https://github.com/pyscaffold/pyscaffold/issues
+.. _our labels: https://github.com/pyscaffold/pyscaffold/labels
+.. _pre-commit: https://pre-commit.com/
+
+.. _project repository: https://github.com/pyscaffold/pyscaffold
+.. _main repository: https://github.com/pyscaffold/pyscaffold
+
+.. _ptpdb: https://pypi.org/project/ptpdb/
+.. _pytest: https://docs.pytest.org/en/stable/
+.. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/
+.. _reviewing existing open pull requests: https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews
+.. _tox: https://tox.readthedocs.io/en/stable/
+.. _virtual environment: https://realpython.com/python-virtual-environments-a-primer/
+.. _virtualenv: https://virtualenv.pypa.io/en/stable/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -451,6 +451,13 @@ This might avoid confusion since GitHub does not provide any special mechanism
 for dealing with dependencies between PRs. Moreover, the merging might be just
 easier via git_ CLI.
 
+.. note::
+   PyScaffold's repositories also contain ``archives/*`` branches. These
+   branches correspond to old experiments and alternative feature
+   implementations that, although not merged, are kept for reference as
+   interesting (or very complex) pieces of code that might be useful in the
+   future.
+
 
 |:mega:| Spread the Word
 ------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.extlinks",
     "sphinx_copybutton",
+    "sphinxemoji.sphinxemoji",
 ]
 
 # TODO: Autodoc cannot leave type hints alone (without expansion), as result the docs

--- a/docs/dev-guide.rst
+++ b/docs/dev-guide.rst
@@ -1,0 +1,134 @@
+===============
+Developer Guide
+===============
+
+
+This document describes the internal architecture and the main concepts behind
+PyScaffold. It assumes the reader has some experience in *using* PyScaffold
+(specially its command line interface, ``putup``) and some familiarity with `Python's
+package ecosystem`_.
+
+Please notice this document does not target PyScaffold's users, instead it
+provides **internal** documentation for those who are involved in PyScaffold's
+development.
+
+
+.. _core-concepts:
+
+Architecture
+============
+
+As indicated in the figure bellow, PyScaffold can be divided in two main
+execution blocks: a pure Python API and the command line interface wrapping
+it as an executable program that runs on the shell.
+
+.. image:: gfx/api-paths.svg
+   :alt: PyScaffold's architecture
+   :align: center
+
+The CLI is responsible for defining all arguments ``putup``
+accepts and parsing the user input accordingly. The result is a :obj:`dict`
+that contains options expressing the user preference and can be fed
+into PyScaffold's main API, :obj:`~pyscaffold.api.create_project`.
+
+This function is responsible for combining the provided options :obj:`dict`
+with pre-existing project configurations that might be available in the project
+directory (the ``setup.cfg`` file, if present) and globally defined default
+values (via :ref:`PyScaffold's own configuration file <configuration>`).
+It will then create an (initially empty) *in-memory* representation of the
+project structure and run PyScaffold's action pipeline, which in turn will
+(between other tasks) write customized versions of PyScaffold's templates to
+the disk as project files, according to the combined scaffold options.
+
+The project representation and the action pipeline are two key concepts in
+PyScaffold's architecture and are described in detail in the following
+sections.
+
+.. _project-structure:
+.. include:: project-structure.rst
+
+.. _action-pipeline:
+.. include:: action-pipeline.rst
+
+
+Extensions
+==========
+
+Extensions are a mechanism provided by PyScaffold to modify its action pipeline
+at runtime and the preferred way of adding new functionality.
+There are **built-in extensions** (e.g. :mod:`pyscaffold.extensions.cirrus`)
+and **external extensions** (e.g. `pyscaffoldext-dsproject`_), but both types
+of extensions work exactly in the same way.
+This division is purely based on the fact that some of PyScaffold features are
+implemented as extensions that ship by default with the ``pyscaffold`` package,
+while other require the user to install additional Python packages.
+
+Extensions are required to add at least one CLI argument that allow the users
+to opt-in for their behaviour. When ``putup`` runs, PyScaffold's will
+dynamically discover installed extensions via `setuptools entry points`_ and
+add their defined arguments to the main CLI parser. Once activated, a
+extension can use the helper functions defined in :mod:`pyscaffold.actions` to
+manipulate PyScaffold's action pipeline and therefore the project structure.
+
+For more details on extensions, please consult our :ref:`Extending PyScaffold
+<extensions>` guide.
+
+
+Code base Organization
+======================
+
+PyScaffold is organized in a series of internal Python modules, the main ones
+being:
+
+- :mod:`~pyscaffold.api`: top level functions for accessing PyScaffold
+  functionality, by combining together the other modules
+- :mod:`~pyscaffold.cli`: wrapper around the API to create a command
+  line executable program
+- :mod:`~pyscaffold.actions`: default action pipeline and helper functions for
+  manipulating it
+- :mod:`~pyscaffold.structure`: functions specialized in defining the in-memory
+  project structure representation and in taking this representation and
+  creating it as part of the file system.
+- :mod:`~pyscaffold.update`: steps required for updating projects generated
+  with old versions of PyScaffold
+- :mod:`~pyscaffold.extensions`: main extension mechanism and subpackages
+  corresponding to the built-in extensions
+
+Additionally, a series of internal auxiliary libraries is defined in:
+
+- :mod:`~pyscaffold.dependencies`: processing and manipulating of package
+  dependencies and requirements
+- :mod:`~pyscaffold.exceptions`: custom PyScaffold exceptions and exception handlers
+- :mod:`~pyscaffold.file_system`: wrappers around file system functions that
+  make them easy to be used from PyScaffold.
+- :mod:`~pyscaffold.identification`: creating and processing of
+  project/package/function names and other general identifiers
+- :mod:`~pyscaffold.info`: general information about the system, user and
+  package being generated
+- :mod:`~pyscaffold.log`: custom logging infrastructure for PyScaffold,
+  specialized in its verbose execution
+- :mod:`~pyscaffold.operations`: file operations that can be
+  embedded in the in-memory project structure representation
+- :mod:`~pyscaffold.repo`: wrapper around the ``git`` command
+- :mod:`~pyscaffold.shell`: helper functions for working with external programs
+- :mod:`~pyscaffold.termui`: basic support for ANSI code formatting
+- :mod:`~pyscaffold.toml`: thin adapter layer around third-party TOML parsing
+  libraries, focused in API stability
+
+For more details about each module and its functions and classes, please
+consult our :doc:`module reference <api/modules>`.
+
+When contributing to PyScaffold, please try to maintain this overall
+project organization by respecting each module's own purpose.
+Moreover, when introducing new files or renaming existing ones, please
+try to use meaningful naming and avoid terms that are too generic, e.g.
+``utils.py`` (when in doubt, Peter Hilton has a great `article about naming
+smells`_ and a nice `presentation aboug how to name things`_).
+
+
+
+.. _Python's package ecosystem: https://packaging.python.org
+.. _pyscaffoldext-dsproject: https://pyscaffold.org/projects/dsproject
+.. _setuptools entry points: https://setuptools.readthedocs.io/en/stable/userguide/entry_point.html
+.. _article about naming smells: https://hilton.org.uk/blog/naming-smells
+.. _presentation aboug how to name things: https://hilton.org.uk/presentations/naming

--- a/docs/gfx/api-paths.svg
+++ b/docs/gfx/api-paths.svg
@@ -7,9 +7,9 @@
    xmlns="http://www.w3.org/2000/svg"
    id="svg8"
    version="1.1"
-   viewBox="0 0 199.99999 158.41367"
-   height="158.41367mm"
-   width="200mm">
+   viewBox="0 0 149.99999 112.4319"
+   height="112.4319mm"
+   width="150mm">
   <defs
      id="defs2">
     <marker
@@ -254,18 +254,18 @@
     </rdf:RDF>
   </metadata>
   <g
-     transform="translate(-28.706368,-121.7088)"
+     transform="translate(-28.706368,-167.69056)"
      id="layer1">
     <path
        id="path1020"
-       d="m 188.76319,177.55051 c -8.13331,-0.1585 -20.51322,1.86695 -20.76003,9.35231"
-       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM)" />
+       d="m 148.74898,203.1935 c -6.09998,-0.11888 -15.38491,1.40021 -15.57002,7.01423"
+       style="fill:none;stroke:#000000;stroke-width:0.57780254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM)" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4378)"
-       d="m 188.76319,217.54896 c -8.13331,0.1585 -20.51322,-1.86695 -20.76003,-9.35231"
+       style="fill:none;stroke:#000000;stroke-width:0.57780254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4378)"
+       d="m 148.74898,233.19234 c -6.09998,0.11887 -15.38491,-1.40022 -15.57002,-7.01424"
        id="path4374" />
     <g
-       transform="matrix(1.2840056,0,0,1.2840056,-6.5798686,-79.556336)"
+       transform="matrix(0.96300419,0,0,0.96300419,2.241691,10.363368)"
        id="g8257">
       <path
          id="rect827"
@@ -276,39 +276,39 @@
          style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#005ca0;fill-opacity:1;stroke:none;stroke-width:0.26458332"
          aria-label="Python API">
         <path
-           id="path1210"
+           id="path1147"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
            d="m 30.123467,182.51356 q 0.247587,0 0.404224,0.0101 0.16169,0.0101 0.429489,0.0556 0.272851,0.0404 0.515386,0.16169 0.247588,0.11621 0.459806,0.30317 0.752868,0.66697 0.752868,1.7129 0,1.04593 -0.752868,1.7129 -0.212218,0.18695 -0.459806,0.30822 -0.242535,0.11622 -0.515386,0.16169 -0.267799,0.0404 -0.429489,0.0505 -0.156637,0.0101 -0.404224,0.0101 h -0.752868 v 2.62746 h -0.64676 v -7.11435 z m 1.768482,2.97105 q 0.146532,-0.33348 0.146532,-0.7276 0,-0.39412 -0.146532,-0.72255 -0.146531,-0.33349 -0.394119,-0.54571 -0.151584,-0.13137 -0.328432,-0.21221 -0.171796,-0.0808 -0.373908,-0.11117 -0.202112,-0.0303 -0.328432,-0.0354 -0.126321,-0.0101 -0.343591,-0.0101 h -0.752868 v 3.27422 h 0.752868 q 0.21727,0 0.343591,-0.005 0.12632,-0.0101 0.328432,-0.0404 0.202112,-0.0303 0.373908,-0.11116 0.176848,-0.0808 0.328432,-0.21222 0.247588,-0.21221 0.394119,-0.54065 z" />
         <path
-           id="path1212"
+           id="path1149"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
            d="m 35.65629,188.41524 q 0.480017,-1.47542 1.076248,-3.9614 h 0.661918 q -0.02526,0.096 -0.121268,0.48002 -0.09095,0.37896 -0.116214,0.49012 -0.02526,0.10611 -0.111162,0.4497 -0.0859,0.33854 -0.12632,0.48002 -0.03537,0.13642 -0.116215,0.4497 -0.08085,0.30822 -0.136426,0.48506 -0.05053,0.17685 -0.136425,0.46992 -0.0859,0.29306 -0.16169,0.52044 -0.07074,0.22737 -0.166743,0.51033 -0.09095,0.28296 -0.186954,0.56086 -0.121267,0.34359 -0.192006,0.51539 -0.06569,0.17684 -0.192007,0.39917 -0.12632,0.22232 -0.272852,0.33854 -0.474963,0.39917 -1.465314,0.39917 v -0.60634 q 0.722552,0 0.990351,-0.20716 0.116214,-0.0859 0.212217,-0.26275 0.101057,-0.17685 0.156637,-0.32843 0.06063,-0.15159 0.222324,-0.61644 h -0.262746 q -0.545703,-0.99035 -0.914558,-2.09187 -0.363802,-1.10151 -0.666971,-2.43545 h 0.661918 q 0.525492,2.41524 1.31373,3.9614 z" />
         <path
-           id="path1214"
+           id="path1151"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
            d="m 42.295678,189.63297 q -0.54065,0.0758 -0.970139,0.0758 -0.404225,0 -0.73771,-0.14653 -0.328432,-0.14653 -0.535597,-0.39917 -0.16169,-0.19201 -0.242535,-0.4497 -0.08084,-0.2577 -0.09095,-0.42949 -0.01011,-0.1718 -0.01011,-0.47497 v -2.71841 h -1.293519 v -0.63665 h 1.293519 v -1.29352 H 40.3554 v 1.29352 h 1.940278 v 0.63665 H 40.3554 v 2.66789 q 0,0.2779 0.0051,0.41433 0.01011,0.13642 0.06063,0.31327 0.05053,0.17685 0.151584,0.30317 0.262746,0.31327 0.803396,0.31327 0.358749,0 0.919611,-0.0758 z" />
         <path
-           id="path1216"
+           id="path1153"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
            d="m 45.948857,184.373 q 0.363802,0 0.66697,0.14653 0.303168,0.14653 0.500228,0.39412 0.12632,0.15663 0.202112,0.32338 0.07579,0.16674 0.101056,0.36885 0.03032,0.20211 0.03537,0.33349 0.01011,0.13137 0.01011,0.36885 v 3.31969 h -0.64676 v -3.31969 q 0,-0.2779 -0.01011,-0.41433 -0.0051,-0.13643 -0.06063,-0.30317 -0.05053,-0.17179 -0.156637,-0.29811 -0.272852,-0.31328 -0.742763,-0.31328 -0.469911,0 -0.742762,0.31328 -0.106109,0.12632 -0.16169,0.29811 -0.05053,0.16674 -0.06063,0.30317 -0.0051,0.13643 -0.0051,0.41433 v 3.31969 h -0.646759 v -7.11435 h 0.646759 v 2.50619 h 0.05053 q 0.186953,-0.29306 0.459805,-0.46991 0.277904,-0.17684 0.560862,-0.17684 z" />
         <path
-           id="path1218"
+           id="path1155"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
            d="m 50.173003,184.59027 q 0.373908,-0.21727 0.843819,-0.21727 0.469911,0 0.838766,0.21727 0.373908,0.21221 0.61139,0.59117 0.197059,0.32338 0.262745,0.76803 0.06569,0.4396 0.06569,1.09141 0,0.65181 -0.06569,1.09646 -0.06569,0.43959 -0.262745,0.76297 -0.237482,0.37896 -0.61139,0.59623 -0.368855,0.21222 -0.838766,0.21222 -0.469911,0 -0.843819,-0.21222 -0.368855,-0.21727 -0.606337,-0.59623 -0.197059,-0.32338 -0.262746,-0.76297 -0.06569,-0.44465 -0.06569,-1.09646 0,-0.65181 0.06569,-1.09141 0.06569,-0.44465 0.262746,-0.76803 0.237482,-0.37896 0.606337,-0.59117 z m 1.733113,0.88424 q -0.293063,-0.49518 -0.889294,-0.49518 -0.596231,0 -0.889294,0.49518 -0.111162,0.18695 -0.166743,0.46991 -0.05558,0.2779 -0.06569,0.50023 -0.01011,0.22232 -0.01011,0.59623 0,0.37391 0.01011,0.59623 0.0101,0.22232 0.06569,0.50528 0.05558,0.2779 0.166743,0.46486 0.293063,0.49517 0.889294,0.49517 0.596231,0 0.889294,-0.49517 0.111162,-0.18696 0.166743,-0.46486 0.05558,-0.28296 0.06569,-0.50528 0.01011,-0.22232 0.01011,-0.59623 0,-0.37391 -0.01011,-0.59623 -0.01011,-0.22233 -0.06569,-0.50023 -0.05558,-0.28296 -0.166743,-0.46991 z" />
         <path
-           id="path1220"
+           id="path1157"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
            d="m 56.2869,184.373 q 0.363802,0 0.66697,0.14653 0.303169,0.14653 0.500228,0.39412 0.12632,0.15663 0.202112,0.32338 0.07579,0.16674 0.101057,0.36885 0.03032,0.20211 0.03537,0.33349 0.01011,0.13137 0.01011,0.36885 v 3.31969 h -0.64676 v -3.31969 q 0,-0.2779 -0.01011,-0.41433 -0.0051,-0.13643 -0.06063,-0.30317 -0.05053,-0.17179 -0.156637,-0.29811 -0.272851,-0.31328 -0.742762,-0.31328 -0.469911,0 -0.742763,0.31328 -0.106109,0.12632 -0.16169,0.29811 -0.05053,0.16674 -0.06063,0.30317 -0.0051,0.13643 -0.0051,0.41433 v 3.31969 h -0.64676 v -5.17407 h 0.64676 v 0.56591 h 0.05053 q 0.186954,-0.29306 0.459805,-0.46991 0.277905,-0.17684 0.560862,-0.17684 z" />
         <path
-           id="path1222"
+           id="path1159"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
            d="m 64.133907,189.62791 q 0.4497,-4.23425 2.061545,-7.11435 h 0.656865 q 1.611846,2.8801 2.061546,7.11435 h -0.682129 q -0.07579,-0.91455 -0.277905,-1.96048 h -2.859888 q -0.02526,0.15663 -0.07579,0.46485 -0.05053,0.30317 -0.08084,0.50023 -0.03032,0.19706 -0.06569,0.47497 -0.03537,0.2779 -0.05558,0.52043 z m 3.713813,-2.56682 q -0.293063,-1.23794 -0.591178,-2.17271 -0.298116,-0.93477 -0.707393,-1.72301 h -0.05053 q -0.409277,0.78824 -0.707393,1.72301 -0.298116,0.93477 -0.591178,2.17271 z" />
         <path
-           id="path1224"
+           id="path1161"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
            d="m 71.475636,182.51356 q 0.247587,0 0.404224,0.0101 0.16169,0.0101 0.429489,0.0556 0.272851,0.0404 0.515386,0.16169 0.247588,0.11621 0.459806,0.30317 0.752868,0.66697 0.752868,1.7129 0,1.04593 -0.752868,1.7129 -0.212218,0.18695 -0.459806,0.30822 -0.242535,0.11622 -0.515386,0.16169 -0.267799,0.0404 -0.429489,0.0505 -0.156637,0.0101 -0.404224,0.0101 h -0.752868 v 2.62746 h -0.64676 v -7.11435 z m 1.768482,2.97105 q 0.146532,-0.33348 0.146532,-0.7276 0,-0.39412 -0.146532,-0.72255 -0.146531,-0.33349 -0.394119,-0.54571 -0.151584,-0.13137 -0.328432,-0.21221 -0.171796,-0.0808 -0.373908,-0.11117 -0.202112,-0.0303 -0.328432,-0.0354 -0.126321,-0.0101 -0.343591,-0.0101 h -0.752868 v 3.27422 h 0.752868 q 0.21727,0 0.343591,-0.005 0.12632,-0.0101 0.328432,-0.0404 0.202112,-0.0303 0.373908,-0.11116 0.176848,-0.0808 0.328432,-0.21222 0.247588,-0.21221 0.394119,-0.54065 z" />
         <path
-           id="path1226"
+           id="path1163"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#005ca0;fill-opacity:1;stroke-width:0.26458332"
            d="m 78.478826,182.51356 v 0.60634 h -1.293518 v 5.90168 h 1.293518 v 0.60633 H 75.24503 v -0.60633 h 1.293518 V 183.1199 H 75.24503 v -0.60634 z" />
       </g>
@@ -317,65 +317,65 @@
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
          aria-label="create_project">
         <path
-           id="path1229"
+           id="path1166"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
            d="m 31.656051,198.83132 q 0.387512,0 0.721837,-0.23555 l 0.16463,0.21275 q -0.169695,0.14184 -0.412841,0.22795 -0.243145,0.0836 -0.460963,0.0836 -0.382447,0 -0.653453,-0.16716 -0.271005,-0.16716 -0.41284,-0.47616 -0.141835,-0.309 -0.141835,-0.7269 0,-0.40018 0.141835,-0.71424 0.141835,-0.31406 0.415373,-0.49389 0.273539,-0.17983 0.653453,-0.17983 0.488824,0 0.863673,0.3014 l -0.167163,0.22542 q -0.362185,-0.24821 -0.711706,-0.24821 -0.248211,0 -0.440701,0.12663 -0.189958,0.12664 -0.298866,0.37739 -0.106376,0.24821 -0.106376,0.60533 0,0.36218 0.106376,0.60533 0.106376,0.24061 0.296333,0.35965 0.19249,0.11651 0.443234,0.11651 z" />
         <path
-           id="path1231"
+           id="path1168"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
            d="m 35.279693,196.35681 q 0.09371,0 0.169695,0.0127 0.07852,0.0127 0.189958,0.0405 l -0.03546,0.83581 h -0.303932 v -0.51922 l 0.0051,-0.0658 q -0.02026,-0.003 -0.06332,-0.003 -0.324194,0 -0.54961,0.22288 -0.222883,0.22035 -0.364718,0.68891 v 1.23599 h 0.547077 v 0.26341 h -1.294242 v -0.26341 h 0.433102 v -2.13005 H 33.580209 V 196.41 h 0.673715 l 0.05825,0.63825 q 0.167162,-0.34699 0.390045,-0.51921 0.222883,-0.17223 0.57747,-0.17223 z" />
         <path
-           id="path1233"
+           id="path1170"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
            d="m 36.821404,197.86633 q 0.0051,0.32167 0.116507,0.53948 0.111442,0.21529 0.293801,0.32166 0.184892,0.10385 0.410308,0.10385 0.202621,0 0.364718,-0.0583 0.164629,-0.0582 0.352054,-0.18742 l 0.164629,0.23555 q -0.182359,0.14183 -0.415373,0.22035 -0.230481,0.0785 -0.453365,0.0785 -0.362185,0 -0.628125,-0.16969 -0.263407,-0.17223 -0.402709,-0.48376 -0.139302,-0.31153 -0.139302,-0.72437 0,-0.40271 0.139302,-0.71424 0.141834,-0.31406 0.397643,-0.48882 0.25581,-0.1773 0.585069,-0.1773 0.319128,0 0.552142,0.15703 0.233015,0.1545 0.354587,0.44577 0.124106,0.28874 0.124106,0.68385 0,0.0583 -0.0076,0.21781 z m 0.792755,-1.21066 q -0.22035,0 -0.392578,0.10385 -0.169695,0.10131 -0.273539,0.30899 -0.103843,0.20769 -0.121572,0.51415 h 1.51206 q -0.01013,-0.45589 -0.205154,-0.69144 -0.195023,-0.23555 -0.519217,-0.23555 z" />
         <path
-           id="path1235"
+           id="path1172"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
            d="m 41.43789,198.54511 q 0,0.15704 0.05319,0.23555 0.05319,0.076 0.174761,0.11144 l -0.08611,0.23049 q -0.162097,-0.0253 -0.278604,-0.11651 -0.113974,-0.0937 -0.159564,-0.26594 -0.139302,0.18489 -0.349522,0.28367 -0.207686,0.0962 -0.471094,0.0962 -0.260874,0 -0.453364,-0.0988 -0.189958,-0.10131 -0.291268,-0.2862 -0.101311,-0.18489 -0.101311,-0.4331 0,-0.40524 0.316596,-0.62053 0.316595,-0.21528 0.91686,-0.21528 h 0.40271 v -0.25834 q 0,-0.29887 -0.172228,-0.43057 -0.169695,-0.13171 -0.493889,-0.13171 -0.306465,0 -0.681314,0.13424 l -0.09118,-0.25834 q 0.230481,-0.0861 0.428037,-0.12158 0.197555,-0.038 0.390046,-0.038 0.306464,0 0.519216,0.10385 0.212752,0.10384 0.319128,0.29126 0.108909,0.18743 0.108909,0.4407 z m -1.056162,0.3242 q 0.215285,0 0.405242,-0.10638 0.189957,-0.10637 0.324194,-0.29633 v -0.75983 h -0.440701 q -0.450832,0 -0.650921,0.15703 -0.197555,0.15703 -0.197555,0.4483 0,0.2786 0.136769,0.41791 0.139302,0.1393 0.422972,0.1393 z" />
         <path
-           id="path1237"
+           id="path1174"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
            d="m 44.699348,198.94276 q -0.126639,0.0836 -0.314063,0.12917 -0.184892,0.0481 -0.352054,0.0481 -0.260875,0 -0.455898,-0.0962 -0.19249,-0.0962 -0.296333,-0.26594 -0.101311,-0.1697 -0.101311,-0.38498 V 196.6734 H 42.551564 V 196.41 h 0.628125 v -0.61293 l 0.314063,-0.038 V 196.41 h 0.937123 l -0.04306,0.2634 h -0.894066 v 1.69189 q 0,0.23808 0.129171,0.35965 0.129171,0.12157 0.417906,0.12157 0.276071,0 0.521749,-0.12917 z" />
         <path
-           id="path1239"
+           id="path1176"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
            d="m 45.937127,197.86633 q 0.0051,0.32167 0.116507,0.53948 0.111442,0.21529 0.293801,0.32166 0.184891,0.10385 0.410307,0.10385 0.202621,0 0.364718,-0.0583 0.16463,-0.0582 0.352054,-0.18742 l 0.16463,0.23555 q -0.182359,0.14183 -0.415373,0.22035 -0.230482,0.0785 -0.453365,0.0785 -0.362185,0 -0.628125,-0.16969 -0.263408,-0.17223 -0.40271,-0.48376 -0.139302,-0.31153 -0.139302,-0.72437 0,-0.40271 0.139302,-0.71424 0.141835,-0.31406 0.397644,-0.48882 0.255809,-0.1773 0.585069,-0.1773 0.319128,0 0.552142,0.15703 0.233014,0.1545 0.354587,0.44577 0.124105,0.28874 0.124105,0.68385 0,0.0583 -0.0076,0.21781 z m 0.792755,-1.21066 q -0.220351,0 -0.392579,0.10385 -0.169695,0.10131 -0.273538,0.30899 -0.103843,0.20769 -0.121573,0.51415 h 1.51206 q -0.01013,-0.45589 -0.205154,-0.69144 -0.195022,-0.23555 -0.519216,-0.23555 z" />
         <path
-           id="path1241"
+           id="path1178"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
            d="m 50.979117,199.98119 h -2.532764 v -0.29633 h 2.532764 z" />
         <path
-           id="path1243"
+           id="path1180"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
            d="m 52.890611,196.36187 q 0.511619,0 0.734502,0.35966 0.225416,0.35965 0.225416,1.01817 0,0.4103 -0.111442,0.72183 -0.111441,0.309 -0.341923,0.48376 -0.230481,0.17476 -0.572404,0.17476 -0.453365,0 -0.724371,-0.31659 v 1.28158 l -0.314062,0.043 V 196.41 h 0.258341 l 0.03546,0.39257 q 0.1469,-0.20768 0.352054,-0.32419 0.207687,-0.11651 0.45843,-0.11651 z m -0.05572,0.26848 q -0.225416,0 -0.412841,0.13423 -0.187424,0.13171 -0.321661,0.32926 v 1.37782 q 0.111442,0.16717 0.288735,0.26594 0.179826,0.0963 0.38498,0.0963 0.369784,0 0.54961,-0.27101 0.182359,-0.27353 0.182359,-0.82821 0,-1.10428 -0.671182,-1.10428 z" />
         <path
-           id="path1245"
+           id="path1182"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
            d="m 56.549713,196.35681 q 0.09371,0 0.169695,0.0127 0.07852,0.0127 0.189957,0.0405 l -0.03546,0.83581 h -0.303932 v -0.51922 l 0.0051,-0.0658 q -0.02026,-0.003 -0.06332,-0.003 -0.324193,0 -0.549609,0.22288 -0.222884,0.22035 -0.364718,0.68891 v 1.23599 h 0.547077 v 0.26341 h -1.294243 v -0.26341 h 0.433103 v -2.13005 H 54.850228 V 196.41 h 0.673716 l 0.05825,0.63825 q 0.167162,-0.34699 0.390046,-0.51921 0.222883,-0.17223 0.57747,-0.17223 z" />
         <path
-           id="path1247"
+           id="path1184"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
            d="m 58.836056,196.36187 q 0.35712,0 0.602798,0.16717 0.245678,0.16716 0.367251,0.47615 0.121572,0.309 0.121572,0.73451 0,0.40017 -0.126638,0.71424 -0.124105,0.31153 -0.372316,0.48882 -0.248211,0.17729 -0.600265,0.17729 -0.35712,0 -0.605331,-0.16969 -0.245678,-0.17223 -0.369783,-0.48123 -0.124105,-0.309 -0.124105,-0.72437 0,-0.41284 0.124105,-0.72437 0.126638,-0.31153 0.374849,-0.48376 0.250744,-0.17476 0.607863,-0.17476 z m 0,0.27607 q -0.762362,0 -0.762362,1.10682 0,1.09669 0.754764,1.09669 0.754763,0 0.754763,-1.10175 0,-1.10176 -0.747165,-1.10176 z" />
         <path
-           id="path1249"
+           id="path1186"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
            d="m 62.198824,195.20693 q 0.11904,0 0.19249,0.0735 0.07345,0.0709 0.07345,0.1773 0,0.11397 -0.07345,0.18742 -0.07345,0.0734 -0.19249,0.0734 -0.113974,0 -0.184892,-0.0734 -0.06838,-0.0735 -0.06838,-0.18742 0,-0.10638 0.07092,-0.1773 0.07092,-0.0735 0.182359,-0.0735 z m 0.362185,3.53827 q 0,0.5876 -0.420438,0.92193 -0.420439,0.33686 -1.215727,0.46096 l -0.05319,-0.24568 q 1.375291,-0.20008 1.375291,-1.11441 v -2.08447 H 61.094539 V 196.41 h 1.46647 z" />
         <path
-           id="path1251"
+           id="path1188"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
            d="m 64.168572,197.86633 q 0.0051,0.32167 0.116507,0.53948 0.111442,0.21529 0.293801,0.32166 0.184892,0.10385 0.410308,0.10385 0.202621,0 0.364718,-0.0583 0.164629,-0.0582 0.352054,-0.18742 l 0.164629,0.23555 q -0.182359,0.14183 -0.415373,0.22035 -0.230481,0.0785 -0.453365,0.0785 -0.362185,0 -0.628125,-0.16969 -0.263407,-0.17223 -0.402709,-0.48376 -0.139302,-0.31153 -0.139302,-0.72437 0,-0.40271 0.139302,-0.71424 0.141834,-0.31406 0.397643,-0.48882 0.25581,-0.1773 0.585069,-0.1773 0.319128,0 0.552142,0.15703 0.233015,0.1545 0.354587,0.44577 0.124106,0.28874 0.124106,0.68385 0,0.0583 -0.0076,0.21781 z m 0.792755,-1.21066 q -0.22035,0 -0.392578,0.10385 -0.169695,0.10131 -0.273539,0.30899 -0.103843,0.20769 -0.121572,0.51415 h 1.51206 q -0.01013,-0.45589 -0.205154,-0.69144 -0.195023,-0.23555 -0.519217,-0.23555 z" />
         <path
-           id="path1253"
+           id="path1190"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
            d="m 68.118941,198.83132 q 0.387513,0 0.721838,-0.23555 l 0.16463,0.21275 q -0.169696,0.14184 -0.412841,0.22795 -0.243145,0.0836 -0.460963,0.0836 -0.382447,0 -0.653453,-0.16716 -0.271006,-0.16716 -0.41284,-0.47616 -0.141835,-0.309 -0.141835,-0.7269 0,-0.40018 0.141835,-0.71424 0.141834,-0.31406 0.415373,-0.49389 0.273538,-0.17983 0.653453,-0.17983 0.488823,0 0.863672,0.3014 l -0.167162,0.22542 q -0.362185,-0.24821 -0.711707,-0.24821 -0.248211,0 -0.440701,0.12663 -0.189957,0.12664 -0.298866,0.37739 -0.106376,0.24821 -0.106376,0.60533 0,0.36218 0.106376,0.60533 0.106376,0.24061 0.296334,0.35965 0.19249,0.11651 0.443233,0.11651 z" />
         <path
-           id="path1255"
+           id="path1192"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
            d="m 72.046515,198.94276 q -0.126638,0.0836 -0.314062,0.12917 -0.184892,0.0481 -0.352054,0.0481 -0.260875,0 -0.455898,-0.0962 -0.19249,-0.0962 -0.296333,-0.26594 -0.101311,-0.1697 -0.101311,-0.38498 V 196.6734 H 69.898732 V 196.41 h 0.628125 v -0.61293 l 0.314063,-0.038 V 196.41 h 0.937123 l -0.04306,0.2634 H 70.84092 v 1.69189 q 0,0.23808 0.129171,0.35965 0.129171,0.12157 0.417906,0.12157 0.276071,0 0.521749,-0.12917 z" />
       </g>
     </g>
     <g
-       transform="matrix(1.2840056,0,0,1.2840056,-234.7989,-23.653332)"
+       transform="matrix(0.96300419,0,0,0.96300419,-168.92258,52.29062)"
        id="g864">
       <path
          id="rect821"
@@ -386,77 +386,77 @@
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
          aria-label="bootstrap_options">
         <path
-           id="path1259"
+           id="path1196"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 260.52767,171.38551 q 0.1545,-0.20262 0.35206,-0.309 0.19755,-0.10638 0.43057,-0.10638 0.51921,0 0.75983,0.36472 0.24061,0.36219 0.24061,1.01311 0,0.40524 -0.12157,0.71677 -0.12158,0.31153 -0.35712,0.48882 -0.23555,0.17476 -0.56988,0.17476 -0.24314,0 -0.4255,-0.0811 -0.18236,-0.081 -0.31913,-0.2558 l -0.0304,0.2862 h -0.27354 v -3.73583 l 0.31406,-0.0431 z m 0.66612,2.06926 q 0.37232,0 0.56734,-0.2786 0.19502,-0.28114 0.19502,-0.83328 0,-0.53441 -0.17476,-0.81808 -0.17476,-0.2862 -0.51668,-0.2862 -0.22795,0 -0.41538,0.13423 -0.18742,0.13171 -0.32166,0.32926 v 1.37783 q 0.11651,0.17222 0.29127,0.27353 0.17729,0.10131 0.37485,0.10131 z" />
         <path
-           id="path1261"
+           id="path1198"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 264.22477,170.97013 q 0.35712,0 0.60279,0.16717 0.24568,0.16716 0.36725,0.47616 0.12158,0.30899 0.12158,0.7345 0,0.40017 -0.12664,0.71424 -0.12411,0.31153 -0.37232,0.48882 -0.24821,0.17729 -0.60026,0.17729 -0.35712,0 -0.60533,-0.16969 -0.24568,-0.17223 -0.36979,-0.48123 -0.1241,-0.30899 -0.1241,-0.72437 0,-0.41284 0.1241,-0.72437 0.12664,-0.31153 0.37485,-0.48376 0.25075,-0.17476 0.60787,-0.17476 z m 0,0.27608 q -0.76237,0 -0.76237,1.10681 0,1.09669 0.75477,1.09669 0.75476,0 0.75476,-1.10175 0,-1.10175 -0.74716,-1.10175 z" />
         <path
-           id="path1263"
+           id="path1200"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 267.26334,170.97013 q 0.35712,0 0.6028,0.16717 0.24568,0.16716 0.36725,0.47616 0.12157,0.30899 0.12157,0.7345 0,0.40017 -0.12664,0.71424 -0.1241,0.31153 -0.37231,0.48882 -0.24821,0.17729 -0.60027,0.17729 -0.35712,0 -0.60533,-0.16969 -0.24568,-0.17223 -0.36978,-0.48123 -0.12411,-0.30899 -0.12411,-0.72437 0,-0.41284 0.12411,-0.72437 0.12664,-0.31153 0.37485,-0.48376 0.25074,-0.17476 0.60786,-0.17476 z m 0,0.27608 q -0.76236,0 -0.76236,1.10681 0,1.09669 0.75476,1.09669 0.75476,0 0.75476,-1.10175 0,-1.10175 -0.74716,-1.10175 z" />
         <path
-           id="path1265"
+           id="path1202"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 271.35808,173.55102 q -0.12664,0.0836 -0.31407,0.12917 -0.18489,0.0481 -0.35205,0.0481 -0.26088,0 -0.4559,-0.0962 -0.19249,-0.0962 -0.29633,-0.26594 -0.10131,-0.1697 -0.10131,-0.38498 v -1.69949 h -0.62813 v -0.2634 h 0.62813 v -0.61293 l 0.31406,-0.038 v 0.65092 h 0.93712 l -0.043,0.2634 h -0.89407 v 1.69189 q 0,0.23808 0.12917,0.35965 0.12917,0.12157 0.41791,0.12157 0.27607,0 0.52175,-0.12917 z" />
         <path
-           id="path1267"
+           id="path1204"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 273.22398,173.44211 q 0.22288,0 0.38751,-0.0583 0.16463,-0.0608 0.25075,-0.16716 0.0886,-0.10638 0.0886,-0.24822 0,-0.14436 -0.0456,-0.23554 -0.0456,-0.0937 -0.18489,-0.1697 -0.13677,-0.076 -0.41537,-0.14437 -0.32166,-0.0785 -0.51922,-0.16209 -0.19502,-0.0861 -0.30393,-0.22795 -0.10891,-0.14184 -0.10891,-0.36219 0,-0.21528 0.12411,-0.37231 0.1241,-0.15703 0.34192,-0.24062 0.22035,-0.0836 0.49896,-0.0836 0.29126,0 0.52428,0.0785 0.23301,0.0785 0.40777,0.20769 l -0.1469,0.23301 q -0.16716,-0.11651 -0.34699,-0.17729 -0.17982,-0.0633 -0.43563,-0.0633 -0.33433,0 -0.48629,0.10637 -0.14944,0.10385 -0.14944,0.28621 0,0.1317 0.0684,0.21781 0.0684,0.0836 0.22035,0.1469 0.15197,0.0633 0.4407,0.13931 0.2862,0.076 0.47363,0.17222 0.18742,0.0963 0.29127,0.25328 0.10384,0.1545 0.10384,0.39005 0,0.26594 -0.15197,0.43816 -0.15196,0.17223 -0.39764,0.25075 -0.24315,0.0785 -0.53188,0.0785 -0.5952,0 -0.99538,-0.34699 l 0.19502,-0.23048 q 0.15957,0.13677 0.36472,0.21529 0.20769,0.076 0.43817,0.076 z" />
         <path
-           id="path1269"
+           id="path1206"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 277.43522,173.55102 q -0.12663,0.0836 -0.31406,0.12917 -0.18489,0.0481 -0.35205,0.0481 -0.26088,0 -0.4559,-0.0962 -0.19249,-0.0962 -0.29633,-0.26594 -0.10131,-0.1697 -0.10131,-0.38498 v -1.69949 h -0.62813 v -0.2634 h 0.62813 v -0.61293 l 0.31406,-0.038 v 0.65092 h 0.93712 l -0.0431,0.2634 h -0.89406 v 1.69189 q 0,0.23808 0.12917,0.35965 0.12917,0.12157 0.41791,0.12157 0.27607,0 0.52175,-0.12917 z" />
         <path
-           id="path1271"
+           id="path1208"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 280.16987,170.96507 q 0.0937,0 0.16969,0.0127 0.0785,0.0127 0.18996,0.0405 l -0.0355,0.83581 h -0.30393 v -0.51922 l 0.005,-0.0658 q -0.0203,-0.003 -0.0633,-0.003 -0.3242,0 -0.54961,0.22288 -0.22289,0.22035 -0.36472,0.68891 v 1.23599 h 0.54708 v 0.26341 h -1.29425 v -0.26341 h 0.43311 v -2.13005 h -0.43311 v -0.26594 h 0.67372 l 0.0583,0.63825 q 0.16716,-0.34699 0.39005,-0.51921 0.22288,-0.17223 0.57747,-0.17223 z" />
         <path
-           id="path1273"
+           id="path1210"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 283.28949,173.15338 q 0,0.15703 0.0532,0.23554 0.0532,0.076 0.17476,0.11144 l -0.0861,0.23049 q -0.16209,-0.0253 -0.2786,-0.11651 -0.11397,-0.0937 -0.15956,-0.26594 -0.13931,0.18489 -0.34952,0.28367 -0.20769,0.0962 -0.4711,0.0962 -0.26087,0 -0.45336,-0.0988 -0.18996,-0.10131 -0.29127,-0.28621 -0.10131,-0.18489 -0.10131,-0.4331 0,-0.40524 0.31659,-0.62053 0.3166,-0.21528 0.91686,-0.21528 h 0.40271 v -0.25834 q 0,-0.29887 -0.17222,-0.43057 -0.1697,-0.13171 -0.49389,-0.13171 -0.30647,0 -0.68132,0.13424 l -0.0912,-0.25834 q 0.23049,-0.0861 0.42804,-0.12157 0.19756,-0.038 0.39005,-0.038 0.30646,0 0.51921,0.10385 0.21276,0.10384 0.31913,0.29126 0.10891,0.18743 0.10891,0.44071 z m -1.05616,0.32419 q 0.21528,0 0.40524,-0.10638 0.18996,-0.10637 0.32419,-0.29633 v -0.75983 h -0.4407 q -0.45083,0 -0.65092,0.15703 -0.19755,0.15703 -0.19755,0.4483 0,0.27861 0.13677,0.41791 0.1393,0.1393 0.42297,0.1393 z" />
         <path
-           id="path1275"
+           id="path1212"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 285.62649,170.97013 q 0.51162,0 0.7345,0.35966 0.22542,0.35965 0.22542,1.01817 0,0.4103 -0.11145,0.72183 -0.11144,0.309 -0.34192,0.48376 -0.23048,0.17476 -0.5724,0.17476 -0.45337,0 -0.72437,-0.31659 v 1.28158 l -0.31407,0.043 v -3.71809 h 0.25835 l 0.0354,0.39257 q 0.1469,-0.20768 0.35206,-0.32419 0.20769,-0.11651 0.45843,-0.11651 z m -0.0557,0.26848 q -0.22542,0 -0.41284,0.13423 -0.18743,0.13171 -0.32166,0.32926 v 1.37783 q 0.11144,0.16716 0.28873,0.26594 0.17983,0.0962 0.38498,0.0962 0.36979,0 0.54961,-0.271 0.18236,-0.27354 0.18236,-0.82822 0,-1.10428 -0.67118,-1.10428 z" />
         <path
-           id="path1277"
+           id="path1214"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 289.79214,174.58945 h -2.53276 v -0.29633 h 2.53276 z" />
         <path
-           id="path1279"
+           id="path1216"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 291.57193,170.97013 q 0.35712,0 0.6028,0.16717 0.24568,0.16716 0.36725,0.47616 0.12157,0.30899 0.12157,0.7345 0,0.40017 -0.12663,0.71424 -0.12411,0.31153 -0.37232,0.48882 -0.24821,0.17729 -0.60026,0.17729 -0.35712,0 -0.60534,-0.16969 -0.24567,-0.17223 -0.36978,-0.48123 -0.1241,-0.30899 -0.1241,-0.72437 0,-0.41284 0.1241,-0.72437 0.12664,-0.31153 0.37485,-0.48376 0.25074,-0.17476 0.60786,-0.17476 z m 0,0.27608 q -0.76236,0 -0.76236,1.10681 0,1.09669 0.75477,1.09669 0.75476,0 0.75476,-1.10175 0,-1.10175 -0.74717,-1.10175 z" />
         <path
-           id="path1281"
+           id="path1218"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 294.74221,170.97013 q 0.51162,0 0.7345,0.35966 0.22542,0.35965 0.22542,1.01817 0,0.4103 -0.11144,0.72183 -0.11144,0.309 -0.34193,0.48376 -0.23048,0.17476 -0.5724,0.17476 -0.45337,0 -0.72437,-0.31659 v 1.28158 l -0.31406,0.043 v -3.71809 h 0.25834 l 0.0355,0.39257 q 0.1469,-0.20768 0.35205,-0.32419 0.20769,-0.11651 0.45843,-0.11651 z m -0.0557,0.26848 q -0.22542,0 -0.41284,0.13423 -0.18742,0.13171 -0.32166,0.32926 v 1.37783 q 0.11144,0.16716 0.28873,0.26594 0.17983,0.0962 0.38498,0.0962 0.36979,0 0.54961,-0.271 0.18236,-0.27354 0.18236,-0.82822 0,-1.10428 -0.67118,-1.10428 z" />
         <path
-           id="path1283"
+           id="path1220"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 298.70524,173.55102 q -0.12663,0.0836 -0.31406,0.12917 -0.18489,0.0481 -0.35205,0.0481 -0.26088,0 -0.4559,-0.0962 -0.19249,-0.0962 -0.29633,-0.26594 -0.10131,-0.1697 -0.10131,-0.38498 v -1.69949 h -0.62813 v -0.2634 h 0.62813 v -0.61293 l 0.31406,-0.038 v 0.65092 h 0.93712 l -0.0431,0.2634 h -0.89406 v 1.69189 q 0,0.23808 0.12917,0.35965 0.12917,0.12157 0.41791,0.12157 0.27607,0 0.52175,-0.12917 z" />
         <path
-           id="path1285"
+           id="path1222"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 300.68259,169.81519 q 0.11904,0 0.18996,0.0735 0.0735,0.0709 0.0735,0.1773 0,0.11397 -0.0735,0.18742 -0.0709,0.0735 -0.18996,0.0735 -0.11397,0 -0.18489,-0.0735 -0.0709,-0.0734 -0.0709,-0.18742 0,-0.10638 0.0709,-0.1773 0.0734,-0.0735 0.18489,-0.0735 z m -0.83328,1.20307 h 1.12961 v 2.38586 h 0.7725 v 0.27354 h -1.92744 v -0.27354 h 0.84088 v -2.11233 h -0.81555 z" />
         <path
-           id="path1287"
+           id="path1224"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 303.72623,170.97013 q 0.35712,0 0.6028,0.16717 0.24568,0.16716 0.36725,0.47616 0.12157,0.30899 0.12157,0.7345 0,0.40017 -0.12664,0.71424 -0.1241,0.31153 -0.37231,0.48882 -0.24821,0.17729 -0.60027,0.17729 -0.35712,0 -0.60533,-0.16969 -0.24568,-0.17223 -0.36978,-0.48123 -0.12411,-0.30899 -0.12411,-0.72437 0,-0.41284 0.12411,-0.72437 0.12664,-0.31153 0.37485,-0.48376 0.25074,-0.17476 0.60786,-0.17476 z m 0,0.27608 q -0.76236,0 -0.76236,1.10681 0,1.09669 0.75476,1.09669 0.75477,0 0.75477,-1.10175 0,-1.10175 -0.74717,-1.10175 z" />
         <path
-           id="path1289"
+           id="path1226"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 305.79222,173.67766 v -2.6594 h 0.26341 l 0.0253,0.38751 q 0.10131,-0.13424 0.25327,-0.23302 0.15197,-0.0988 0.31913,-0.14943 0.1697,-0.0532 0.32166,-0.0532 0.39512,0 0.57494,0.20009 0.17983,0.20009 0.17983,0.58254 v 1.9249 h -0.31407 v -1.58804 q 0,-0.33433 -0.0355,-0.50909 -0.0329,-0.17729 -0.14437,-0.26341 -0.10891,-0.0861 -0.33686,-0.0861 -0.16716,0 -0.32419,0.0735 -0.1545,0.0735 -0.27354,0.18489 -0.11904,0.11144 -0.19502,0.22795 v 1.96036 z" />
         <path
-           id="path1291"
+           id="path1228"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:center;writing-mode:lr-tb;text-anchor:middle;stroke-width:0.26458332"
            d="m 309.68687,173.44211 q 0.22288,0 0.38751,-0.0583 0.16463,-0.0608 0.25075,-0.16716 0.0886,-0.10638 0.0886,-0.24822 0,-0.14436 -0.0456,-0.23554 -0.0456,-0.0937 -0.1849,-0.1697 -0.13677,-0.076 -0.41537,-0.14437 -0.32166,-0.0785 -0.51922,-0.16209 -0.19502,-0.0861 -0.30393,-0.22795 -0.10891,-0.14184 -0.10891,-0.36219 0,-0.21528 0.12411,-0.37231 0.1241,-0.15703 0.34192,-0.24062 0.22035,-0.0836 0.49896,-0.0836 0.29126,0 0.52428,0.0785 0.23301,0.0785 0.40777,0.20769 l -0.1469,0.23301 q -0.16716,-0.11651 -0.34699,-0.17729 -0.17982,-0.0633 -0.43563,-0.0633 -0.33433,0 -0.48629,0.10637 -0.14943,0.10385 -0.14943,0.28621 0,0.1317 0.0684,0.21781 0.0684,0.0836 0.22035,0.1469 0.15197,0.0633 0.4407,0.13931 0.2862,0.076 0.47363,0.17222 0.18742,0.0963 0.29127,0.25328 0.10384,0.1545 0.10384,0.39005 0,0.26594 -0.15197,0.43816 -0.15196,0.17223 -0.39764,0.25075 -0.24315,0.0785 -0.53188,0.0785 -0.5952,0 -0.99538,-0.34699 l 0.19503,-0.23048 q 0.15956,0.13677 0.36471,0.21529 0.20769,0.076 0.43817,0.076 z" />
       </g>
     </g>
     <g
-       transform="matrix(1.2840056,0,0,1.2840056,178.45418,-55.047496)"
+       transform="matrix(0.96300419,0,0,0.96300419,141.01723,28.744998)"
        id="g1005">
       <g
          id="g993">
@@ -485,39 +485,39 @@
              style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
              aria-label="setup.cfg">
             <path
-               id="path1295"
+               id="path1232"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -40.427882,190.66323 q 0.262684,0 0.41465,-0.0977 0.154136,-0.0977 0.154136,-0.26485 0,-0.11289 -0.04125,-0.18453 -0.03908,-0.0738 -0.158478,-0.1346 -0.117231,-0.0608 -0.353863,-0.1194 -0.262684,-0.0651 -0.429847,-0.14111 -0.164991,-0.0782 -0.258341,-0.2019 -0.09118,-0.12374 -0.09118,-0.31479 0,-0.18887 0.108547,-0.32998 0.108547,-0.14111 0.303932,-0.21709 0.197555,-0.076 0.455897,-0.076 0.258342,0 0.464581,0.0695 0.208411,0.0673 0.364718,0.18236 l -0.160649,0.24749 q -0.143282,-0.0977 -0.301761,-0.14979 -0.156308,-0.0543 -0.362547,-0.0543 -0.258342,0 -0.377744,0.0803 -0.11723,0.0781 -0.11723,0.21926 0,0.10204 0.05427,0.16716 0.05644,0.0651 0.180188,0.11723 0.125915,0.0499 0.373402,0.11724 0.247487,0.0673 0.405966,0.14979 0.158478,0.0825 0.247487,0.21709 0.08901,0.13243 0.08901,0.33867 0,0.23229 -0.134598,0.38643 -0.134598,0.15196 -0.353863,0.2236 -0.217094,0.0717 -0.475436,0.0717 -0.538393,0 -0.894427,-0.30828 l 0.20841,-0.24097 q 0.13894,0.11723 0.314786,0.18236 0.175846,0.0651 0.371231,0.0651 z" />
             <path
-               id="path1297"
+               id="path1234"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -38.314023,189.90123 q 0.0087,0.25617 0.09986,0.42767 0.09118,0.16933 0.238803,0.25183 0.147624,0.0803 0.329983,0.0803 0.169333,0 0.310444,-0.0499 0.143282,-0.0499 0.29959,-0.1563 l 0.171504,0.24097 q -0.160649,0.12591 -0.369059,0.19755 -0.20624,0.0717 -0.416821,0.0717 -0.327812,0 -0.564444,-0.14763 -0.236633,-0.14762 -0.360376,-0.41682 -0.121573,-0.2692 -0.121573,-0.62523 0,-0.34518 0.123744,-0.61655 0.123743,-0.27136 0.349521,-0.42333 0.225778,-0.15414 0.525367,-0.15414 0.286565,0 0.494975,0.1346 0.210581,0.1346 0.321299,0.3886 0.112889,0.25183 0.112889,0.59701 0,0.0999 -0.0087,0.19973 z m 0.620889,-1.02035 q -0.264854,0 -0.432017,0.1867 -0.164991,0.18453 -0.186701,0.55142 h 1.191846 q -0.0065,-0.36037 -0.158478,-0.54924 -0.151966,-0.18888 -0.41465,-0.18888 z" />
             <path
-               id="path1299"
+               id="path1236"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -34.181189,190.79999 q -0.11506,0.076 -0.284393,0.11941 -0.167162,0.0456 -0.327812,0.0456 -0.240974,0 -0.414649,-0.0868 -0.171505,-0.089 -0.262684,-0.24532 -0.09118,-0.15631 -0.09118,-0.3582 v -1.36335 h -0.525367 v -0.28223 h 0.525367 v -0.51885 l 0.364718,-0.0434 v 0.56227 h 0.790222 l -0.04342,0.28223 h -0.746804 v 1.35901 q 0,0.19538 0.102034,0.29307 0.104206,0.0977 0.334325,0.0977 0.232291,0 0.43853,-0.10854 z" />
             <path
-               id="path1301"
+               id="path1238"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -33.026885,190.24858 q 0,0.2236 0.09118,0.32564 0.09335,0.0999 0.293077,0.0999 0.180188,0 0.349522,-0.10421 0.171504,-0.1042 0.269196,-0.25834 v -1.68248 h 0.364718 v 2.286 h -0.310444 l -0.03039,-0.30827 q -0.132428,0.16933 -0.329983,0.26486 -0.195385,0.0933 -0.401624,0.0933 -0.327812,0 -0.494975,-0.17368 -0.164991,-0.17585 -0.164991,-0.49932 v -1.66294 h 0.364718 z" />
             <path
-               id="path1303"
+               id="path1240"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -29.764598,188.58129 q 0.43853,0 0.631744,0.31045 0.195384,0.31044 0.195384,0.87923 0,0.35386 -0.09769,0.62306 -0.09769,0.26702 -0.297419,0.41899 -0.197555,0.15197 -0.486291,0.15197 -0.377743,0 -0.603521,-0.26486 v 1.08981 l -0.364718,0.0456 v -3.20648 h 0.310445 l 0.03039,0.31913 q 0.125914,-0.17801 0.29959,-0.27136 0.175846,-0.0955 0.382085,-0.0955 z m -0.08684,0.29308 q -0.175846,0 -0.321299,0.10421 -0.143282,0.1042 -0.249658,0.26268 v 1.13323 q 0.09118,0.1346 0.225778,0.21058 0.136769,0.076 0.297419,0.076 0.286564,0 0.427675,-0.21926 0.143282,-0.21927 0.143282,-0.67299 0,-0.45156 -0.128086,-0.67299 -0.128085,-0.22144 -0.395111,-0.22144 z" />
             <path
-               id="path1305"
+               id="path1242"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -27.70067,190.58073 q 0,-0.10421 0.04993,-0.19104 0.04993,-0.0868 0.136769,-0.13677 0.08684,-0.0521 0.193214,-0.0521 0.108547,0 0.195384,0.0521 0.08901,0.0499 0.13894,0.13677 0.04993,0.0868 0.04993,0.19104 0,0.10638 -0.04993,0.19538 -0.04993,0.0868 -0.13894,0.13894 -0.08684,0.0499 -0.195384,0.0499 -0.106376,0 -0.193214,-0.0499 -0.08684,-0.0521 -0.136769,-0.13894 -0.04993,-0.089 -0.04993,-0.19538 z" />
             <path
-               id="path1307"
+               id="path1244"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -24.54476,190.6502 q 0.306103,0 0.594838,-0.19973 l 0.178017,0.23881 q -0.149795,0.12591 -0.360376,0.20189 -0.210581,0.0738 -0.412479,0.0738 -0.336496,0 -0.579641,-0.14546 -0.240974,-0.14545 -0.366889,-0.41248 -0.125914,-0.26702 -0.125914,-0.62523 0,-0.34518 0.128085,-0.61654 0.128086,-0.27354 0.371231,-0.42768 0.243145,-0.15631 0.57747,-0.15631 0.436359,0 0.764171,0.26486 l -0.178017,0.24314 q -0.295248,-0.20406 -0.590496,-0.20406 -0.201897,0 -0.353863,0.0999 -0.151966,0.0999 -0.238804,0.30176 -0.08467,0.2019 -0.08467,0.49497 0,0.43853 0.182359,0.65346 0.18453,0.21492 0.494974,0.21492 z" />
             <path
-               id="path1309"
+               id="path1246"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -21.62331,187.66299 q 0.178017,0 0.327811,0.0326 0.149795,0.0304 0.290906,0.0912 l -0.11723,0.27137 q -0.212752,-0.0955 -0.490633,-0.0955 -0.479778,0 -0.479778,0.37991 v 0.46458 h 0.775026 l -0.03908,0.28657 h -0.735949 v 1.82141 h -0.364717 v -1.82141 h -0.544906 v -0.28657 h 0.544906 v -0.4559 q 0,-0.20624 0.108547,-0.36254 0.108547,-0.15631 0.297418,-0.24098 0.188872,-0.0847 0.427676,-0.0847 z" />
             <path
-               id="path1311"
+               id="path1248"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -18.397929,188.72892 q -0.134599,0.0413 -0.288735,0.0543 -0.151966,0.013 -0.379915,0.013 0.397282,0.18236 0.397282,0.5753 0,0.22577 -0.104205,0.40379 -0.102034,0.17585 -0.297419,0.27571 -0.193213,0.0977 -0.458068,0.0977 -0.112889,0 -0.191043,-0.009 -0.07598,-0.0109 -0.149795,-0.0347 -0.0521,0.0369 -0.08684,0.0977 -0.03256,0.0586 -0.03256,0.12374 0,0.089 0.06947,0.14111 0.06947,0.0499 0.236632,0.0499 h 0.412479 q 0.225777,0 0.410307,0.0825 0.186701,0.0803 0.290906,0.2236 0.106376,0.14112 0.106376,0.31479 0,0.3365 -0.284393,0.51668 -0.284393,0.18019 -0.807589,0.18019 -0.360377,0 -0.573129,-0.0738 -0.210581,-0.0738 -0.30176,-0.22578 -0.09118,-0.14979 -0.09118,-0.3886 h 0.329983 q 0,0.14112 0.0521,0.22361 0.05427,0.0847 0.191042,0.12592 0.138941,0.0412 0.39077,0.0412 0.373401,0 0.549247,-0.0933 0.175847,-0.0934 0.175847,-0.28222 0,-0.15848 -0.143282,-0.24314 -0.143283,-0.0847 -0.373402,-0.0847 h -0.408137 q -0.188872,0 -0.319128,-0.0586 -0.130256,-0.0586 -0.193214,-0.1563 -0.06296,-0.0977 -0.06296,-0.21493 0,-0.11071 0.06513,-0.21492 0.06513,-0.1042 0.186701,-0.18453 -0.197556,-0.1042 -0.290906,-0.25834 -0.09335,-0.15414 -0.09335,-0.3734 0,-0.22795 0.115059,-0.40814 0.117231,-0.18236 0.323471,-0.28439 0.20841,-0.10204 0.473264,-0.10204 0.27571,0 0.455898,-0.0217 0.180188,-0.0239 0.301761,-0.063 0.123743,-0.0391 0.284393,-0.10855 z m -1.154941,0.11723 q -0.267025,0 -0.403794,0.14328 -0.134599,0.14328 -0.134599,0.38426 0,0.24314 0.13677,0.3886 0.13894,0.14328 0.410307,0.14328 0.238804,0 0.366889,-0.13894 0.130257,-0.14111 0.130257,-0.39511 0,-0.25835 -0.128086,-0.39077 -0.128085,-0.1346 -0.377744,-0.1346 z" />
           </g>
@@ -528,57 +528,57 @@
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light,  Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
          aria-label="Pre-existing">
         <path
-           id="path1314"
+           id="path1251"
            style=""
            d="m 13.458904,163.24627 q 0,0.62287 -0.286632,0.91502 -0.283876,0.29214 -0.843359,0.29214 h -0.286632 v 1.66467 h -0.270096 v -4.02938 h 0.551216 q 0.5898,0 0.862651,0.27836 0.272852,0.27837 0.272852,0.87919 z m -1.416623,0.95912 h 0.270095 q 0.474045,0 0.672483,-0.22325 0.198437,-0.22324 0.198437,-0.73587 0,-0.48782 -0.206705,-0.69729 -0.20395,-0.21221 -0.633898,-0.21221 h -0.300412 z" />
         <path
-           id="path1316"
+           id="path1253"
            style=""
            d="m 14.875527,163.06988 q 0.14056,0 0.261828,0.0386 l -0.06339,0.26182 q -0.09922,-0.0413 -0.20395,-0.0413 -0.151584,0 -0.283876,0.1571 -0.129535,0.15434 -0.203949,0.4327 -0.07441,0.27837 -0.07441,0.61461 v 1.58474 h -0.261828 v -2.99034 h 0.214974 l 0.02756,0.52365 h 0.01929 q 0.209461,-0.58153 0.567751,-0.58153 z" />
         <path
-           id="path1318"
+           id="path1255"
            style=""
            d="m 16.438223,166.17322 q -0.474045,0 -0.73036,-0.40238 -0.25356,-0.40515 -0.25356,-1.12724 0,-0.76619 0.225999,-1.16857 0.228754,-0.40515 0.655946,-0.40515 0.37207,0 0.587044,0.35554 0.214974,0.35277 0.214974,0.9536 v 0.24253 h -1.416623 q 0.0055,0.65319 0.184657,0.97841 0.179145,0.32522 0.542947,0.32522 0.28112,0 0.592556,-0.18466 v 0.25356 q -0.286631,0.17914 -0.60358,0.17914 z m -0.118512,-2.86631 q -0.54019,0 -0.592556,1.07762 h 1.149284 q 0,-0.49334 -0.151584,-0.78548 -0.148828,-0.29214 -0.405144,-0.29214 z" />
         <path
-           id="path1320"
+           id="path1257"
            style=""
            d="m 17.551677,164.73455 v -0.28112 h 1.129992 v 0.28112 z" />
         <path
-           id="path1322"
+           id="path1259"
            style=""
            d="m 20.076243,166.17322 q -0.474045,0 -0.73036,-0.40238 -0.253559,-0.40515 -0.253559,-1.12724 0,-0.76619 0.225998,-1.16857 0.228755,-0.40515 0.655946,-0.40515 0.372071,0 0.587045,0.35554 0.214974,0.35277 0.214974,0.9536 v 0.24253 h -1.416624 q 0.0055,0.65319 0.184658,0.97841 0.179144,0.32522 0.542947,0.32522 0.281119,0 0.592556,-0.18466 v 0.25356 q -0.286632,0.17914 -0.603581,0.17914 z m -0.118511,-2.86631 q -0.540191,0 -0.592556,1.07762 h 1.149283 q 0,-0.49334 -0.151584,-0.78548 -0.148828,-0.29214 -0.405143,-0.29214 z" />
         <path
-           id="path1324"
+           id="path1261"
            style=""
            d="m 21.851157,164.56643 -0.655946,-1.43867 h 0.283876 l 0.501606,1.21267 0.523654,-1.21267 h 0.272852 l -0.666971,1.47174 0.700044,1.5186 h -0.275608 l -0.559483,-1.2926 -0.564996,1.2926 h -0.270096 z" />
         <path
-           id="path1326"
+           id="path1263"
            style=""
            d="m 23.568193,166.1181 h -0.261827 v -2.99034 h 0.261827 z m -0.300413,-3.81992 q 0,-0.12402 0.04961,-0.19292 0.05237,-0.0689 0.132292,-0.0689 0.07441,0 0.118511,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.118511,0.0689 -0.07993,0 -0.132292,-0.0689 -0.04961,-0.0717 -0.04961,-0.19017 z" />
         <path
-           id="path1328"
+           id="path1265"
            style=""
            d="m 25.538787,165.36845 q 0,0.37758 -0.198438,0.59256 -0.198437,0.21221 -0.573264,0.21221 -0.20395,0 -0.35829,-0.0524 -0.15434,-0.0524 -0.239778,-0.11576 v -0.30592 q 0.101974,0.10197 0.270095,0.16536 0.168121,0.0606 0.34451,0.0606 0.23151,0 0.363802,-0.15159 0.132291,-0.15158 0.132291,-0.40514 0,-0.19844 -0.09646,-0.33348 -0.09371,-0.13781 -0.361046,-0.31144 -0.305925,-0.19293 -0.418924,-0.30868 -0.110243,-0.11576 -0.173633,-0.25907 -0.06063,-0.14332 -0.06063,-0.34176 0,-0.32246 0.21773,-0.53192 0.21773,-0.21222 0.553971,-0.21222 0.361046,0 0.603581,0.17088 l -0.135048,0.22875 q -0.225998,-0.15158 -0.479557,-0.15158 -0.231511,0 -0.369315,0.1378 -0.137803,0.13505 -0.137803,0.35829 0,0.19844 0.09371,0.33349 0.09371,0.13229 0.396875,0.32246 0.297656,0.19568 0.407899,0.31419 0.110244,0.11576 0.162609,0.25907 0.05512,0.14056 0.05512,0.32522 z" />
         <path
-           id="path1330"
+           id="path1267"
            style=""
            d="m 26.688071,165.93069 q 0.121267,0 0.214974,-0.0331 v 0.22048 q -0.121267,0.0551 -0.311437,0.0551 -0.463021,0 -0.463021,-0.69177 v -2.12218 h -0.270095 v -0.15434 l 0.264583,-0.0772 0.08544,-0.71107 h 0.181901 v 0.71107 h 0.474045 v 0.23151 h -0.474045 v 2.04777 q 0,0.30316 0.06615,0.41341 0.06614,0.11024 0.23151,0.11024 z" />
         <path
-           id="path1332"
+           id="path1269"
            style=""
            d="m 27.636161,166.1181 h -0.261827 v -2.99034 h 0.261827 z m -0.300412,-3.81992 q 0,-0.12402 0.04961,-0.19292 0.05237,-0.0689 0.132292,-0.0689 0.07441,0 0.118511,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.118511,0.0689 -0.07993,0 -0.132292,-0.0689 -0.04961,-0.0717 -0.04961,-0.19017 z" />
         <path
-           id="path1334"
+           id="path1271"
            style=""
            d="m 29.783146,166.1181 v -2.06154 q 0,-0.74414 -0.440973,-0.74414 -0.336241,0 -0.493337,0.27836 -0.15434,0.27836 -0.15434,0.8847 v 1.64262 h -0.261828 v -2.99034 h 0.220486 l 0.02205,0.41617 h 0.02481 q 0.09371,-0.226 0.270095,-0.35002 0.176389,-0.12403 0.377583,-0.12403 0.347265,0 0.520898,0.23427 0.173633,0.23151 0.173633,0.7469 v 2.06705 z" />
         <path
-           id="path1336"
+           id="path1273"
            style=""
            d="m 32.401417,163.12776 v 0.18466 l -0.407899,0.0469 q 0.08268,0.10749 0.135048,0.30868 0.05237,0.19844 0.05237,0.4079 0,0.43546 -0.198438,0.70556 -0.195681,0.27009 -0.518142,0.27009 h -0.06615 l -0.05788,-0.006 q -0.132292,0.0937 -0.209462,0.18741 -0.07441,0.0937 -0.07441,0.21773 0,0.12678 0.09922,0.19844 0.09922,0.0689 0.267339,0.0689 h 0.187413 q 0.399631,0 0.620117,0.20671 0.220486,0.2067 0.220486,0.59807 0,0.43821 -0.297656,0.69453 -0.2949,0.25631 -0.779969,0.25631 -0.405144,0 -0.622874,-0.2067 -0.21773,-0.20395 -0.21773,-0.5898 0,-0.28112 0.143316,-0.48232 0.143316,-0.19843 0.449241,-0.31419 -0.137804,-0.0606 -0.223242,-0.16812 -0.08268,-0.10749 -0.08268,-0.25632 0,-0.13504 0.08819,-0.23977 0.09095,-0.10749 0.256315,-0.22876 -0.228755,-0.10473 -0.347266,-0.339 -0.115755,-0.23426 -0.115755,-0.55121 0,-0.4768 0.201194,-0.75241 0.201193,-0.27561 0.551215,-0.27561 0.187413,0 0.314193,0.0579 z m -1.609549,3.52778 q 0,0.28387 0.146073,0.44373 0.148828,0.15985 0.446484,0.15985 0.369314,0 0.584288,-0.19293 0.21773,-0.19292 0.21773,-0.52916 0,-0.2701 -0.148828,-0.41893 -0.146072,-0.14607 -0.427192,-0.14607 h -0.192925 q -0.270096,0 -0.449241,0.18741 -0.176389,0.19017 -0.176389,0.4961 z m 0.162609,-2.55213 q 0,0.36656 0.135048,0.55673 0.135047,0.18741 0.35829,0.18741 0.479557,0 0.479557,-0.7717 0,-0.37207 -0.124023,-0.58153 -0.121268,-0.20946 -0.355534,-0.20946 -0.239779,0 -0.366559,0.21497 -0.126779,0.21497 -0.126779,0.60358 z" />
       </g>
     </g>
     <g
-       transform="matrix(1.2840056,0,0,1.2840056,170.32501,-55.53282)"
+       transform="matrix(0.96300419,0,0,0.96300419,134.92035,28.381005)"
        id="g1018">
       <g
          id="g984">
@@ -607,47 +607,47 @@
              style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
              aria-label="default.cfg">
             <path
-               id="path1340"
+               id="path1277"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -39.500625,187.75748 0.364718,0.0456 v 3.20648 h -0.319128 l -0.03473,-0.30176 q -0.125915,0.17802 -0.290906,0.26486 -0.164992,0.0868 -0.358205,0.0868 -0.434188,0 -0.653453,-0.31912 -0.217094,-0.31913 -0.217094,-0.87055 0,-0.34518 0.106376,-0.61655 0.108547,-0.27137 0.310444,-0.42333 0.204069,-0.15414 0.479778,-0.15414 0.195385,0 0.34518,0.0673 0.151965,0.0673 0.267025,0.2019 z m -0.516684,1.21139 q -0.288735,0 -0.442871,0.22795 -0.151966,0.22577 -0.151966,0.67299 0,0.44287 0.13894,0.66865 0.141111,0.22578 0.410308,0.22578 0.32347,0 0.562273,-0.36038 v -1.14191 q -0.09335,-0.13894 -0.227949,-0.21493 -0.132427,-0.0781 -0.288735,-0.0781 z" />
             <path
-               id="path1342"
+               id="path1279"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -37.977261,189.99572 q 0.0087,0.25617 0.09986,0.42768 0.09118,0.16933 0.238804,0.25183 0.147624,0.0803 0.329982,0.0803 0.169334,0 0.310445,-0.0499 0.143282,-0.0499 0.29959,-0.15631 l 0.171504,0.24098 q -0.16065,0.12591 -0.36906,0.19755 -0.206239,0.0716 -0.41682,0.0716 -0.327812,0 -0.564445,-0.14762 -0.236632,-0.14762 -0.360376,-0.41682 -0.121573,-0.2692 -0.121573,-0.62523 0,-0.34518 0.123744,-0.61655 0.123744,-0.27137 0.349521,-0.42333 0.225778,-0.15414 0.525368,-0.15414 0.286564,0 0.494974,0.1346 0.210581,0.1346 0.321299,0.3886 0.112889,0.25183 0.112889,0.59701 0,0.0999 -0.0087,0.19972 z m 0.620889,-1.02034 q -0.264855,0 -0.432017,0.1867 -0.164992,0.18453 -0.186701,0.55142 h 1.191846 q -0.0065,-0.36038 -0.158479,-0.54925 -0.151965,-0.18887 -0.414649,-0.18887 z" />
             <path
-               id="path1344"
+               id="path1281"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -34.309008,187.75748 q 0.178017,0 0.327811,0.0326 0.149795,0.0304 0.290906,0.0912 l -0.11723,0.27136 q -0.212752,-0.0955 -0.490633,-0.0955 -0.479778,0 -0.479778,0.37992 v 0.46458 h 0.775026 l -0.03908,0.28656 h -0.735949 v 1.82142 h -0.364717 v -1.82142 h -0.544906 v -0.28656 h 0.544906 v -0.4559 q 0,-0.20624 0.108547,-0.36255 0.108547,-0.1563 0.297418,-0.24097 0.188872,-0.0847 0.427676,-0.0847 z" />
             <path
-               id="path1346"
+               id="path1283"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -31.417953,190.51024 q 0,0.13459 0.04342,0.19972 0.04342,0.063 0.143282,0.0934 l -0.08901,0.25617 q -0.329983,-0.0434 -0.418992,-0.3213 -0.121572,0.15848 -0.308273,0.24098 -0.18453,0.0803 -0.408137,0.0803 -0.225778,0 -0.39294,-0.0868 -0.167163,-0.0868 -0.256171,-0.24532 -0.08901,-0.16065 -0.08901,-0.3734 0,-0.35387 0.27571,-0.54274 0.275709,-0.18887 0.796735,-0.18887 h 0.336495 v -0.19104 q 0,-0.2388 -0.13894,-0.34518 -0.13894,-0.10855 -0.405966,-0.10855 -0.258341,0 -0.594837,0.11723 l -0.09552,-0.27571 q 0.382085,-0.14328 0.746803,-0.14328 0.418991,0 0.636085,0.19756 0.219265,0.19538 0.219265,0.54056 z m -0.944359,0.27136 q 0.169334,0 0.3213,-0.0847 0.154136,-0.0868 0.25617,-0.23881 v -0.58832 h -0.329982 q -0.362547,0 -0.525368,0.12374 -0.16282,0.12375 -0.16282,0.35604 0,0.43201 0.4407,0.43201 z" />
             <path
-               id="path1348"
+               id="path1285"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -30.085631,190.34307 q 0,0.22361 0.09118,0.32564 0.09335,0.0999 0.293077,0.0999 0.180188,0 0.349521,-0.10421 0.171505,-0.1042 0.269197,-0.25834 v -1.68248 h 0.364718 v 2.286 h -0.310445 l -0.03039,-0.30827 q -0.132427,0.16933 -0.329983,0.26485 -0.195384,0.0934 -0.401624,0.0934 -0.327811,0 -0.494974,-0.17367 -0.164991,-0.17585 -0.164991,-0.49932 v -1.66294 h 0.364718 z" />
             <path
-               id="path1350"
+               id="path1287"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -26.955772,190.44511 q 0,0.16065 0.09986,0.23663 0.102034,0.0738 0.27788,0.0738 0.18453,0 0.384256,-0.0803 l 0.09769,0.26702 q -0.104206,0.0521 -0.243146,0.0847 -0.13894,0.0326 -0.299589,0.0326 -0.201898,0 -0.358206,-0.076 -0.154136,-0.076 -0.238803,-0.21926 -0.08467,-0.14329 -0.08467,-0.33867 v -2.33376 h -0.701213 v -0.28874 h 1.065931 z" />
             <path
-               id="path1352"
+               id="path1289"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -23.42646,190.89449 q -0.11506,0.076 -0.284393,0.1194 -0.167163,0.0456 -0.327812,0.0456 -0.240974,0 -0.41465,-0.0868 -0.171504,-0.089 -0.262683,-0.24532 -0.09118,-0.15631 -0.09118,-0.35821 v -1.36335 h -0.525367 v -0.28222 h 0.525367 v -0.51885 l 0.364718,-0.0434 v 0.56227 h 0.790222 l -0.04342,0.28222 h -0.746803 v 1.35901 q 0,0.19539 0.102034,0.29308 0.104205,0.0977 0.334325,0.0977 0.232291,0 0.43853,-0.10854 z" />
             <path
-               id="path1354"
+               id="path1291"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -22.154925,190.67523 q 0,-0.10421 0.04993,-0.19105 0.04993,-0.0868 0.136769,-0.13676 0.08684,-0.0521 0.193214,-0.0521 0.108547,0 0.195384,0.0521 0.08901,0.0499 0.13894,0.13676 0.04993,0.0868 0.04993,0.19105 0,0.10637 -0.04993,0.19538 -0.04993,0.0868 -0.13894,0.13894 -0.08684,0.0499 -0.195384,0.0499 -0.106377,0 -0.193214,-0.0499 -0.08684,-0.0521 -0.136769,-0.13894 -0.04993,-0.089 -0.04993,-0.19538 z" />
             <path
-               id="path1356"
+               id="path1293"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -18.999014,190.7447 q 0.306103,0 0.594838,-0.19973 l 0.178017,0.2388 q -0.149795,0.12592 -0.360376,0.2019 -0.210582,0.0738 -0.412479,0.0738 -0.336496,0 -0.579641,-0.14545 -0.240974,-0.14545 -0.366889,-0.41248 -0.125914,-0.26702 -0.125914,-0.62523 0,-0.34518 0.128085,-0.61655 0.128085,-0.27353 0.371231,-0.42767 0.243145,-0.15631 0.57747,-0.15631 0.436359,0 0.764171,0.26486 l -0.178017,0.24314 q -0.295248,-0.20407 -0.590496,-0.20407 -0.201897,0 -0.353863,0.0999 -0.151966,0.0999 -0.238804,0.30176 -0.08467,0.20189 -0.08467,0.49497 0,0.43853 0.182359,0.65345 0.18453,0.21493 0.494974,0.21493 z" />
             <path
-               id="path1358"
+               id="path1295"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -16.077565,187.75748 q 0.178017,0 0.327812,0.0326 0.149795,0.0304 0.290906,0.0912 l -0.11723,0.27136 q -0.212753,-0.0955 -0.490633,-0.0955 -0.479778,0 -0.479778,0.37992 v 0.46458 h 0.775026 l -0.03908,0.28656 h -0.735949 v 1.82142 h -0.364718 v -1.82142 h -0.544906 v -0.28656 h 0.544906 v -0.4559 q 0,-0.20624 0.108547,-0.36255 0.108547,-0.1563 0.297419,-0.24097 0.188872,-0.0847 0.427675,-0.0847 z" />
             <path
-               id="path1360"
+               id="path1297"
                style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:4.23333311px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code';fill:#ffffff"
                d="m -12.852184,188.82342 q -0.134598,0.0412 -0.288735,0.0543 -0.151965,0.013 -0.379914,0.013 0.397282,0.18236 0.397282,0.5753 0,0.22578 -0.104205,0.4038 -0.102034,0.17584 -0.297419,0.27571 -0.193214,0.0977 -0.458068,0.0977 -0.112889,0 -0.191043,-0.009 -0.07598,-0.0109 -0.149795,-0.0347 -0.0521,0.0369 -0.08684,0.0977 -0.03256,0.0586 -0.03256,0.12375 0,0.089 0.06947,0.14111 0.06947,0.0499 0.236633,0.0499 h 0.412479 q 0.225777,0 0.410307,0.0825 0.186701,0.0803 0.290906,0.2236 0.106376,0.14111 0.106376,0.31479 0,0.33649 -0.284393,0.51668 -0.284393,0.18019 -0.80759,0.18019 -0.360376,0 -0.573128,-0.0738 -0.210581,-0.0738 -0.30176,-0.22578 -0.09118,-0.14979 -0.09118,-0.3886 h 0.329983 q 0,0.14111 0.0521,0.22361 0.05427,0.0847 0.191042,0.12591 0.13894,0.0412 0.390769,0.0412 0.373402,0 0.549248,-0.0933 0.175846,-0.0934 0.175846,-0.28222 0,-0.15848 -0.143282,-0.24315 -0.143282,-0.0847 -0.373401,-0.0847 h -0.408137 q -0.188872,0 -0.319128,-0.0586 -0.130257,-0.0586 -0.193214,-0.15631 -0.06296,-0.0977 -0.06296,-0.21492 0,-0.11072 0.06513,-0.21492 0.06513,-0.10421 0.186701,-0.18453 -0.197556,-0.10421 -0.290906,-0.25834 -0.09335,-0.15414 -0.09335,-0.37341 0,-0.22794 0.115059,-0.40813 0.117231,-0.18236 0.32347,-0.2844 0.208411,-0.10203 0.473265,-0.10203 0.27571,0 0.455898,-0.0217 0.180188,-0.0239 0.30176,-0.063 0.123744,-0.0391 0.284394,-0.10854 z m -1.15494,0.11723 q -0.267025,0 -0.403795,0.14328 -0.134598,0.14328 -0.134598,0.38425 0,0.24315 0.136769,0.3886 0.138941,0.14328 0.410308,0.14328 0.238803,0 0.366889,-0.13894 0.130256,-0.14111 0.130256,-0.39511 0,-0.25834 -0.128085,-0.39077 -0.128086,-0.13459 -0.377744,-0.13459 z" />
           </g>
@@ -659,104 +659,104 @@
          aria-label="PyScaffold's own
 config file">
         <path
-           id="path1363"
+           id="path1300"
            style="text-align:center;text-anchor:middle"
            d="m 15.349967,223.91145 q 0,0.62287 -0.286632,0.91502 -0.283876,0.29214 -0.84336,0.29214 h -0.286632 v 1.66467 h -0.270095 v -4.02938 h 0.551215 q 0.589801,0 0.862652,0.27836 0.272852,0.27836 0.272852,0.87919 z m -1.416624,0.95911 h 0.270096 q 0.474045,0 0.672483,-0.22324 0.198437,-0.22324 0.198437,-0.73587 0,-0.48783 -0.206706,-0.69729 -0.203949,-0.21222 -0.633897,-0.21222 h -0.300413 z" />
         <path
-           id="path1365"
+           id="path1302"
            style="text-align:center;text-anchor:middle"
            d="m 16.311837,226.77777 -0.746896,-2.98483 h 0.264583 l 0.451997,1.86586 q 0.07993,0.33624 0.15434,0.75792 h 0.02205 q 0.05237,-0.36656 0.146072,-0.76343 l 0.440972,-1.86035 h 0.264583 l -0.873676,3.55534 q -0.09646,0.39411 -0.253559,0.59255 -0.15434,0.19844 -0.413412,0.19844 -0.10473,0 -0.237022,-0.0469 v -0.23703 q 0.110243,0.0386 0.214974,0.0386 0.165364,0 0.261827,-0.14332 0.09646,-0.14056 0.170877,-0.45475 z" />
         <path
-           id="path1367"
+           id="path1304"
            style="text-align:center;text-anchor:middle"
            d="m 19.321473,225.7277 q 0,0.4961 -0.275608,0.80478 -0.275607,0.30592 -0.700043,0.30592 -0.482313,0 -0.774457,-0.14056 v -0.29214 q 0.143316,0.0799 0.355533,0.12678 0.212218,0.0469 0.418924,0.0469 0.308681,0 0.507118,-0.23427 0.198438,-0.23426 0.198438,-0.59531 0,-0.33348 -0.14056,-0.52917 -0.14056,-0.19568 -0.537435,-0.39136 -0.311437,-0.1571 -0.465777,-0.30317 -0.15434,-0.14883 -0.228754,-0.34451 -0.07441,-0.19568 -0.07441,-0.46853 0,-0.29766 0.121268,-0.52917 0.121267,-0.23151 0.338997,-0.35829 0.21773,-0.12953 0.476801,-0.12953 0.234267,0 0.424436,0.0524 0.192926,0.0524 0.303169,0.113 l -0.104731,0.25907 q -0.305925,-0.15709 -0.622874,-0.15709 -0.297656,0 -0.485069,0.20395 -0.184657,0.20119 -0.184657,0.53468 0,0.33899 0.135048,0.52641 0.135047,0.18741 0.529166,0.3886 0.4079,0.19844 0.595313,0.46578 0.190169,0.26458 0.190169,0.64492 z" />
         <path
-           id="path1369"
+           id="path1306"
            style="text-align:center;text-anchor:middle"
            d="m 20.729828,226.8384 q -0.44924,0 -0.677995,-0.38861 -0.225998,-0.39136 -0.225998,-1.14652 0,-0.76619 0.228754,-1.16582 0.231511,-0.40239 0.680751,-0.40239 0.278364,0 0.463021,0.10197 l -0.101975,0.23151 q -0.184657,-0.0854 -0.338997,-0.0854 -0.658702,0 -0.658702,1.31464 0,1.30363 0.658702,1.30363 0.195681,0 0.424436,-0.0882 v 0.22049 q -0.09095,0.0496 -0.223243,0.0772 -0.132291,0.0276 -0.228754,0.0276 z" />
         <path
-           id="path1371"
+           id="path1308"
            style="text-align:center;text-anchor:middle"
            d="m 22.8713,226.78328 -0.03307,-0.41892 h -0.01103 q -0.214974,0.47404 -0.650434,0.47404 -0.292144,0 -0.471289,-0.23151 -0.176389,-0.23427 -0.176389,-0.62563 0,-0.42719 0.256316,-0.67524 0.256315,-0.2508 0.719335,-0.27285 l 0.322461,-0.0165 v -0.24804 q 0,-0.41893 -0.10473,-0.6091 -0.104731,-0.19292 -0.347266,-0.19292 -0.256315,0 -0.523655,0.16812 l -0.112999,-0.20671 q 0.311437,-0.19292 0.65319,-0.19292 0.369315,0 0.531923,0.23427 0.162609,0.23151 0.162609,0.77721 v 2.03674 z m -0.636654,-0.16812 q 0.28112,0 0.43546,-0.27561 0.157096,-0.27836 0.157096,-0.78548 v -0.31144 l -0.311436,0.0165 q -0.361046,0.0193 -0.537435,0.20119 -0.173633,0.17915 -0.173633,0.52641 0,0.32522 0.115755,0.4768 0.115756,0.15159 0.314193,0.15159 z" />
         <path
-           id="path1373"
+           id="path1310"
            style="text-align:center;text-anchor:middle"
            d="m 24.637944,224.02445 h -0.468533 v 2.75883 H 23.91034 v -2.75883 h -0.380338 v -0.14883 l 0.380338,-0.113 v -0.226 q 0,-0.57051 0.135048,-0.82131 0.135048,-0.2508 0.468533,-0.2508 0.192925,0 0.350022,0.0689 l -0.09095,0.24253 q -0.146072,-0.0689 -0.264583,-0.0689 -0.135048,0 -0.20395,0.0799 -0.0689,0.0799 -0.101975,0.25907 -0.03307,0.17914 -0.03307,0.49609 v 0.25081 h 0.468533 z m 1.276064,0 h -0.468533 v 2.75883 h -0.259071 v -2.75883 h -0.380339 v -0.14883 l 0.380339,-0.113 v -0.226 q 0,-0.57051 0.135047,-0.82131 0.135048,-0.2508 0.468533,-0.2508 0.192926,0 0.350022,0.0689 l -0.09095,0.24253 q -0.146072,-0.0689 -0.264584,-0.0689 -0.135047,0 -0.203949,0.0799 -0.0689,0.0799 -0.101975,0.25907 -0.03307,0.17914 -0.03307,0.49609 v 0.25081 h 0.468533 z" />
         <path
-           id="path1375"
+           id="path1312"
            style="text-align:center;text-anchor:middle"
            d="m 28.08304,225.28122 q 0,0.75516 -0.239779,1.15755 -0.237023,0.39963 -0.680751,0.39963 -0.438216,0 -0.672482,-0.39963 -0.231511,-0.40239 -0.231511,-1.15755 0,-1.54616 0.915017,-1.54616 0.429948,0 0.669727,0.40514 0.239779,0.40515 0.239779,1.14102 z m -1.551671,0 q 0,0.64768 0.15434,0.9784 0.15434,0.33073 0.482313,0.33073 0.642166,0 0.642166,-1.30913 0,-1.29811 -0.642166,-1.29811 -0.336241,0 -0.487825,0.32521 -0.148828,0.32522 -0.148828,0.9729 z" />
         <path
-           id="path1377"
+           id="path1314"
            style="text-align:center;text-anchor:middle"
            d="m 29.009081,226.78328 h -0.261827 v -4.28846 h 0.261827 z" />
         <path
-           id="path1379"
+           id="path1316"
            style="text-align:center;text-anchor:middle"
            d="m 30.535949,226.8384 q -0.870921,0 -0.870921,-1.54616 0,-0.76067 0.21773,-1.15755 0.21773,-0.39963 0.642166,-0.39963 0.201194,0 0.380339,0.11575 0.181901,0.11576 0.289388,0.31971 h 0.02205 l -0.01102,-0.33349 v -1.34221 h 0.261827 v 4.28846 h -0.214974 l -0.02205,-0.41892 h -0.02481 q -0.107487,0.22875 -0.278364,0.35277 -0.170876,0.12127 -0.391362,0.12127 z m 0.01654,-0.22875 q 0.314193,0 0.482313,-0.28939 0.170877,-0.29215 0.170877,-0.85714 v -0.17088 q 0,-0.67799 -0.165364,-0.99219 -0.162609,-0.31694 -0.49885,-0.31694 -0.322461,0 -0.463021,0.33899 -0.14056,0.33624 -0.14056,0.97565 0,0.64493 0.146072,0.97841 0.146072,0.33349 0.468533,0.33349 z" />
         <path
-           id="path1381"
+           id="path1318"
            style="text-align:center;text-anchor:middle"
            d="m 32.569933,222.7539 -0.07993,1.4552 h -0.16812 l -0.09095,-1.4552 z" />
         <path
-           id="path1383"
+           id="path1320"
            style="text-align:center;text-anchor:middle"
            d="m 34.507454,226.03363 q 0,0.37758 -0.198438,0.59255 -0.198437,0.21222 -0.573264,0.21222 -0.203949,0 -0.35829,-0.0524 -0.15434,-0.0524 -0.239778,-0.11576 v -0.30592 q 0.101974,0.10197 0.270095,0.16536 0.168121,0.0606 0.34451,0.0606 0.23151,0 0.363802,-0.15158 0.132291,-0.15158 0.132291,-0.40514 0,-0.19844 -0.09646,-0.33349 -0.09371,-0.1378 -0.361046,-0.31144 -0.305925,-0.19292 -0.418924,-0.30868 -0.110243,-0.11575 -0.173633,-0.25907 -0.06063,-0.14331 -0.06063,-0.34175 0,-0.32246 0.21773,-0.53192 0.21773,-0.21222 0.553971,-0.21222 0.361046,0 0.603581,0.17088 l -0.135048,0.22875 q -0.225998,-0.15158 -0.479557,-0.15158 -0.231511,0 -0.369315,0.1378 -0.137803,0.13505 -0.137803,0.35829 0,0.19844 0.09371,0.33348 0.09371,0.1323 0.396875,0.32247 0.297656,0.19568 0.4079,0.31419 0.110243,0.11575 0.162608,0.25907 0.05512,0.14056 0.05512,0.32522 z" />
         <path
-           id="path1385"
+           id="path1322"
            style="text-align:center;text-anchor:middle"
            d="m 37.850574,225.28122 q 0,0.75516 -0.239779,1.15755 -0.237022,0.39963 -0.680751,0.39963 -0.438216,0 -0.672482,-0.39963 -0.231511,-0.40239 -0.231511,-1.15755 0,-1.54616 0.915018,-1.54616 0.429948,0 0.669726,0.40514 0.239779,0.40515 0.239779,1.14102 z m -1.551671,0 q 0,0.64768 0.15434,0.9784 0.15434,0.33073 0.482314,0.33073 0.642165,0 0.642165,-1.30913 0,-1.29811 -0.642165,-1.29811 -0.336242,0 -0.487826,0.32521 -0.148828,0.32522 -0.148828,0.9729 z" />
         <path
-           id="path1387"
+           id="path1324"
            style="text-align:center;text-anchor:middle"
            d="m 40.176702,226.78328 -0.413411,-2.02572 q -0.0055,-0.0221 -0.01102,-0.0469 -0.0028,-0.0248 -0.08544,-0.52917 h -0.0055 l -0.03858,0.23427 -0.06339,0.34175 -0.427192,2.02572 h -0.311436 l -0.650434,-2.99034 h 0.261827 l 0.37207,1.74184 0.173633,0.9095 h 0.01654 q 0.04961,-0.39412 0.159852,-0.91502 l 0.37207,-1.73632 h 0.275608 l 0.374826,1.74184 q 0.0441,0.19568 0.157097,0.9095 h 0.01654 q 0.0083,-0.0909 0.07993,-0.45751 0.07441,-0.36655 0.468533,-2.19383 h 0.259071 l -0.672482,2.99034 z" />
         <path
-           id="path1389"
+           id="path1326"
            style="text-align:center;text-anchor:middle"
            d="m 42.963095,226.78328 v -2.06155 q 0,-0.74414 -0.440972,-0.74414 -0.336241,0 -0.493337,0.27837 -0.154341,0.27836 -0.154341,0.8847 v 1.64262 h -0.261827 v -2.99034 h 0.220486 l 0.02205,0.41616 h 0.0248 q 0.09371,-0.22599 0.270096,-0.35002 0.176389,-0.12402 0.377582,-0.12402 0.347266,0 0.520899,0.23427 0.173633,0.23151 0.173633,0.74689 v 2.06706 z" />
         <path
-           id="path1391"
+           id="path1328"
            style="text-align:center;text-anchor:middle"
            d="m 20.834559,233.89396 q -0.449241,0 -0.677995,-0.38861 -0.225998,-0.39136 -0.225998,-1.14653 0,-0.76619 0.228754,-1.16582 0.23151,-0.40239 0.680751,-0.40239 0.278364,0 0.463021,0.10198 l -0.101975,0.23151 q -0.184657,-0.0854 -0.338997,-0.0854 -0.658703,0 -0.658703,1.31465 0,1.30362 0.658703,1.30362 0.195681,0 0.424435,-0.0882 v 0.22049 q -0.09095,0.0496 -0.223242,0.0772 -0.132292,0.0276 -0.228754,0.0276 z" />
         <path
-           id="path1393"
+           id="path1330"
            style="text-align:center;text-anchor:middle"
            d="m 23.502441,232.33677 q 0,0.75517 -0.239779,1.15756 -0.237022,0.39963 -0.680751,0.39963 -0.438216,0 -0.672482,-0.39963 -0.231511,-0.40239 -0.231511,-1.15756 0,-1.54616 0.915018,-1.54616 0.429947,0 0.669726,0.40515 0.239779,0.40514 0.239779,1.14101 z m -1.551671,0 q 0,0.64768 0.15434,0.97841 0.15434,0.33073 0.482313,0.33073 0.642166,0 0.642166,-1.30914 0,-1.29811 -0.642166,-1.29811 -0.336241,0 -0.487825,0.32522 -0.148828,0.32522 -0.148828,0.97289 z" />
         <path
-           id="path1395"
+           id="path1332"
            style="text-align:center;text-anchor:middle"
            d="m 25.517133,233.83884 v -2.06155 q 0,-0.74414 -0.440973,-0.74414 -0.336241,0 -0.493337,0.27836 -0.154341,0.27837 -0.154341,0.8847 v 1.64263 h -0.261827 v -2.99035 h 0.220486 l 0.02205,0.41617 h 0.02481 q 0.09371,-0.226 0.270095,-0.35002 0.176389,-0.12403 0.377583,-0.12403 0.347265,0 0.520898,0.23427 0.173633,0.23151 0.173633,0.7469 v 2.06706 z" />
         <path
-           id="path1397"
+           id="path1334"
            style="text-align:center;text-anchor:middle"
            d="m 27.333387,231.08 h -0.468533 v 2.75884 H 26.605783 V 231.08 h -0.380339 v -0.14883 l 0.380339,-0.11299 v -0.226 q 0,-0.57051 0.135047,-0.82131 0.135048,-0.25081 0.468533,-0.25081 0.192926,0 0.350022,0.0689 l -0.09095,0.24253 q -0.146073,-0.0689 -0.264584,-0.0689 -0.135048,0 -0.203949,0.0799 -0.0689,0.0799 -0.101975,0.25908 -0.03307,0.17914 -0.03307,0.49609 v 0.2508 h 0.468533 z m 0.746896,2.75884 h -0.261827 v -2.99035 h 0.261827 z m -0.300412,-3.81993 q 0,-0.12402 0.04961,-0.19292 0.05236,-0.0689 0.132291,-0.0689 0.07441,0 0.118511,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.118511,0.0689 -0.07993,0 -0.132291,-0.0689 -0.04961,-0.0717 -0.04961,-0.19017 z" />
         <path
-           id="path1399"
+           id="path1336"
            style="text-align:center;text-anchor:middle"
            d="m 30.450509,230.84849 v 0.18466 L 30.04261,231.08 q 0.08268,0.10749 0.135048,0.30868 0.05236,0.19844 0.05236,0.4079 0,0.43546 -0.198437,0.70556 -0.195682,0.27009 -0.518142,0.27009 h -0.06615 l -0.05788,-0.006 q -0.132292,0.0937 -0.209462,0.18741 -0.07441,0.0937 -0.07441,0.21773 0,0.12678 0.09922,0.19844 0.09922,0.0689 0.267339,0.0689 h 0.187414 q 0.399631,0 0.620117,0.20671 0.220486,0.20671 0.220486,0.59807 0,0.43821 -0.297656,0.69453 -0.294901,0.25631 -0.77997,0.25631 -0.405143,0 -0.622873,-0.2067 -0.21773,-0.20395 -0.21773,-0.5898 0,-0.28112 0.143316,-0.48231 0.143316,-0.19844 0.44924,-0.3142 -0.137804,-0.0606 -0.223242,-0.16812 -0.08268,-0.10749 -0.08268,-0.25631 0,-0.13505 0.08819,-0.23978 0.09095,-0.10749 0.256315,-0.22876 -0.228754,-0.10473 -0.347265,-0.33899 -0.115756,-0.23427 -0.115756,-0.55122 0,-0.4768 0.201194,-0.75241 0.201194,-0.27561 0.551215,-0.27561 0.187413,0 0.314193,0.0579 z m -1.609548,3.52778 q 0,0.28388 0.146072,0.44373 0.148828,0.15985 0.446484,0.15985 0.369315,0 0.584288,-0.19292 0.217731,-0.19293 0.217731,-0.52917 0,-0.2701 -0.148829,-0.41892 -0.146072,-0.14608 -0.427191,-0.14608 H 29.46659 q -0.270095,0 -0.44924,0.18742 -0.176389,0.19017 -0.176389,0.49609 z m 0.162608,-2.55213 q 0,0.36656 0.135048,0.55673 0.135048,0.18741 0.35829,0.18741 0.479557,0 0.479557,-0.7717 0,-0.37207 -0.124023,-0.58153 -0.121267,-0.20946 -0.355534,-0.20946 -0.239779,0 -0.366558,0.21497 -0.12678,0.21498 -0.12678,0.60358 z" />
         <path
-           id="path1401"
+           id="path1338"
            style="text-align:center;text-anchor:middle"
            d="m 32.746321,231.08 h -0.468533 v 2.75884 H 32.018717 V 231.08 h -0.380339 v -0.14883 l 0.380339,-0.11299 v -0.226 q 0,-0.57051 0.135048,-0.82131 0.135047,-0.25081 0.468533,-0.25081 0.192925,0 0.350021,0.0689 l -0.09095,0.24253 q -0.146072,-0.0689 -0.264584,-0.0689 -0.135047,0 -0.203949,0.0799 -0.0689,0.0799 -0.101975,0.25908 -0.03307,0.17914 -0.03307,0.49609 v 0.2508 h 0.468533 z m 0.746897,2.75884 h -0.261827 v -2.99035 h 0.261827 z m -0.300413,-3.81993 q 0,-0.12402 0.04961,-0.19292 0.05237,-0.0689 0.132291,-0.0689 0.07441,0 0.118512,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.118512,0.0689 -0.07993,0 -0.132291,-0.0689 -0.04961,-0.0717 -0.04961,-0.19017 z" />
         <path
-           id="path1403"
+           id="path1340"
            style="text-align:center;text-anchor:middle"
            d="m 34.55982,233.83884 h -0.261828 v -4.28846 h 0.261828 z" />
         <path
-           id="path1405"
+           id="path1342"
            style="text-align:center;text-anchor:middle"
            d="m 36.205197,233.89396 q -0.474045,0 -0.73036,-0.40239 -0.253559,-0.40514 -0.253559,-1.12724 0,-0.76619 0.225998,-1.16857 0.228755,-0.40515 0.655947,-0.40515 0.37207,0 0.587044,0.35554 0.214974,0.35278 0.214974,0.9536 v 0.24254 h -1.416624 q 0.0055,0.65319 0.184658,0.9784 0.179145,0.32522 0.542947,0.32522 0.281119,0 0.592556,-0.18466 v 0.25356 q -0.286632,0.17915 -0.603581,0.17915 z m -0.118511,-2.86632 q -0.540191,0 -0.592556,1.07762 h 1.149283 q 0,-0.49333 -0.151584,-0.78548 -0.148828,-0.29214 -0.405143,-0.29214 z" />
       </g>
     </g>
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4782)"
-       d="m 128.72091,147.80019 v 39.29677"
+       style="fill:none;stroke:#000000;stroke-width:0.57780254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4782)"
+       d="m 103.71727,180.88076 v 29.47258"
        id="path4778" />
     <g
-       transform="matrix(1.2840056,0,0,1.2840056,-56.685115,-0.73911601)"
+       transform="matrix(0.96300419,0,0,0.96300419,-35.337243,69.476282)"
        id="g6777" />
     <g
-       transform="matrix(1.2840056,0,0,1.2840056,-8.152768,-79.556336)"
+       transform="matrix(0.96300419,0,0,0.96300419,1.0620165,10.363368)"
        id="g12869">
       <path
          id="rect4716"
@@ -767,84 +767,84 @@ config file">
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;line-height:1.25;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
          aria-label="{}">
         <path
-           id="path1409"
+           id="path1346"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
            d="m 62.200562,213.63052 q -0.324193,0 -0.516683,0.10131 -0.19249,0.0988 -0.169696,0.32673 l 0.113975,1.12708 q 0.0076,0.0684 0.0076,0.12664 0,0.22035 -0.09625,0.34192 -0.09371,0.11904 -0.291268,0.15957 0.200089,0.038 0.293801,0.14943 0.09371,0.11144 0.09371,0.33686 0,0.0659 -0.0076,0.14183 l -0.113975,1.12708 q -0.0025,0.0152 -0.0025,0.0456 0,0.20515 0.187424,0.2938 0.189957,0.0887 0.501487,0.0887 v 0.26847 q -0.400176,0 -0.691444,-0.14943 -0.288735,-0.1469 -0.288735,-0.50655 0,-0.0253 0.0051,-0.0912 l 0.111442,-1.03337 q 0.0076,-0.0608 0.0076,-0.11904 0,-0.14184 -0.06585,-0.23302 -0.06332,-0.0937 -0.238079,-0.14436 -0.172228,-0.0507 -0.491357,-0.0507 v -0.24821 q 0.319129,0 0.491357,-0.0481 0.17476,-0.0507 0.238079,-0.14184 0.06585,-0.0912 0.06585,-0.23301 0,-0.0557 -0.0076,-0.11904 l -0.111442,-1.04097 q -0.0051,-0.0608 -0.0051,-0.0886 0,-0.35712 0.288735,-0.50656 0.288735,-0.14943 0.691444,-0.14943 z" />
         <path
-           id="path1411"
+           id="path1348"
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332"
            d="m 63.749872,213.36205 q 0.400176,0 0.688911,0.14943 0.291268,0.1469 0.291268,0.50656 0,0.0253 -0.0051,0.0912 l -0.111442,1.03843 q -0.0051,0.0608 -0.0051,0.0887 0,0.14943 0.07092,0.24821 0.07345,0.0988 0.245678,0.15196 0.174761,0.0532 0.476159,0.0532 v 0.24821 q -0.4407,0 -0.617994,0.11651 -0.174761,0.11651 -0.174761,0.34192 0,0.0279 0.0051,0.0887 l 0.111442,1.0359 q 0.0051,0.0608 0.0051,0.0887 0,0.35711 -0.288735,0.50655 -0.288735,0.14943 -0.691444,0.14943 v -0.26847 q 0.329259,0 0.519216,-0.0988 0.189957,-0.0988 0.167162,-0.32926 l -0.113974,-1.12708 q -0.0076,-0.0811 -0.0076,-0.1469 0,-0.22795 0.103843,-0.33179 0.103843,-0.10638 0.35712,-0.14184 -0.240613,-0.043 -0.349522,-0.16716 -0.108908,-0.1241 -0.108908,-0.35205 0,-0.076 0.0051,-0.11651 l 0.113974,-1.12708 q 0.0025,-0.0152 0.0025,-0.0431 0,-0.20515 -0.189957,-0.2938 -0.187425,-0.0912 -0.498954,-0.0912 z" />
       </g>
     </g>
     <g
        id="g9228"
-       transform="matrix(1.2840056,0,0,1.2840056,-282.72951,-12.694343)">
+       transform="matrix(0.96300419,0,0,0.96300419,-204.87054,60.509862)">
       <g
          id="text8853"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#10b981;fill-opacity:1;stroke:none;stroke-width:0.26458332"
          aria-label="Project Structure">
         <path
-           id="path1414"
+           id="path1351"
            style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
            d="m 247.16019,176.35029 q 0,0.62287 -0.28663,0.91502 -0.28388,0.29214 -0.84336,0.29214 h -0.28663 v 1.66467 h -0.2701 v -4.02938 h 0.55122 q 0.5898,0 0.86265,0.27836 0.27285,0.27837 0.27285,0.87919 z m -1.41662,0.95912 h 0.27009 q 0.47405,0 0.67249,-0.22325 0.19843,-0.22324 0.19843,-0.73587 0,-0.48782 -0.2067,-0.69729 -0.20395,-0.21221 -0.6339,-0.21221 h -0.30041 z" />
         <path
-           id="path1416"
+           id="path1353"
            style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
            d="m 248.57681,176.1739 q 0.14056,0 0.26183,0.0386 l -0.0634,0.26182 q -0.0992,-0.0413 -0.20395,-0.0413 -0.15158,0 -0.28387,0.1571 -0.12954,0.15434 -0.20395,0.4327 -0.0744,0.27837 -0.0744,0.61461 v 1.58474 h -0.26182 v -2.99034 h 0.21497 l 0.0276,0.52365 h 0.0193 q 0.20946,-0.58153 0.56775,-0.58153 z" />
         <path
-           id="path1418"
+           id="path1355"
            style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
            d="m 250.9746,177.72006 q 0,0.75517 -0.23978,1.15755 -0.23702,0.39963 -0.68075,0.39963 -0.43821,0 -0.67248,-0.39963 -0.23151,-0.40238 -0.23151,-1.15755 0,-1.54616 0.91502,-1.54616 0.42994,0 0.66972,0.40514 0.23978,0.40515 0.23978,1.14102 z m -1.55167,0 q 0,0.64768 0.15434,0.97841 0.15434,0.33073 0.48231,0.33073 0.64217,0 0.64217,-1.30914 0,-1.29811 -0.64217,-1.29811 -0.33624,0 -0.48782,0.32522 -0.14883,0.32521 -0.14883,0.97289 z" />
         <path
-           id="path1420"
+           id="path1357"
            style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
            d="m 251.41282,180.57811 q -0.11576,0 -0.18466,-0.0469 v -0.24805 q 0.0882,0.0441 0.17363,0.0441 0.12954,0 0.1819,-0.12678 0.0551,-0.12402 0.0551,-0.38585 v -3.5829 h 0.26183 v 3.54431 q 0,0.41066 -0.11851,0.60634 -0.11851,0.19568 -0.36931,0.19568 z m 0.18741,-5.17591 q 0,-0.12402 0.0496,-0.19293 0.0524,-0.0689 0.13229,-0.0689 0.0744,0 0.11851,0.0689 0.0441,0.0689 0.0441,0.19293 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.11851,0.0689 -0.0799,0 -0.13229,-0.0689 -0.0496,-0.0717 -0.0496,-0.19017 z" />
         <path
-           id="path1422"
+           id="path1359"
            style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
            d="m 253.54602,179.27724 q -0.47405,0 -0.73036,-0.40238 -0.25356,-0.40515 -0.25356,-1.12724 0,-0.76619 0.226,-1.16858 0.22875,-0.40514 0.65595,-0.40514 0.37207,0 0.58704,0.35554 0.21497,0.35277 0.21497,0.9536 v 0.24253 h -1.41662 q 0.006,0.65319 0.18466,0.97841 0.17914,0.32522 0.54294,0.32522 0.28112,0 0.59256,-0.18466 v 0.25356 q -0.28663,0.17914 -0.60358,0.17914 z m -0.11851,-2.86632 q -0.54019,0 -0.59256,1.07763 h 1.14929 q 0,-0.49334 -0.15159,-0.78548 -0.14883,-0.29215 -0.40514,-0.29215 z" />
         <path
-           id="path1424"
+           id="path1361"
            style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
            d="m 255.68198,179.27724 q -0.44924,0 -0.678,-0.3886 -0.22599,-0.39137 -0.22599,-1.14653 0,-0.76619 0.22875,-1.16582 0.23151,-0.40239 0.68075,-0.40239 0.27836,0 0.46302,0.10198 l -0.10197,0.23151 q -0.18466,-0.0854 -0.339,-0.0854 -0.6587,0 -0.6587,1.31465 0,1.30362 0.6587,1.30362 0.19568,0 0.42444,-0.0882 v 0.22048 q -0.091,0.0496 -0.22325,0.0772 -0.13229,0.0276 -0.22875,0.0276 z" />
         <path
-           id="path1426"
+           id="path1363"
            style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
            d="m 257.21436,179.03471 q 0.12126,0 0.21497,-0.0331 v 0.22048 q -0.12127,0.0551 -0.31144,0.0551 -0.46302,0 -0.46302,-0.69177 v -2.12218 h -0.27009 v -0.15434 l 0.26458,-0.0772 0.0854,-0.71107 h 0.1819 v 0.71107 h 0.47405 v 0.23151 h -0.47405 v 2.04776 q 0,0.30317 0.0661,0.41342 0.0661,0.11024 0.23151,0.11024 z" />
         <path
-           id="path1428"
+           id="path1365"
            style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
            d="m 260.54645,178.16654 q 0,0.4961 -0.2756,0.80478 -0.27561,0.30592 -0.70005,0.30592 -0.48231,0 -0.77445,-0.14056 v -0.29214 q 0.14331,0.0799 0.35553,0.12678 0.21222,0.0469 0.41892,0.0469 0.30868,0 0.50712,-0.23426 0.19844,-0.23427 0.19844,-0.59532 0,-0.33348 -0.14056,-0.52916 -0.14056,-0.19568 -0.53744,-0.39137 -0.31143,-0.15709 -0.46577,-0.30316 -0.15434,-0.14883 -0.22876,-0.34451 -0.0744,-0.19569 -0.0744,-0.46854 0,-0.29765 0.12127,-0.52916 0.12126,-0.23151 0.33899,-0.35829 0.21773,-0.12954 0.4768,-0.12954 0.23427,0 0.42444,0.0524 0.19293,0.0524 0.30317,0.113 l -0.10473,0.25907 q -0.30593,-0.1571 -0.62288,-0.1571 -0.29765,0 -0.48507,0.20395 -0.18465,0.20119 -0.18465,0.53468 0,0.339 0.13505,0.52641 0.13504,0.18741 0.52916,0.38861 0.4079,0.19843 0.59531,0.46577 0.19017,0.26459 0.19017,0.64492 z" />
         <path
-           id="path1430"
+           id="path1367"
            style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
            d="m 261.73432,179.03471 q 0.12127,0 0.21498,-0.0331 v 0.22048 q -0.12127,0.0551 -0.31144,0.0551 -0.46302,0 -0.46302,-0.69177 v -2.12218 h -0.2701 v -0.15434 l 0.26459,-0.0772 0.0854,-0.71107 h 0.1819 v 0.71107 h 0.47404 v 0.23151 h -0.47404 v 2.04776 q 0,0.30317 0.0661,0.41342 0.0661,0.11024 0.23151,0.11024 z" />
         <path
-           id="path1432"
+           id="path1369"
            style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
            d="m 263.25016,176.1739 q 0.14056,0 0.26183,0.0386 l -0.0634,0.26182 q -0.0992,-0.0413 -0.20395,-0.0413 -0.15158,0 -0.28387,0.1571 -0.12954,0.15434 -0.20395,0.4327 -0.0744,0.27837 -0.0744,0.61461 v 1.58474 h -0.26182 v -2.99034 h 0.21497 l 0.0276,0.52365 h 0.0193 q 0.20946,-0.58153 0.56775,-0.58153 z" />
         <path
-           id="path1434"
+           id="path1371"
            style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
            d="m 264.21479,176.23178 v 1.9513 q 0,0.44373 0.10473,0.64768 0.10749,0.20395 0.32798,0.20395 0.33899,0 0.49609,-0.27285 0.15985,-0.27561 0.15985,-0.88746 v -1.64262 h 0.25907 v 2.99034 h -0.22048 l -0.0331,-0.41892 h -0.022 q -0.0965,0.22875 -0.26734,0.35278 -0.17088,0.12126 -0.37207,0.12126 -0.36105,0 -0.52917,-0.25631 -0.16536,-0.25632 -0.16536,-0.83785 v -1.9513 z" />
         <path
-           id="path1436"
+           id="path1373"
            style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
            d="m 267.13623,179.27724 q -0.44924,0 -0.67799,-0.3886 -0.226,-0.39137 -0.226,-1.14653 0,-0.76619 0.22875,-1.16582 0.23151,-0.40239 0.68075,-0.40239 0.27837,0 0.46303,0.10198 l -0.10198,0.23151 q -0.18466,-0.0854 -0.339,-0.0854 -0.6587,0 -0.6587,1.31465 0,1.30362 0.6587,1.30362 0.19568,0 0.42444,-0.0882 v 0.22048 q -0.091,0.0496 -0.22324,0.0772 -0.1323,0.0276 -0.22876,0.0276 z" />
         <path
-           id="path1438"
+           id="path1375"
            style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
            d="m 268.66861,179.03471 q 0.12127,0 0.21497,-0.0331 v 0.22048 q -0.12126,0.0551 -0.31143,0.0551 -0.46302,0 -0.46302,-0.69177 v -2.12218 h -0.2701 v -0.15434 l 0.26459,-0.0772 0.0854,-0.71107 h 0.1819 v 0.71107 h 0.47405 v 0.23151 h -0.47405 v 2.04776 q 0,0.30317 0.0661,0.41342 0.0661,0.11024 0.23151,0.11024 z" />
         <path
-           id="path1440"
+           id="path1377"
            style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
            d="m 269.60568,176.23178 v 1.9513 q 0,0.44373 0.10473,0.64768 0.10748,0.20395 0.32797,0.20395 0.339,0 0.49609,-0.27285 0.15986,-0.27561 0.15986,-0.88746 v -1.64262 h 0.25907 v 2.99034 h -0.22049 l -0.0331,-0.41892 h -0.022 q -0.0965,0.22875 -0.26734,0.35278 -0.17088,0.12126 -0.37207,0.12126 -0.36105,0 -0.52917,-0.25631 -0.16536,-0.25632 -0.16536,-0.83785 v -1.9513 z" />
         <path
-           id="path1442"
+           id="path1379"
            style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
            d="m 272.58775,176.1739 q 0.14056,0 0.26183,0.0386 l -0.0634,0.26182 q -0.0992,-0.0413 -0.20395,-0.0413 -0.15158,0 -0.28388,0.1571 -0.12953,0.15434 -0.20395,0.4327 -0.0744,0.27837 -0.0744,0.61461 v 1.58474 h -0.26183 v -2.99034 h 0.21498 l 0.0276,0.52365 h 0.0193 q 0.20946,-0.58153 0.56775,-0.58153 z" />
         <path
-           id="path1444"
+           id="path1381"
            style="text-align:center;text-anchor:middle;fill:#10b981;fill-opacity:1;stroke-width:0.26458332"
            d="m 274.15045,179.27724 q -0.47405,0 -0.73036,-0.40238 -0.25356,-0.40515 -0.25356,-1.12724 0,-0.76619 0.226,-1.16858 0.22875,-0.40514 0.65594,-0.40514 0.37207,0 0.58705,0.35554 0.21497,0.35277 0.21497,0.9536 v 0.24253 h -1.41662 q 0.006,0.65319 0.18466,0.97841 0.17914,0.32522 0.54294,0.32522 0.28112,0 0.59256,-0.18466 v 0.25356 q -0.28663,0.17914 -0.60358,0.17914 z m -0.11851,-2.86632 q -0.54019,0 -0.59256,1.07763 h 1.14928 q 0,-0.49334 -0.15158,-0.78548 -0.14883,-0.29215 -0.40514,-0.29215 z" />
       </g>
@@ -853,65 +853,65 @@ config file">
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#3b82f6;fill-opacity:1;stroke:none;stroke-width:0.26458332"
          aria-label="Scaffold Options">
         <path
-           id="path1447"
+           id="path1384"
            style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
            d="m 315.04738,178.16654 q 0,0.4961 -0.27561,0.80478 -0.27561,0.30592 -0.70004,0.30592 -0.48232,0 -0.77446,-0.14056 v -0.29214 q 0.14331,0.0799 0.35553,0.12678 0.21222,0.0469 0.41893,0.0469 0.30868,0 0.50711,-0.23426 0.19844,-0.23427 0.19844,-0.59532 0,-0.33348 -0.14056,-0.52916 -0.14056,-0.19568 -0.53743,-0.39137 -0.31144,-0.15709 -0.46578,-0.30316 -0.15434,-0.14883 -0.22875,-0.34451 -0.0744,-0.19569 -0.0744,-0.46854 0,-0.29765 0.12127,-0.52916 0.12127,-0.23151 0.339,-0.35829 0.21773,-0.12954 0.4768,-0.12954 0.23426,0 0.42443,0.0524 0.19293,0.0524 0.30317,0.113 l -0.10473,0.25907 q -0.30592,-0.1571 -0.62287,-0.1571 -0.29766,0 -0.48507,0.20395 -0.18466,0.20119 -0.18466,0.53468 0,0.339 0.13505,0.52641 0.13505,0.18741 0.52917,0.38861 0.40789,0.19843 0.59531,0.46577 0.19017,0.26459 0.19017,0.64492 z" />
         <path
-           id="path1449"
+           id="path1386"
            style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
            d="m 316.45573,179.27724 q -0.44924,0 -0.67799,-0.3886 -0.226,-0.39137 -0.226,-1.14653 0,-0.76619 0.22875,-1.16582 0.23151,-0.40239 0.68075,-0.40239 0.27837,0 0.46302,0.10198 l -0.10197,0.23151 q -0.18466,-0.0854 -0.339,-0.0854 -0.6587,0 -0.6587,1.31465 0,1.30362 0.6587,1.30362 0.19568,0 0.42444,-0.0882 v 0.22048 q -0.091,0.0496 -0.22324,0.0772 -0.1323,0.0276 -0.22876,0.0276 z" />
         <path
-           id="path1451"
+           id="path1388"
            style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
            d="m 318.5972,179.22212 -0.0331,-0.41892 h -0.011 q -0.21498,0.47404 -0.65044,0.47404 -0.29214,0 -0.47129,-0.23151 -0.17639,-0.23426 -0.17639,-0.62563 0,-0.42719 0.25632,-0.67523 0.25631,-0.25081 0.71933,-0.27286 l 0.32247,-0.0165 v -0.24805 q 0,-0.41892 -0.10474,-0.60909 -0.10473,-0.19293 -0.34726,-0.19293 -0.25632,0 -0.52366,0.16812 l -0.11299,-0.2067 q 0.31143,-0.19293 0.65319,-0.19293 0.36931,0 0.53192,0.23427 0.16261,0.23151 0.16261,0.77721 v 2.03674 z m -0.63665,-0.16812 q 0.28112,0 0.43546,-0.27561 0.1571,-0.27836 0.1571,-0.78548 v -0.31143 l -0.31144,0.0165 q -0.36105,0.0193 -0.53744,0.2012 -0.17363,0.17914 -0.17363,0.52641 0,0.32521 0.11576,0.4768 0.11575,0.15158 0.31419,0.15158 z" />
         <path
-           id="path1453"
+           id="path1390"
            style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
            d="m 320.36385,176.46329 h -0.46853 v 2.75883 h -0.25908 v -2.75883 h -0.38033 v -0.14883 l 0.38033,-0.113 v -0.226 q 0,-0.5705 0.13505,-0.82131 0.13505,-0.2508 0.46853,-0.2508 0.19293,0 0.35003,0.0689 l -0.091,0.24254 q -0.14608,-0.0689 -0.26459,-0.0689 -0.13505,0 -0.20395,0.0799 -0.0689,0.0799 -0.10197,0.25907 -0.0331,0.17915 -0.0331,0.4961 v 0.2508 h 0.46853 z m 1.27606,0 h -0.46853 v 2.75883 h -0.25907 v -2.75883 h -0.38034 v -0.14883 l 0.38034,-0.113 v -0.226 q 0,-0.5705 0.13505,-0.82131 0.13504,-0.2508 0.46853,-0.2508 0.19292,0 0.35002,0.0689 l -0.0909,0.24254 q -0.14607,-0.0689 -0.26458,-0.0689 -0.13505,0 -0.20395,0.0799 -0.0689,0.0799 -0.10198,0.25907 -0.0331,0.17915 -0.0331,0.4961 v 0.2508 h 0.46853 z" />
         <path
-           id="path1455"
+           id="path1392"
            style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
            d="m 323.80894,177.72006 q 0,0.75517 -0.23978,1.15755 -0.23702,0.39963 -0.68075,0.39963 -0.43821,0 -0.67248,-0.39963 -0.23151,-0.40238 -0.23151,-1.15755 0,-1.54616 0.91502,-1.54616 0.42995,0 0.66972,0.40514 0.23978,0.40515 0.23978,1.14102 z m -1.55167,0 q 0,0.64768 0.15434,0.97841 0.15434,0.33073 0.48232,0.33073 0.64216,0 0.64216,-1.30914 0,-1.29811 -0.64216,-1.29811 -0.33625,0 -0.48783,0.32522 -0.14883,0.32521 -0.14883,0.97289 z" />
         <path
-           id="path1457"
+           id="path1394"
            style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
            d="m 324.73498,179.22212 h -0.26182 v -4.28845 h 0.26182 z" />
         <path
-           id="path1459"
+           id="path1396"
            style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
            d="m 326.26185,179.27724 q -0.87092,0 -0.87092,-1.54616 0,-0.76067 0.21773,-1.15755 0.21773,-0.39963 0.64217,-0.39963 0.20119,0 0.38034,0.11576 0.1819,0.11575 0.28938,0.3197 h 0.0221 l -0.011,-0.33348 v -1.34221 h 0.26183 v 4.28845 h -0.21498 l -0.022,-0.41892 h -0.0248 q -0.10749,0.22875 -0.27836,0.35278 -0.17088,0.12126 -0.39137,0.12126 z m 0.0165,-0.22875 q 0.31419,0 0.48231,-0.28939 0.17088,-0.29214 0.17088,-0.85714 v -0.17088 q 0,-0.67799 -0.16537,-0.99218 -0.1626,-0.31695 -0.49885,-0.31695 -0.32246,0 -0.46302,0.339 -0.14056,0.33624 -0.14056,0.97565 0,0.64492 0.14608,0.9784 0.14607,0.33349 0.46853,0.33349 z" />
         <path
-           id="path1461"
+           id="path1398"
            style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
            d="m 331.27791,177.20192 q 0,1.00045 -0.30041,1.53789 -0.29766,0.53743 -0.86265,0.53743 -0.57051,0 -0.86541,-0.54019 -0.2949,-0.54294 -0.2949,-1.54064 0,-1.0418 0.29214,-1.55167 0.29215,-0.50988 0.87644,-0.50988 0.56223,0 0.85713,0.53744 0.29766,0.53467 0.29766,1.52962 z m -2.04225,0 q 0,0.89848 0.22324,1.35874 0.226,0.45751 0.65595,0.45751 0.4327,0 0.65594,-0.45475 0.226,-0.45475 0.226,-1.3615 0,-0.89573 -0.22048,-1.35048 -0.22049,-0.45751 -0.65319,-0.45751 -0.44373,0 -0.66698,0.46302 -0.22048,0.46027 -0.22048,1.34497 z" />
         <path
-           id="path1463"
+           id="path1400"
            style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
            d="m 332.94258,179.27724 q -0.226,0 -0.41341,-0.12402 -0.18466,-0.12678 -0.28112,-0.34451 h -0.0248 l 0.0193,0.32797 v 1.44143 h -0.26183 v -4.34633 h 0.21497 l 0.0276,0.41065 h 0.0248 q 0.11024,-0.22599 0.28112,-0.34726 0.17363,-0.12127 0.37758,-0.12127 0.87643,0 0.87643,1.54616 0,0.7469 -0.21497,1.15204 -0.21497,0.40514 -0.62563,0.40514 z m -0.0524,-2.85529 q -0.32798,0 -0.48783,0.28939 -0.15985,0.28938 -0.15985,0.90675 v 0.0854 q 0,0.68902 0.16261,1.01424 0.16261,0.32246 0.49609,0.32246 0.30868,0 0.45751,-0.3197 0.15158,-0.32246 0.15158,-1.00046 0,-0.64768 -0.14056,-0.97289 -0.14056,-0.32522 -0.47955,-0.32522 z" />
         <path
-           id="path1465"
+           id="path1402"
            style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
            d="m 334.98759,179.03471 q 0.12127,0 0.21497,-0.0331 v 0.22048 q -0.12126,0.0551 -0.31143,0.0551 -0.46302,0 -0.46302,-0.69177 v -2.12218 h -0.2701 v -0.15434 l 0.26458,-0.0772 0.0854,-0.71107 h 0.1819 v 0.71107 h 0.47405 v 0.23151 h -0.47405 v 2.04776 q 0,0.30317 0.0661,0.41342 0.0661,0.11024 0.23151,0.11024 z" />
         <path
-           id="path1467"
+           id="path1404"
            style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
            d="m 335.93568,179.22212 h -0.26183 v -2.99034 h 0.26183 z m -0.30041,-3.81992 q 0,-0.12402 0.0496,-0.19293 0.0524,-0.0689 0.13229,-0.0689 0.0744,0 0.11851,0.0689 0.0441,0.0689 0.0441,0.19293 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.11851,0.0689 -0.0799,0 -0.13229,-0.0689 -0.0496,-0.0717 -0.0496,-0.19017 z" />
         <path
-           id="path1469"
+           id="path1406"
            style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
            d="m 338.41615,177.72006 q 0,0.75517 -0.23978,1.15755 -0.23702,0.39963 -0.68075,0.39963 -0.43822,0 -0.67248,-0.39963 -0.23151,-0.40238 -0.23151,-1.15755 0,-1.54616 0.91501,-1.54616 0.42995,0 0.66973,0.40514 0.23978,0.40515 0.23978,1.14102 z m -1.55167,0 q 0,0.64768 0.15434,0.97841 0.15434,0.33073 0.48231,0.33073 0.64217,0 0.64217,-1.30914 0,-1.29811 -0.64217,-1.29811 -0.33624,0 -0.48783,0.32522 -0.14882,0.32521 -0.14882,0.97289 z" />
         <path
-           id="path1471"
+           id="path1408"
            style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
            d="m 340.43084,179.22212 v -2.06154 q 0,-0.74414 -0.44097,-0.74414 -0.33624,0 -0.49334,0.27836 -0.15434,0.27836 -0.15434,0.8847 v 1.64262 h -0.26183 v -2.99034 h 0.22049 l 0.022,0.41617 h 0.0248 q 0.0937,-0.226 0.2701,-0.35002 0.17639,-0.12403 0.37758,-0.12403 0.34727,0 0.5209,0.23427 0.17363,0.23151 0.17363,0.74689 v 2.06706 z" />
         <path
-           id="path1473"
+           id="path1410"
            style="text-align:center;text-anchor:middle;fill:#3b82f6;fill-opacity:1;stroke-width:0.26458332"
            d="m 342.65775,178.47247 q 0,0.37758 -0.19844,0.59256 -0.19844,0.21221 -0.57326,0.21221 -0.20395,0 -0.35829,-0.0524 -0.15434,-0.0524 -0.23978,-0.11576 v -0.30592 q 0.10197,0.10197 0.2701,0.16536 0.16812,0.0606 0.34451,0.0606 0.23151,0 0.3638,-0.15159 0.13229,-0.15158 0.13229,-0.40514 0,-0.19844 -0.0965,-0.33349 -0.0937,-0.1378 -0.36105,-0.31143 -0.30592,-0.19293 -0.41892,-0.30868 -0.11025,-0.11576 -0.17364,-0.25907 -0.0606,-0.14332 -0.0606,-0.34176 0,-0.32246 0.21773,-0.53192 0.21773,-0.21222 0.55397,-0.21222 0.36105,0 0.60358,0.17088 l -0.13505,0.22875 q -0.22599,-0.15158 -0.47955,-0.15158 -0.23151,0 -0.36932,0.1378 -0.1378,0.13505 -0.1378,0.35829 0,0.19844 0.0937,0.33349 0.0937,0.13229 0.39687,0.32246 0.29766,0.19568 0.4079,0.31419 0.11024,0.11576 0.16261,0.25907 0.0551,0.14056 0.0551,0.32522 z" />
       </g>
     </g>
     <g
-       transform="matrix(1.2840056,0,0,1.2840056,-105.16895,-147.0163)"
+       transform="matrix(0.96300419,0,0,0.96300419,-71.700119,-40.231605)"
        id="g7801">
       <path
          id="rect7730"
@@ -920,290 +920,286 @@ config file">
       <g
          id="text973-4"
          style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.64444447px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
-         aria-label="Actions Pipeline">
+         aria-label="Action Pipeline">
         <path
-           id="path1477"
+           id="path1414"
            style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
-           d="m 143.71975,297.18369 -0.35554,-1.46073 h -0.9784 l -0.35003,1.46073 h -0.28112 l 0.97014,-4.02939 h 0.27837 l 0.99218,4.02939 z m -0.41893,-1.73358 -0.35553,-1.50206 q -0.0551,-0.25356 -0.0854,-0.47956 -0.0248,0.23978 -0.0772,0.47956 l -0.34451,1.50206 z" />
+           d="m 144.6072,297.18369 -0.35553,-1.46073 h -0.97841 l -0.35002,1.46073 h -0.28112 l 0.97014,-4.02939 h 0.27836 l 0.99219,4.02939 z m -0.41892,-1.73358 -0.35553,-1.50206 q -0.0551,-0.25356 -0.0854,-0.47956 -0.0248,0.23978 -0.0772,0.47956 l -0.34451,1.50206 z" />
         <path
-           id="path1479"
+           id="path1416"
            style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
-           d="m 145.16117,297.23881 q -0.44924,0 -0.67799,-0.38861 -0.226,-0.39136 -0.226,-1.14653 0,-0.76619 0.22876,-1.16582 0.23151,-0.40239 0.68075,-0.40239 0.27836,0 0.46302,0.10198 l -0.10198,0.23151 q -0.18465,-0.0854 -0.33899,-0.0854 -0.65871,0 -0.65871,1.31465 0,1.30362 0.65871,1.30362 0.19568,0 0.42443,-0.0882 v 0.22049 q -0.0909,0.0496 -0.22324,0.0772 -0.13229,0.0276 -0.22876,0.0276 z" />
+           d="m 146.04863,297.23881 q -0.44924,0 -0.67799,-0.38861 -0.226,-0.39136 -0.226,-1.14653 0,-0.76619 0.22875,-1.16582 0.23151,-0.40239 0.68075,-0.40239 0.27837,0 0.46302,0.10198 l -0.10197,0.23151 q -0.18466,-0.0854 -0.339,-0.0854 -0.6587,0 -0.6587,1.31465 0,1.30362 0.6587,1.30362 0.19568,0 0.42444,-0.0882 v 0.22049 q -0.0909,0.0496 -0.22324,0.0772 -0.1323,0.0276 -0.22876,0.0276 z" />
         <path
-           id="path1481"
+           id="path1418"
            style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
-           d="m 146.69355,296.99627 q 0.12127,0 0.21498,-0.0331 v 0.22049 q -0.12127,0.0551 -0.31144,0.0551 -0.46302,0 -0.46302,-0.69178 v -2.12218 h -0.2701 v -0.15434 l 0.26459,-0.0772 0.0854,-0.71107 h 0.1819 v 0.71107 h 0.47404 v 0.23151 h -0.47404 v 2.04777 q 0,0.30317 0.0661,0.41341 0.0661,0.11024 0.23151,0.11024 z" />
+           d="m 147.58101,296.99627 q 0.12127,0 0.21497,-0.0331 v 0.22049 q -0.12126,0.0551 -0.31143,0.0551 -0.46302,0 -0.46302,-0.69178 v -2.12218 h -0.2701 v -0.15434 l 0.26458,-0.0772 0.0854,-0.71107 h 0.1819 v 0.71107 h 0.47405 v 0.23151 h -0.47405 v 2.04777 q 0,0.30317 0.0661,0.41341 0.0661,0.11024 0.23151,0.11024 z" />
         <path
-           id="path1483"
+           id="path1420"
            style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
-           d="m 147.64164,297.18369 h -0.26182 v -2.99035 h 0.26182 z m -0.30041,-3.81993 q 0,-0.12402 0.0496,-0.19292 0.0524,-0.0689 0.13229,-0.0689 0.0744,0 0.11851,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.11851,0.0689 -0.0799,0 -0.13229,-0.0689 -0.0496,-0.0717 -0.0496,-0.19017 z" />
+           d="m 148.5291,297.18369 h -0.26183 v -2.99035 h 0.26183 z m -0.30041,-3.81993 q 0,-0.12402 0.0496,-0.19292 0.0524,-0.0689 0.13229,-0.0689 0.0744,0 0.11851,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.11851,0.0689 -0.0799,0 -0.13229,-0.0689 -0.0496,-0.0717 -0.0496,-0.19017 z" />
         <path
-           id="path1485"
+           id="path1422"
            style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
-           d="m 150.12211,295.68162 q 0,0.75517 -0.23978,1.15756 -0.23702,0.39963 -0.68075,0.39963 -0.43821,0 -0.67248,-0.39963 -0.23151,-0.40239 -0.23151,-1.15756 0,-1.54616 0.91502,-1.54616 0.42995,0 0.66972,0.40515 0.23978,0.40514 0.23978,1.14101 z m -1.55167,0 q 0,0.64768 0.15434,0.97841 0.15434,0.33073 0.48232,0.33073 0.64216,0 0.64216,-1.30914 0,-1.29811 -0.64216,-1.29811 -0.33625,0 -0.48783,0.32522 -0.14883,0.32522 -0.14883,0.97289 z" />
+           d="m 151.00957,295.68162 q 0,0.75517 -0.23978,1.15756 -0.23702,0.39963 -0.68075,0.39963 -0.43822,0 -0.67248,-0.39963 -0.23151,-0.40239 -0.23151,-1.15756 0,-1.54616 0.91501,-1.54616 0.42995,0 0.66973,0.40515 0.23978,0.40514 0.23978,1.14101 z m -1.55167,0 q 0,0.64768 0.15434,0.97841 0.15434,0.33073 0.48231,0.33073 0.64217,0 0.64217,-1.30914 0,-1.29811 -0.64217,-1.29811 -0.33624,0 -0.48782,0.32522 -0.14883,0.32522 -0.14883,0.97289 z" />
         <path
-           id="path1487"
+           id="path1424"
            style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
-           d="m 152.1368,297.18369 v -2.06155 q 0,-0.74414 -0.44097,-0.74414 -0.33624,0 -0.49334,0.27836 -0.15434,0.27837 -0.15434,0.8847 v 1.64263 h -0.26182 v -2.99035 h 0.22048 l 0.0221,0.41617 h 0.0248 q 0.0937,-0.226 0.27009,-0.35002 0.17639,-0.12403 0.37758,-0.12403 0.34727,0 0.5209,0.23427 0.17364,0.23151 0.17364,0.7469 v 2.06706 z" />
+           d="m 153.02426,297.18369 v -2.06155 q 0,-0.74414 -0.44097,-0.74414 -0.33624,0 -0.49334,0.27836 -0.15434,0.27837 -0.15434,0.8847 v 1.64263 h -0.26183 v -2.99035 h 0.22049 l 0.0221,0.41617 h 0.0248 q 0.0937,-0.226 0.2701,-0.35002 0.17639,-0.12403 0.37758,-0.12403 0.34727,0 0.5209,0.23427 0.17363,0.23151 0.17363,0.7469 v 2.06706 z" />
         <path
-           id="path1489"
+           id="path1426"
            style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
-           d="m 154.36371,296.43403 q 0,0.37758 -0.19843,0.59256 -0.19844,0.21222 -0.57327,0.21222 -0.20395,0 -0.35829,-0.0524 -0.15434,-0.0524 -0.23978,-0.11575 v -0.30593 q 0.10198,0.10198 0.2701,0.16537 0.16812,0.0606 0.34451,0.0606 0.23151,0 0.3638,-0.15158 0.13229,-0.15159 0.13229,-0.40515 0,-0.19843 -0.0965,-0.33348 -0.0937,-0.13781 -0.36105,-0.31144 -0.30592,-0.19292 -0.41892,-0.30868 -0.11024,-0.11576 -0.17363,-0.25907 -0.0606,-0.14332 -0.0606,-0.34175 0,-0.32247 0.21773,-0.53193 0.21773,-0.21222 0.55398,-0.21222 0.36104,0 0.60358,0.17088 l -0.13505,0.22876 q -0.226,-0.15159 -0.47956,-0.15159 -0.23151,0 -0.36931,0.13781 -0.13781,0.13504 -0.13781,0.35829 0,0.19843 0.0937,0.33348 0.0937,0.13229 0.39687,0.32246 0.29766,0.19568 0.4079,0.31419 0.11025,0.11576 0.16261,0.25908 0.0551,0.14056 0.0551,0.32521 z" />
+           d="m 156.86348,294.31185 q 0,0.62288 -0.28664,0.91502 -0.28387,0.29215 -0.84336,0.29215 h -0.28663 v 1.66467 h -0.27009 v -4.02939 h 0.55121 q 0.5898,0 0.86265,0.27837 0.27286,0.27836 0.27286,0.87918 z m -1.41663,0.95912 h 0.2701 q 0.47404,0 0.67248,-0.22324 0.19844,-0.22325 0.19844,-0.73588 0,-0.48782 -0.20671,-0.69728 -0.20395,-0.21222 -0.6339,-0.21222 h -0.30041 z" />
         <path
-           id="path1491"
+           id="path1428"
            style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
-           d="m 157.75093,294.31185 q 0,0.62288 -0.28663,0.91502 -0.28388,0.29215 -0.84336,0.29215 h -0.28663 v 1.66467 h -0.2701 v -4.02939 h 0.55122 q 0.5898,0 0.86265,0.27837 0.27285,0.27836 0.27285,0.87918 z m -1.41662,0.95912 h 0.27009 q 0.47405,0 0.67249,-0.22324 0.19843,-0.22325 0.19843,-0.73588 0,-0.48782 -0.2067,-0.69728 -0.20395,-0.21222 -0.6339,-0.21222 h -0.30041 z" />
+           d="m 157.71235,297.18369 h -0.26183 v -2.99035 h 0.26183 z m -0.30042,-3.81993 q 0,-0.12402 0.0496,-0.19292 0.0524,-0.0689 0.1323,-0.0689 0.0744,0 0.11851,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.11851,0.0689 -0.0799,0 -0.1323,-0.0689 -0.0496,-0.0717 -0.0496,-0.19017 z" />
         <path
-           id="path1493"
+           id="path1430"
            style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
-           d="m 158.5998,297.18369 h -0.26182 v -2.99035 h 0.26182 z m -0.30041,-3.81993 q 0,-0.12402 0.0496,-0.19292 0.0524,-0.0689 0.13229,-0.0689 0.0744,0 0.11851,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.11851,0.0689 -0.0799,0 -0.13229,-0.0689 -0.0496,-0.0717 -0.0496,-0.19017 z" />
+           d="m 159.47072,297.23881 q -0.22599,0 -0.41341,-0.12403 -0.18465,-0.12678 -0.28112,-0.34451 h -0.0248 l 0.0193,0.32798 v 1.44142 h -0.26183 v -4.34633 h 0.21498 l 0.0276,0.41066 h 0.0248 q 0.11025,-0.226 0.28112,-0.34727 0.17364,-0.12127 0.37758,-0.12127 0.87644,0 0.87644,1.54616 0,0.7469 -0.21498,1.15204 -0.21497,0.40515 -0.62563,0.40515 z m -0.0524,-2.8553 q -0.32797,0 -0.48783,0.28939 -0.15985,0.28939 -0.15985,0.90675 v 0.0854 q 0,0.68902 0.16261,1.01423 0.16261,0.32246 0.49609,0.32246 0.30868,0 0.45751,-0.3197 0.15159,-0.32246 0.15159,-1.00046 0,-0.64767 -0.14056,-0.97289 -0.14056,-0.32522 -0.47956,-0.32522 z" />
         <path
-           id="path1495"
+           id="path1432"
            style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
-           d="m 160.35818,297.23881 q -0.226,0 -0.41341,-0.12403 -0.18466,-0.12678 -0.28112,-0.34451 h -0.0248 l 0.0193,0.32798 v 1.44142 h -0.26183 v -4.34633 h 0.21497 l 0.0276,0.41066 h 0.0248 q 0.11024,-0.226 0.28112,-0.34727 0.17363,-0.12127 0.37758,-0.12127 0.87643,0 0.87643,1.54616 0,0.7469 -0.21497,1.15204 -0.21497,0.40515 -0.62563,0.40515 z m -0.0524,-2.8553 q -0.32797,0 -0.48782,0.28939 -0.15985,0.28939 -0.15985,0.90675 v 0.0854 q 0,0.68902 0.16261,1.01423 0.1626,0.32246 0.49609,0.32246 0.30868,0 0.45751,-0.3197 0.15158,-0.32246 0.15158,-1.00046 0,-0.64767 -0.14056,-0.97289 -0.14056,-0.32522 -0.47956,-0.32522 z" />
+           d="m 161.81615,297.23881 q -0.47405,0 -0.73036,-0.40239 -0.25356,-0.40514 -0.25356,-1.12724 0,-0.76618 0.22599,-1.16857 0.22876,-0.40515 0.65595,-0.40515 0.37207,0 0.58704,0.35554 0.21498,0.35278 0.21498,0.9536 v 0.24254 h -1.41662 q 0.006,0.65319 0.18465,0.9784 0.17915,0.32522 0.54295,0.32522 0.28112,0 0.59256,-0.18466 v 0.25356 q -0.28664,0.17915 -0.60358,0.17915 z m -0.11852,-2.86632 q -0.54019,0 -0.59255,1.07762 h 1.14928 q 0,-0.49333 -0.15158,-0.78548 -0.14883,-0.29214 -0.40515,-0.29214 z" />
         <path
-           id="path1497"
+           id="path1434"
            style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
-           d="m 162.7036,297.23881 q -0.47404,0 -0.73036,-0.40239 -0.25356,-0.40514 -0.25356,-1.12724 0,-0.76618 0.226,-1.16857 0.22875,-0.40515 0.65595,-0.40515 0.37207,0 0.58704,0.35554 0.21497,0.35278 0.21497,0.9536 v 0.24254 h -1.41662 q 0.006,0.65319 0.18466,0.9784 0.17914,0.32522 0.54295,0.32522 0.28111,0 0.59255,-0.18466 v 0.25356 q -0.28663,0.17915 -0.60358,0.17915 z m -0.11851,-2.86632 q -0.54019,0 -0.59256,1.07762 h 1.14929 q 0,-0.49333 -0.15159,-0.78548 -0.14883,-0.29214 -0.40514,-0.29214 z" />
+           d="m 163.44499,297.18369 h -0.26183 v -4.28846 h 0.26183 z" />
         <path
-           id="path1499"
+           id="path1436"
            style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
-           d="m 164.33244,297.18369 h -0.26182 v -4.28846 h 0.26182 z" />
+           d="m 164.50332,297.18369 h -0.26183 v -2.99035 h 0.26183 z m -0.30041,-3.81993 q 0,-0.12402 0.0496,-0.19292 0.0524,-0.0689 0.13229,-0.0689 0.0744,0 0.11851,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.11851,0.0689 -0.0799,0 -0.13229,-0.0689 -0.0496,-0.0717 -0.0496,-0.19017 z" />
         <path
-           id="path1501"
+           id="path1438"
            style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
-           d="m 165.39078,297.18369 h -0.26183 v -2.99035 h 0.26183 z m -0.30042,-3.81993 q 0,-0.12402 0.0496,-0.19292 0.0524,-0.0689 0.13229,-0.0689 0.0744,0 0.11852,0.0689 0.0441,0.0689 0.0441,0.19292 0,0.11851 -0.0441,0.19017 -0.0441,0.0689 -0.11852,0.0689 -0.0799,0 -0.13229,-0.0689 -0.0496,-0.0717 -0.0496,-0.19017 z" />
+           d="m 166.6503,297.18369 v -2.06155 q 0,-0.74414 -0.44097,-0.74414 -0.33624,0 -0.49334,0.27836 -0.15434,0.27837 -0.15434,0.8847 v 1.64263 h -0.26182 v -2.99035 h 0.22048 l 0.0221,0.41617 h 0.0248 q 0.0937,-0.226 0.27009,-0.35002 0.17639,-0.12403 0.37758,-0.12403 0.34727,0 0.5209,0.23427 0.17363,0.23151 0.17363,0.7469 v 2.06706 z" />
         <path
-           id="path1503"
+           id="path1440"
            style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
-           d="m 167.53776,297.18369 v -2.06155 q 0,-0.74414 -0.44097,-0.74414 -0.33624,0 -0.49334,0.27836 -0.15434,0.27837 -0.15434,0.8847 v 1.64263 h -0.26183 v -2.99035 h 0.22049 l 0.0221,0.41617 h 0.0248 q 0.0937,-0.226 0.2701,-0.35002 0.17638,-0.12403 0.37758,-0.12403 0.34726,0 0.5209,0.23427 0.17363,0.23151 0.17363,0.7469 v 2.06706 z" />
-        <path
-           id="path1505"
-           style="text-align:center;text-anchor:middle;stroke-width:0.26458332"
-           d="m 169.43945,297.23881 q -0.47404,0 -0.73036,-0.40239 -0.25356,-0.40514 -0.25356,-1.12724 0,-0.76618 0.226,-1.16857 0.22876,-0.40515 0.65595,-0.40515 0.37207,0 0.58704,0.35554 0.21498,0.35278 0.21498,0.9536 v 0.24254 h -1.41663 q 0.006,0.65319 0.18466,0.9784 0.17914,0.32522 0.54295,0.32522 0.28112,0 0.59255,-0.18466 v 0.25356 q -0.28663,0.17915 -0.60358,0.17915 z m -0.11851,-2.86632 q -0.54019,0 -0.59256,1.07762 h 1.14929 q 0,-0.49333 -0.15159,-0.78548 -0.14882,-0.29214 -0.40514,-0.29214 z" />
+           d="m 168.55199,297.23881 q -0.47404,0 -0.73036,-0.40239 -0.25355,-0.40514 -0.25355,-1.12724 0,-0.76618 0.22599,-1.16857 0.22876,-0.40515 0.65595,-0.40515 0.37207,0 0.58704,0.35554 0.21498,0.35278 0.21498,0.9536 v 0.24254 h -1.41663 q 0.006,0.65319 0.18466,0.9784 0.17915,0.32522 0.54295,0.32522 0.28112,0 0.59256,-0.18466 v 0.25356 q -0.28664,0.17915 -0.60359,0.17915 z m -0.11851,-2.86632 q -0.54019,0 -0.59255,1.07762 h 1.14928 q 0,-0.49333 -0.15158,-0.78548 -0.14883,-0.29214 -0.40515,-0.29214 z" />
       </g>
     </g>
     <path
        id="path7645-9"
-       d="m 72.216799,204.80631 v 17.55427"
-       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker6805-2)" />
+       d="m 61.339191,223.63535 v 13.1657"
+       style="fill:none;stroke:#000000;stroke-width:0.57780254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker6805-2)" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker7249-4)"
-       d="m 117.84961,204.80631 v 17.55427"
+       style="fill:none;stroke:#000000;stroke-width:0.57780254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker7249-4)"
+       d="m 95.563799,223.63535 v 13.1657"
        id="path7647-9" />
     <g
        id="text973-5-6"
-       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:7.24749851px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.33972648"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.43562365px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.25479487"
        aria-label="User's Options">
       <path
-         id="path1508"
-         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
-         d="m 134.21232,152.08635 v 3.49281 q 0,1.75172 -1.25274,1.75172 -0.62637,0 -0.95548,-0.45297 -0.32911,-0.45297 -0.32911,-1.29875 v -3.49281 h 0.35034 v 3.53528 q 0,0.67237 0.24064,1.02626 0.24418,0.35034 0.69361,0.35034 0.44589,0 0.67591,-0.35034 0.23003,-0.35389 0.23003,-1.04042 v -3.52112 z" />
+         id="path1443"
+         style="text-align:center;text-anchor:middle;stroke-width:0.25479487"
+         d="m 107.83582,184.09538 v 2.61961 q 0,1.31379 -0.93955,1.31379 -0.46978,0 -0.71661,-0.33973 -0.24683,-0.33973 -0.24683,-0.97406 v -2.61961 h 0.26275 v 2.65146 q 0,0.50428 0.18048,0.76969 0.18314,0.26276 0.52021,0.26276 0.33442,0 0.50693,-0.26276 0.17252,-0.26541 0.17252,-0.78031 v -2.64084 z" />
       <path
-         id="path1510"
-         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
-         d="m 136.75673,156.29754 q 0,0.48482 -0.25479,0.76085 -0.2548,0.27249 -0.73608,0.27249 -0.26187,0 -0.46004,-0.0672 -0.19818,-0.0672 -0.30788,-0.14863 v -0.39281 q 0.13094,0.13094 0.3468,0.21233 0.21587,0.0779 0.44236,0.0779 0.29726,0 0.46712,-0.19463 0.16986,-0.19464 0.16986,-0.52021 0,-0.25479 -0.12386,-0.42819 -0.12032,-0.17694 -0.46358,-0.39989 -0.39281,-0.24772 -0.5379,-0.39635 -0.14155,-0.14863 -0.22295,-0.33265 -0.0779,-0.18402 -0.0779,-0.43881 0,-0.41404 0.27957,-0.68299 0.27956,-0.27249 0.7113,-0.27249 0.46358,0 0.775,0.21941 l -0.1734,0.29372 q -0.29019,-0.19464 -0.61576,-0.19464 -0.29726,0 -0.4742,0.17694 -0.17694,0.17341 -0.17694,0.46005 0,0.25479 0.12032,0.4282 0.12032,0.16986 0.50959,0.41404 0.38219,0.25125 0.52375,0.40342 0.14155,0.14863 0.20879,0.33265 0.0708,0.18048 0.0708,0.41758 z" />
+         id="path1445"
+         style="text-align:center;text-anchor:middle;stroke-width:0.25479487"
+         d="m 109.74413,187.25377 q 0,0.36362 -0.19109,0.57064 -0.1911,0.20437 -0.55206,0.20437 -0.1964,0 -0.34503,-0.0504 -0.14863,-0.0504 -0.23091,-0.11148 v -0.2946 q 0.0982,0.0982 0.2601,0.15924 0.1619,0.0584 0.33176,0.0584 0.22295,0 0.35035,-0.14597 0.1274,-0.14598 0.1274,-0.39016 0,-0.19109 -0.0929,-0.32114 -0.0902,-0.13271 -0.34769,-0.29992 -0.2946,-0.18579 -0.40342,-0.29726 -0.10617,-0.11147 -0.16721,-0.24949 -0.0584,-0.13801 -0.0584,-0.32911 0,-0.31053 0.20967,-0.51224 0.20968,-0.20437 0.53348,-0.20437 0.34769,0 0.58125,0.16456 l -0.13005,0.22029 q -0.21764,-0.14598 -0.46182,-0.14598 -0.22294,0 -0.35565,0.13271 -0.1327,0.13005 -0.1327,0.34503 0,0.1911 0.0902,0.32115 0.0902,0.1274 0.38219,0.31053 0.28664,0.18845 0.39281,0.30257 0.10616,0.11147 0.15659,0.24949 0.0531,0.13536 0.0531,0.31318 z" />
       <path
-         id="path1512"
-         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
-         d="m 138.61815,157.33088 q -0.60868,0 -0.93779,-0.51667 -0.32557,-0.52021 -0.32557,-1.44738 0,-0.98379 0.29019,-1.50045 0.29372,-0.52021 0.84223,-0.52021 0.47774,0 0.75377,0.45651 0.27603,0.45297 0.27603,1.22443 v 0.31141 h -1.81895 q 0.007,0.8387 0.2371,1.25628 0.23002,0.41758 0.69715,0.41758 0.36095,0 0.76084,-0.2371 v 0.32557 q -0.36804,0.23003 -0.775,0.23003 z m -0.15217,-3.68037 q -0.69361,0 -0.76084,1.38368 h 1.47568 q 0,-0.63345 -0.19463,-1.00857 -0.1911,-0.37511 -0.52021,-0.37511 z" />
+         id="path1447"
+         style="text-align:center;text-anchor:middle;stroke-width:0.25479487"
+         d="m 111.1402,188.02878 q -0.45651,0 -0.70334,-0.38751 -0.24418,-0.39015 -0.24418,-1.08553 0,-0.73784 0.21763,-1.12534 0.2203,-0.39016 0.63168,-0.39016 0.35831,0 0.56533,0.34238 0.20702,0.33973 0.20702,0.91833 v 0.23356 h -1.36421 q 0.005,0.62902 0.17782,0.94221 0.17252,0.31318 0.52286,0.31318 0.27072,0 0.57064,-0.17782 v 0.24418 q -0.27603,0.17252 -0.58125,0.17252 z m -0.11413,-2.76028 q -0.52021,0 -0.57064,1.03776 h 1.10677 q 0,-0.47509 -0.14598,-0.75643 -0.14332,-0.28133 -0.39015,-0.28133 z" />
       <path
-         id="path1514"
-         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
-         d="m 141.43859,153.34617 q 0.18048,0 0.33619,0.0495 l -0.0814,0.33619 q -0.1274,-0.0531 -0.26187,-0.0531 -0.19464,0 -0.3645,0.20171 -0.16632,0.19817 -0.26187,0.55559 -0.0956,0.35743 -0.0956,0.78916 v 2.03482 h -0.33619 v -3.83962 h 0.27603 l 0.0354,0.67238 h 0.0248 q 0.26895,-0.74669 0.729,-0.74669 z" />
+         id="path1449"
+         style="text-align:center;text-anchor:middle;stroke-width:0.25479487"
+         d="m 113.25552,185.04024 q 0.13536,0 0.25214,0.0372 l -0.061,0.25214 q -0.0955,-0.0398 -0.19641,-0.0398 -0.14597,0 -0.27337,0.15128 -0.12474,0.14864 -0.1964,0.4167 -0.0717,0.26807 -0.0717,0.59187 v 1.52611 h -0.25214 v -2.87971 h 0.20702 l 0.0265,0.50428 h 0.0186 q 0.20171,-0.56002 0.54674,-0.56002 z" />
       <path
-         id="path1516"
-         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
-         d="m 142.74795,152.08635 -0.10263,1.8685 h -0.21586 l -0.11678,-1.8685 z" />
+         id="path1451"
+         style="text-align:center;text-anchor:middle;stroke-width:0.25479487"
+         d="m 114.23755,184.09538 -0.077,1.40137 h -0.1619 l -0.0876,-1.40137 z" />
       <path
-         id="path1518"
-         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
-         d="m 145.23574,156.29754 q 0,0.48482 -0.2548,0.76085 -0.25479,0.27249 -0.73607,0.27249 -0.26187,0 -0.46005,-0.0672 -0.19817,-0.0672 -0.30787,-0.14863 v -0.39281 q 0.13093,0.13094 0.3468,0.21233 0.21587,0.0779 0.44235,0.0779 0.29726,0 0.46713,-0.19463 0.16986,-0.19464 0.16986,-0.52021 0,-0.25479 -0.12386,-0.42819 -0.12032,-0.17694 -0.46358,-0.39989 -0.39281,-0.24772 -0.5379,-0.39635 -0.14156,-0.14863 -0.22295,-0.33265 -0.0779,-0.18402 -0.0779,-0.43881 0,-0.41404 0.27956,-0.68299 0.27957,-0.27249 0.71131,-0.27249 0.46358,0 0.775,0.21941 l -0.17341,0.29372 q -0.29018,-0.19464 -0.61575,-0.19464 -0.29726,0 -0.4742,0.17694 -0.17694,0.17341 -0.17694,0.46005 0,0.25479 0.12032,0.4282 0.12032,0.16986 0.50959,0.41404 0.38219,0.25125 0.52374,0.40342 0.14156,0.14863 0.20879,0.33265 0.0708,0.18048 0.0708,0.41758 z" />
+         id="path1453"
+         style="text-align:center;text-anchor:middle;stroke-width:0.25479487"
+         d="m 116.10339,187.25377 q 0,0.36362 -0.1911,0.57064 -0.1911,0.20437 -0.55205,0.20437 -0.19641,0 -0.34504,-0.0504 -0.14863,-0.0504 -0.23091,-0.11148 v -0.2946 q 0.0982,0.0982 0.26011,0.15924 0.1619,0.0584 0.33176,0.0584 0.22295,0 0.35034,-0.14597 0.1274,-0.14598 0.1274,-0.39016 0,-0.19109 -0.0929,-0.32114 -0.0902,-0.13271 -0.34769,-0.29992 -0.29461,-0.18579 -0.40343,-0.29726 -0.10616,-0.11147 -0.16721,-0.24949 -0.0584,-0.13801 -0.0584,-0.32911 0,-0.31053 0.20968,-0.51224 0.20967,-0.20437 0.53347,-0.20437 0.34769,0 0.58126,0.16456 l -0.13006,0.22029 q -0.21763,-0.14598 -0.46181,-0.14598 -0.22295,0 -0.35565,0.13271 -0.13271,0.13005 -0.13271,0.34503 0,0.1911 0.0902,0.32115 0.0902,0.1274 0.38219,0.31053 0.28665,0.18845 0.39281,0.30257 0.10617,0.11147 0.15659,0.24949 0.0531,0.13536 0.0531,0.31318 z" />
       <path
-         id="path1520"
-         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
-         d="m 150.22901,154.66615 q 0,1.28459 -0.38573,1.97466 -0.38219,0.69007 -1.10765,0.69007 -0.73254,0 -1.11119,-0.69361 -0.37865,-0.69715 -0.37865,-1.9782 0,-1.33767 0.37511,-1.99235 0.37512,-0.65469 1.12535,-0.65469 0.72192,0 1.10057,0.69007 0.38219,0.68653 0.38219,1.96405 z m -2.62226,0 q 0,1.15365 0.28664,1.74464 0.29018,0.58744 0.84224,0.58744 0.55559,0 0.84224,-0.58391 0.29018,-0.5839 0.29018,-1.74817 0,-1.15012 -0.2831,-1.73402 -0.28311,-0.58745 -0.8387,-0.58745 -0.56975,0 -0.8564,0.59452 -0.2831,0.59099 -0.2831,1.72695 z" />
+         id="path1455"
+         style="text-align:center;text-anchor:middle;stroke-width:0.25479487"
+         d="m 119.84834,186.03023 q 0,0.96344 -0.2893,1.48099 -0.28664,0.51756 -0.83074,0.51756 -0.5494,0 -0.83339,-0.52021 -0.28399,-0.52286 -0.28399,-1.48365 0,-1.00326 0.28134,-1.49427 0.28133,-0.49101 0.84401,-0.49101 0.54144,0 0.82543,0.51756 0.28664,0.51489 0.28664,1.47303 z m -1.9667,0 q 0,0.86524 0.21499,1.30848 0.21763,0.44058 0.63167,0.44058 0.4167,0 0.63168,-0.43793 0.21764,-0.43793 0.21764,-1.31113 0,-0.86259 -0.21233,-1.30052 -0.21233,-0.44058 -0.62902,-0.44058 -0.42732,0 -0.6423,0.44589 -0.21233,0.44324 -0.21233,1.29521 z" />
       <path
-         id="path1522"
-         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
-         d="m 152.36646,157.33088 q -0.29019,0 -0.53083,-0.15925 -0.2371,-0.16278 -0.36096,-0.44235 h -0.0318 l 0.0248,0.42112 v 1.8508 h -0.33619 v -5.58072 h 0.27603 l 0.0354,0.52729 h 0.0318 q 0.14156,-0.29019 0.36096,-0.44589 0.22295,-0.15571 0.48482,-0.15571 1.12535,0 1.12535,1.98528 0,0.95902 -0.27603,1.47922 -0.27603,0.52021 -0.80331,0.52021 z m -0.0672,-3.66622 q -0.42112,0 -0.62637,0.37158 -0.20525,0.37157 -0.20525,1.16427 v 0.1097 q 0,0.88471 0.20879,1.30229 0.20879,0.41404 0.63698,0.41404 0.39635,0 0.58745,-0.4105 0.19463,-0.41405 0.19463,-1.28459 0,-0.83163 -0.18048,-1.24921 -0.18048,-0.41758 -0.61575,-0.41758 z" />
+         id="path1457"
+         style="text-align:center;text-anchor:middle;stroke-width:0.25479487"
+         d="m 121.45142,188.02878 q -0.21763,0 -0.39811,-0.11944 -0.17783,-0.12209 -0.27072,-0.33176 h -0.0239 l 0.0186,0.31584 v 1.3881 h -0.25214 v -4.18554 h 0.20702 l 0.0265,0.39546 h 0.0239 q 0.10616,-0.21763 0.27072,-0.33442 0.16721,-0.11678 0.36361,-0.11678 0.84401,0 0.84401,1.48896 0,0.71927 -0.20702,1.10942 -0.20702,0.39016 -0.60249,0.39016 z m -0.0504,-2.74967 q -0.31584,0 -0.46978,0.27869 -0.15394,0.27868 -0.15394,0.8732 v 0.0823 q 0,0.66352 0.15659,0.97671 0.1566,0.31053 0.47774,0.31053 0.29726,0 0.44059,-0.30788 0.14597,-0.31053 0.14597,-0.96344 0,-0.62372 -0.13536,-0.9369 -0.13536,-0.31319 -0.46181,-0.31319 z" />
       <path
-         id="path1524"
-         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
-         d="m 154.99226,157.01946 q 0.15571,0 0.27603,-0.0425 v 0.2831 q -0.15571,0.0708 -0.39989,0.0708 -0.59452,0 -0.59452,-0.88825 v -2.72489 h -0.3468 v -0.19817 l 0.33972,-0.0991 0.10971,-0.91301 h 0.23356 v 0.91301 h 0.60867 v 0.29726 h -0.60867 v 2.62935 q 0,0.38927 0.0849,0.53082 0.0849,0.14155 0.29726,0.14155 z" />
+         id="path1459"
+         style="text-align:center;text-anchor:middle;stroke-width:0.25479487"
+         d="m 123.42078,187.79521 q 0.11678,0 0.20702,-0.0318 v 0.21233 q -0.11678,0.0531 -0.29992,0.0531 -0.44589,0 -0.44589,-0.66619 v -2.04366 h -0.2601 v -0.14863 l 0.25479,-0.0743 0.0823,-0.68476 h 0.17517 v 0.68476 h 0.45651 v 0.22295 h -0.45651 v 1.972 q 0,0.29195 0.0637,0.39812 0.0637,0.10616 0.22295,0.10616 z" />
       <path
-         id="path1526"
-         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
-         d="m 156.20961,157.2601 h -0.33618 v -3.83962 h 0.33618 z m -0.38573,-4.9048 q 0,-0.15925 0.0637,-0.24772 0.0672,-0.0885 0.16986,-0.0885 0.0955,0 0.15217,0.0885 0.0566,0.0885 0.0566,0.24772 0,0.15217 -0.0566,0.24418 -0.0566,0.0885 -0.15217,0.0885 -0.10262,0 -0.16986,-0.0885 -0.0637,-0.092 -0.0637,-0.24418 z" />
+         id="path1461"
+         style="text-align:center;text-anchor:middle;stroke-width:0.25479487"
+         d="m 124.33379,187.97569 h -0.25214 v -2.87971 h 0.25214 z m -0.2893,-3.6786 q 0,-0.11943 0.0478,-0.18579 0.0504,-0.0663 0.12739,-0.0663 0.0717,0 0.11413,0.0663 0.0425,0.0664 0.0425,0.18579 0,0.11413 -0.0425,0.18314 -0.0425,0.0663 -0.11413,0.0663 -0.077,0 -0.12739,-0.0663 -0.0478,-0.069 -0.0478,-0.18314 z" />
       <path
-         id="path1528"
-         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
-         d="m 159.39455,155.33145 q 0,0.96963 -0.30788,1.4863 -0.30434,0.51313 -0.87409,0.51313 -0.56267,0 -0.86347,-0.51313 -0.29726,-0.51667 -0.29726,-1.4863 0,-1.98528 1.17489,-1.98528 0.55205,0 0.85993,0.52021 0.30788,0.5202 0.30788,1.46507 z m -1.99236,0 q 0,0.83162 0.19818,1.25628 0.19817,0.42465 0.61929,0.42465 0.82455,0 0.82455,-1.68093 0,-1.66679 -0.82455,-1.66679 -0.43173,0 -0.62637,0.41758 -0.1911,0.41758 -0.1911,1.24921 z" />
+         id="path1463"
+         style="text-align:center;text-anchor:middle;stroke-width:0.25479487"
+         d="m 126.72249,186.5292 q 0,0.72723 -0.2309,1.11473 -0.22826,0.38485 -0.65557,0.38485 -0.422,0 -0.6476,-0.38485 -0.22295,-0.3875 -0.22295,-1.11473 0,-1.48896 0.88117,-1.48896 0.41404,0 0.64495,0.39016 0.2309,0.39015 0.2309,1.0988 z m -1.49426,0 q 0,0.62372 0.14863,0.94221 0.14863,0.31849 0.46447,0.31849 0.61841,0 0.61841,-1.2607 0,-1.25009 -0.61841,-1.25009 -0.3238,0 -0.46978,0.31319 -0.14332,0.31318 -0.14332,0.9369 z" />
       <path
-         id="path1530"
-         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
-         d="m 161.98142,157.2601 v -2.64703 q 0,-0.95549 -0.56621,-0.95549 -0.43173,0 -0.63345,0.35743 -0.19817,0.35742 -0.19817,1.13596 v 2.10913 h -0.33619 v -3.83962 h 0.28311 l 0.0283,0.53437 h 0.0318 q 0.12032,-0.29019 0.3468,-0.44943 0.22649,-0.15925 0.48482,-0.15925 0.44589,0 0.66884,0.3008 0.22294,0.29726 0.22294,0.95902 v 2.65411 z" />
+         id="path1465"
+         style="text-align:center;text-anchor:middle;stroke-width:0.25479487"
+         d="m 128.66265,187.97569 v -1.98527 q 0,-0.71661 -0.42466,-0.71661 -0.3238,0 -0.47508,0.26806 -0.14863,0.26807 -0.14863,0.85197 v 1.58185 h -0.25214 v -2.87971 h 0.21232 l 0.0212,0.40077 h 0.0239 q 0.0902,-0.21764 0.26011,-0.33707 0.16986,-0.11944 0.36361,-0.11944 0.33442,0 0.50163,0.2256 0.16721,0.22295 0.16721,0.71927 v 1.99058 z" />
       <path
-         id="path1532"
-         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
-         d="m 164.84079,156.29754 q 0,0.48482 -0.2548,0.76085 -0.25479,0.27249 -0.73607,0.27249 -0.26187,0 -0.46005,-0.0672 -0.19817,-0.0672 -0.30787,-0.14863 v -0.39281 q 0.13093,0.13094 0.3468,0.21233 0.21587,0.0779 0.44235,0.0779 0.29726,0 0.46713,-0.19463 0.16986,-0.19464 0.16986,-0.52021 0,-0.25479 -0.12386,-0.42819 -0.12032,-0.17694 -0.46358,-0.39989 -0.39281,-0.24772 -0.5379,-0.39635 -0.14156,-0.14863 -0.22295,-0.33265 -0.0779,-0.18402 -0.0779,-0.43881 0,-0.41404 0.27956,-0.68299 0.27957,-0.27249 0.71131,-0.27249 0.46358,0 0.775,0.21941 l -0.17341,0.29372 q -0.29018,-0.19464 -0.61575,-0.19464 -0.29726,0 -0.4742,0.17694 -0.17694,0.17341 -0.17694,0.46005 0,0.25479 0.12032,0.4282 0.12032,0.16986 0.50959,0.41404 0.38219,0.25125 0.52374,0.40342 0.14156,0.14863 0.20879,0.33265 0.0708,0.18048 0.0708,0.41758 z" />
+         id="path1467"
+         style="text-align:center;text-anchor:middle;stroke-width:0.25479487"
+         d="m 130.80717,187.25377 q 0,0.36362 -0.19109,0.57064 -0.1911,0.20437 -0.55206,0.20437 -0.1964,0 -0.34503,-0.0504 -0.14863,-0.0504 -0.23091,-0.11148 v -0.2946 q 0.0982,0.0982 0.2601,0.15924 0.1619,0.0584 0.33177,0.0584 0.22294,0 0.35034,-0.14597 0.1274,-0.14598 0.1274,-0.39016 0,-0.19109 -0.0929,-0.32114 -0.0902,-0.13271 -0.34769,-0.29992 -0.2946,-0.18579 -0.40342,-0.29726 -0.10617,-0.11147 -0.16721,-0.24949 -0.0584,-0.13801 -0.0584,-0.32911 0,-0.31053 0.20967,-0.51224 0.20968,-0.20437 0.53348,-0.20437 0.34769,0 0.58125,0.16456 l -0.13005,0.22029 q -0.21764,-0.14598 -0.46182,-0.14598 -0.22294,0 -0.35565,0.13271 -0.1327,0.13005 -0.1327,0.34503 0,0.1911 0.0902,0.32115 0.0902,0.1274 0.38219,0.31053 0.28664,0.18845 0.39281,0.30257 0.10616,0.11147 0.15659,0.24949 0.0531,0.13536 0.0531,0.31318 z" />
     </g>
     <path
        id="path8415"
-       d="M 95.067976,239.47786 V 259.2161"
-       style="fill:none;stroke:#be185d;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.7704034, 0.7704034;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker8419)" />
+       d="m 78.477573,249.63901 v 14.80368"
+       style="fill:none;stroke:#be185d;stroke-width:0.57780254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.57780254, 0.57780254;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker8419)" />
     <g
        id="text8741"
-       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:7.24749851px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#be185d;fill-opacity:1;stroke:none;stroke-width:0.33972648"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.43562365px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#be185d;fill-opacity:1;stroke:none;stroke-width:0.25479487"
        aria-label="Created/updated
 project in the file system">
       <path
-         id="path1535"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 77.968885,264.3995 q -0.583905,0 -0.930709,0.61929 -0.343266,0.61575 -0.343266,1.70925 0,0.7113 0.159247,1.23858 0.159247,0.52729 0.456508,0.81039 0.29726,0.28311 0.690069,0.28311 0.403425,0 0.693608,-0.14509 v 0.31849 q -0.276027,0.15925 -0.725457,0.15925 -0.491896,0 -0.863472,-0.3185 -0.368037,-0.31849 -0.569749,-0.92009 -0.201713,-0.60514 -0.201713,-1.43322 0,-1.23859 0.438813,-1.94635 0.442353,-0.70776 1.203198,-0.70776 0.474202,0 0.828084,0.2194 l -0.159247,0.30434 q -0.297261,-0.19109 -0.675914,-0.19109 z" />
+         id="path1470"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 65.653256,268.33022 q -0.437929,0 -0.698032,0.46447 -0.257449,0.46182 -0.257449,1.28194 0,0.53348 0.119435,0.92894 0.119435,0.39546 0.342381,0.60779 0.222945,0.21233 0.517552,0.21233 0.302569,0 0.520206,-0.10882 v 0.23887 q -0.207021,0.11944 -0.544093,0.11944 -0.368922,0 -0.647604,-0.23887 -0.276027,-0.23887 -0.427312,-0.69007 -0.151284,-0.45386 -0.151284,-1.07492 0,-0.92894 0.32911,-1.45976 0.331764,-0.53082 0.902398,-0.53082 0.355651,0 0.621063,0.16455 l -0.119435,0.22826 q -0.222946,-0.14333 -0.506936,-0.14333 z" />
       <path
-         id="path1537"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 80.562838,265.40806 q 0.18048,0 0.336188,0.0495 l -0.08139,0.33619 q -0.127398,-0.0531 -0.261873,-0.0531 -0.194635,0 -0.364498,0.20171 -0.166324,0.19817 -0.261872,0.55559 -0.09555,0.35743 -0.09555,0.78916 v 2.03482 h -0.336188 v -3.83962 h 0.276028 l 0.03539,0.67238 h 0.02477 q 0.26895,-0.74669 0.728996,-0.74669 z" />
+         id="path1472"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 67.598721,269.08665 q 0.13536,0 0.252141,0.0371 l -0.06105,0.25214 q -0.09555,-0.0398 -0.196404,-0.0398 -0.145977,0 -0.273374,0.15129 -0.124743,0.14863 -0.196404,0.41669 -0.07166,0.26807 -0.07166,0.59187 v 1.52611 h -0.252141 v -2.87971 h 0.207021 l 0.02654,0.50428 h 0.01858 q 0.201712,-0.56001 0.546747,-0.56001 z" />
       <path
-         id="path1539"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 82.569347,269.39277 q -0.608676,0 -0.937786,-0.51667 -0.325572,-0.52021 -0.325572,-1.44738 0,-0.98379 0.290183,-1.50046 0.293722,-0.5202 0.842239,-0.5202 0.47774,0 0.753768,0.45651 0.276028,0.45296 0.276028,1.22443 v 0.31141 h -1.818952 q 0.0071,0.8387 0.2371,1.25628 0.230024,0.41758 0.697148,0.41758 0.360959,0 0.760845,-0.2371 v 0.32557 q -0.368037,0.23003 -0.775001,0.23003 z m -0.152169,-3.68037 q -0.693608,0 -0.760846,1.38367 h 1.475687 q 0,-0.63344 -0.194635,-1.00856 -0.191096,-0.37511 -0.520206,-0.37511 z" />
+         id="path1474"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 69.103603,272.07518 q -0.456508,0 -0.70334,-0.3875 -0.244178,-0.39016 -0.244178,-1.08554 0,-0.73784 0.217637,-1.12534 0.220291,-0.39015 0.631679,-0.39015 0.358305,0 0.565326,0.34238 0.207021,0.33972 0.207021,0.91832 v 0.23356 h -1.364214 q 0.0053,0.62903 0.177825,0.94221 0.172517,0.31319 0.52286,0.31319 0.27072,0 0.570635,-0.17783 v 0.24418 q -0.276028,0.17252 -0.581251,0.17252 z m -0.114127,-2.76028 q -0.520206,0 -0.570634,1.03776 h 1.106765 q 0,-0.47509 -0.145976,-0.75642 -0.143322,-0.28134 -0.390155,-0.28134 z" />
       <path
-         id="path1541"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 85.810904,269.32199 -0.04246,-0.5379 h -0.01416 q -0.276027,0.60868 -0.835161,0.60868 -0.375114,0 -0.605137,-0.29726 -0.226485,-0.3008 -0.226485,-0.80331 0,-0.54852 0.32911,-0.86702 0.32911,-0.32203 0.923632,-0.35034 l 0.414041,-0.0212 v -0.31849 q 0,-0.53791 -0.134475,-0.78208 -0.134475,-0.24772 -0.445891,-0.24772 -0.32911,0 -0.672375,0.21587 l -0.145092,-0.26541 q 0.399887,-0.24772 0.8387,-0.24772 0.474202,0 0.682992,0.3008 0.20879,0.29726 0.20879,0.99794 v 2.61519 z m -0.817466,-0.21587 q 0.360959,0 0.559133,-0.35388 0.201712,-0.35742 0.201712,-1.00856 v -0.39989 l -0.399886,0.0212 q -0.463585,0.0248 -0.690069,0.25834 -0.222946,0.23002 -0.222946,0.67591 0,0.41758 0.14863,0.61222 0.148631,0.19463 0.403426,0.19463 z" />
+         id="path1476"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 71.53477,272.02209 -0.03185,-0.40342 h -0.01062 q -0.20702,0.45651 -0.62637,0.45651 -0.281336,0 -0.453854,-0.22295 -0.169863,-0.2256 -0.169863,-0.60248 0,-0.41139 0.246833,-0.65026 0.246832,-0.24152 0.692723,-0.26276 l 0.310531,-0.0159 v -0.23887 q 0,-0.40343 -0.100856,-0.58656 -0.100856,-0.18579 -0.334418,-0.18579 -0.246833,0 -0.504282,0.1619 l -0.108818,-0.19906 q 0.299915,-0.18578 0.629025,-0.18578 0.355651,0 0.512243,0.2256 0.156593,0.22294 0.156593,0.74846 v 1.96138 z m -0.6131,-0.1619 q 0.27072,0 0.41935,-0.26541 0.151284,-0.26806 0.151284,-0.75642 v -0.29991 l -0.299914,0.0159 q -0.347689,0.0186 -0.517552,0.19375 -0.16721,0.17252 -0.16721,0.50694 0,0.31318 0.111473,0.45916 0.111473,0.14597 0.302569,0.14597 z" />
       <path
-         id="path1543"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 87.803259,269.08135 q 0.155708,0 0.276028,-0.0425 v 0.2831 q -0.155708,0.0708 -0.399886,0.0708 -0.594522,0 -0.594522,-0.88825 v -2.72489 h -0.346804 v -0.19817 l 0.339727,-0.0991 0.109703,-0.91301 h 0.233562 v 0.91301 h 0.608677 v 0.29726 h -0.608677 v 2.62935 q 0,0.38927 0.08493,0.53082 0.08493,0.14155 0.29726,0.14155 z" />
+         id="path1478"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 73.029036,271.84162 q 0.116781,0 0.207021,-0.0318 v 0.21232 q -0.116781,0.0531 -0.299915,0.0531 -0.445891,0 -0.445891,-0.66619 v -2.04366 h -0.260103 v -0.14863 l 0.254795,-0.0743 0.08228,-0.68476 h 0.175172 v 0.68476 h 0.456507 v 0.22295 h -0.456507 v 1.972 q 0,0.29196 0.0637,0.39812 0.0637,0.10617 0.222945,0.10617 z" />
       <path
-         id="path1545"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 89.774381,269.39277 q -0.608677,0 -0.937787,-0.51667 -0.325571,-0.52021 -0.325571,-1.44738 0,-0.98379 0.290183,-1.50046 0.293722,-0.5202 0.842238,-0.5202 0.477741,0 0.753768,0.45651 0.276028,0.45296 0.276028,1.22443 v 0.31141 h -1.818952 q 0.0071,0.8387 0.237101,1.25628 0.230023,0.41758 0.697147,0.41758 0.360959,0 0.760846,-0.2371 v 0.32557 q -0.368037,0.23003 -0.775001,0.23003 z m -0.15217,-3.68037 q -0.693608,0 -0.760845,1.38367 h 1.475687 q 0,-0.63344 -0.194635,-1.00856 -0.191097,-0.37511 -0.520207,-0.37511 z" />
+         id="path1480"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 74.507377,272.07518 q -0.456507,0 -0.70334,-0.3875 -0.244178,-0.39016 -0.244178,-1.08554 0,-0.73784 0.217637,-1.12534 0.220292,-0.39015 0.631679,-0.39015 0.358306,0 0.565326,0.34238 0.207021,0.33972 0.207021,0.91832 v 0.23356 h -1.364214 q 0.0053,0.62903 0.177826,0.94221 0.172517,0.31319 0.52286,0.31319 0.270719,0 0.570634,-0.17783 v 0.24418 q -0.276028,0.17252 -0.581251,0.17252 z m -0.114126,-2.76028 q -0.520207,0 -0.570635,1.03776 h 1.106765 q 0,-0.47509 -0.145976,-0.75642 -0.143322,-0.28134 -0.390154,-0.28134 z" />
       <path
-         id="path1547"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 92.467421,269.39277 q -1.118267,0 -1.118267,-1.98528 0,-0.97671 0.279567,-1.4863 0.279566,-0.51313 0.824544,-0.51313 0.258334,0 0.488357,0.14863 0.233562,0.14863 0.371576,0.4105 h 0.02831 l -0.01416,-0.4282 v -1.7234 h 0.336188 v 5.5064 h -0.276028 l -0.02831,-0.5379 h -0.03185 q -0.138014,0.29372 -0.35742,0.45297 -0.219407,0.15571 -0.502512,0.15571 z m 0.02123,-0.29372 q 0.403426,0 0.619294,-0.37158 0.219406,-0.37512 0.219406,-1.10057 v -0.21941 q 0,-0.87055 -0.212329,-1.27397 -0.20879,-0.40697 -0.640526,-0.40697 -0.414041,0 -0.594521,0.43528 -0.18048,0.43173 -0.18048,1.25274 0,0.82808 0.187557,1.25628 0.187558,0.4282 0.601599,0.4282 z" />
+         id="path1482"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 76.527157,272.07518 q -0.8387,0 -0.8387,-1.48896 0,-0.73254 0.209675,-1.11473 0.209675,-0.38484 0.618408,-0.38484 0.193751,0 0.366268,0.11147 0.175172,0.11147 0.278682,0.30788 h 0.02123 l -0.01062,-0.32115 v -1.29256 h 0.252141 v 4.1298 h -0.207021 l -0.02123,-0.40342 h -0.02389 q -0.10351,0.22029 -0.268065,0.33973 -0.164555,0.11678 -0.376884,0.11678 z m 0.01592,-0.22029 q 0.302569,0 0.464469,-0.27869 0.164555,-0.28133 0.164555,-0.82543 v -0.16455 q 0,-0.65291 -0.159246,-0.95548 -0.156593,-0.30522 -0.480395,-0.30522 -0.310531,0 -0.445891,0.32645 -0.13536,0.3238 -0.13536,0.93956 0,0.62106 0.140668,0.94221 0.140668,0.32115 0.4512,0.32115 z" />
       <path
-         id="path1549"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 96.558294,264.14824 -1.847263,5.17375 h -0.35742 l 1.864957,-5.17375 z" />
+         id="path1484"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 79.595312,268.14178 -1.385447,3.88031 h -0.268066 l 1.398718,-3.88031 z" />
       <path
-         id="path1551"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 97.52793,265.48237 v 2.50549 q 0,0.56975 0.134475,0.83162 0.138014,0.26187 0.421119,0.26187 0.435275,0 0.636988,-0.35034 0.205251,-0.35388 0.205251,-1.1395 v -2.10914 h 0.332649 v 3.83962 h -0.283105 l -0.04247,-0.5379 h -0.02831 q -0.123858,0.29372 -0.343265,0.45297 -0.219407,0.15571 -0.477741,0.15571 -0.463585,0 -0.679453,-0.32911 -0.212329,-0.32911 -0.212329,-1.0758 v -2.50549 z" />
+         id="path1486"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 80.322539,269.14238 v 1.87911 q 0,0.42732 0.100856,0.62372 0.10351,0.19641 0.315839,0.19641 0.326456,0 0.477741,-0.26276 0.153938,-0.26541 0.153938,-0.85463 v -1.58185 H 81.6204 v 2.87971 h -0.212329 l -0.03185,-0.40342 h -0.02123 q -0.09289,0.22029 -0.257449,0.33973 -0.164555,0.11678 -0.358306,0.11678 -0.347688,0 -0.509589,-0.24684 -0.159247,-0.24683 -0.159247,-0.80685 v -1.87911 z" />
       <path
-         id="path1553"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 101.52679,269.39277 q -0.29018,0 -0.53082,-0.15925 -0.2371,-0.16279 -0.36096,-0.44235 h -0.0318 l 0.0248,0.42112 v 1.8508 h -0.33618 v -5.58072 h 0.27602 l 0.0354,0.52729 h 0.0318 q 0.14155,-0.29019 0.36096,-0.44589 0.22295,-0.15571 0.48482,-0.15571 1.12534,0 1.12534,1.98528 0,0.95901 -0.27603,1.47922 -0.27602,0.52021 -0.80331,0.52021 z m -0.0672,-3.66622 q -0.42112,0 -0.62638,0.37158 -0.20525,0.37157 -0.20525,1.16427 v 0.1097 q 0,0.88471 0.20879,1.30229 0.20879,0.41404 0.63699,0.41404 0.39635,0 0.58744,-0.4105 0.19464,-0.41405 0.19464,-1.28459 0,-0.83163 -0.18048,-1.24921 -0.18048,-0.41758 -0.61575,-0.41758 z" />
+         id="path1488"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 83.321686,272.07518 q -0.217637,0 -0.398117,-0.11944 -0.177825,-0.12209 -0.270719,-0.33176 h -0.02389 l 0.01858,0.31584 v 1.3881 h -0.25214 v -4.18554 h 0.207021 l 0.02654,0.39546 h 0.02389 q 0.106164,-0.21763 0.270719,-0.33441 0.167209,-0.11678 0.363614,-0.11678 0.844008,0 0.844008,1.48895 0,0.71927 -0.207021,1.10942 -0.207021,0.39016 -0.602484,0.39016 z m -0.05043,-2.74966 q -0.315839,0 -0.469778,0.27868 -0.153939,0.27868 -0.153939,0.8732 v 0.0823 q 0,0.66353 0.156593,0.97671 0.156593,0.31053 0.477741,0.31053 0.29726,0 0.440582,-0.30787 0.145976,-0.31054 0.145976,-0.96345 0,-0.62371 -0.135359,-0.9369 -0.13536,-0.31318 -0.461816,-0.31318 z" />
       <path
-         id="path1555"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 104.38616,269.39277 q -1.11827,0 -1.11827,-1.98528 0,-0.97671 0.27957,-1.4863 0.27956,-0.51313 0.82454,-0.51313 0.25834,0 0.48836,0.14863 0.23356,0.14863 0.37158,0.4105 h 0.0283 l -0.0142,-0.4282 v -1.7234 h 0.33619 v 5.5064 h -0.27603 l -0.0283,-0.5379 h -0.0319 q -0.13801,0.29372 -0.35742,0.45297 -0.21941,0.15571 -0.50251,0.15571 z m 0.0212,-0.29372 q 0.40343,0 0.61929,-0.37158 0.21941,-0.37512 0.21941,-1.10057 v -0.21941 q 0,-0.87055 -0.21233,-1.27397 -0.20879,-0.40697 -0.64052,-0.40697 -0.41405,0 -0.59453,0.43528 -0.18048,0.43173 -0.18048,1.25274 0,0.82808 0.18756,1.25628 0.18756,0.4282 0.6016,0.4282 z" />
+         id="path1490"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 85.46621,272.07518 q -0.838699,0 -0.838699,-1.48896 0,-0.73254 0.209675,-1.11473 0.209675,-0.38484 0.618408,-0.38484 0.19375,0 0.366268,0.11147 0.175171,0.11147 0.278682,0.30788 h 0.02123 l -0.01062,-0.32115 v -1.29256 h 0.252141 v 4.1298 H 86.15628 l -0.02123,-0.40342 h -0.02389 q -0.10351,0.22029 -0.268065,0.33973 -0.164555,0.11678 -0.376885,0.11678 z m 0.01592,-0.22029 q 0.302569,0 0.46447,-0.27869 0.164555,-0.28133 0.164555,-0.82543 v -0.16455 q 0,-0.65291 -0.159247,-0.95548 -0.156592,-0.30522 -0.480394,-0.30522 -0.310532,0 -0.445891,0.32645 -0.13536,0.3238 -0.13536,0.93956 0,0.62106 0.140668,0.94221 0.140668,0.32115 0.451199,0.32115 z" />
       <path
-         id="path1557"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 108.0913,269.32199 -0.0425,-0.5379 h -0.0142 q -0.27603,0.60868 -0.83516,0.60868 -0.37512,0 -0.60514,-0.29726 -0.22648,-0.3008 -0.22648,-0.80331 0,-0.54852 0.32911,-0.86702 0.32911,-0.32203 0.92363,-0.35034 l 0.41404,-0.0212 v -0.31849 q 0,-0.53791 -0.13448,-0.78208 -0.13447,-0.24772 -0.44589,-0.24772 -0.32911,0 -0.67237,0.21587 l -0.14509,-0.26541 q 0.39988,-0.24772 0.8387,-0.24772 0.4742,0 0.68299,0.3008 0.20879,0.29726 0.20879,0.99794 v 2.61519 z m -0.81747,-0.21587 q 0.36096,0 0.55914,-0.35388 0.20171,-0.35742 0.20171,-1.00856 v -0.39989 l -0.39989,0.0212 q -0.46358,0.0248 -0.69007,0.25834 -0.22294,0.23002 -0.22294,0.67591 0,0.41758 0.14863,0.61222 0.14863,0.19463 0.40342,0.19463 z" />
+         id="path1492"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 88.245066,272.02209 -0.03185,-0.40342 H 88.2026 q -0.207021,0.45651 -0.626371,0.45651 -0.281336,0 -0.453853,-0.22295 -0.169863,-0.2256 -0.169863,-0.60248 0,-0.41139 0.246832,-0.65026 0.246833,-0.24152 0.692724,-0.26276 l 0.310531,-0.0159 v -0.23887 q 0,-0.40343 -0.100856,-0.58656 -0.100857,-0.18579 -0.334418,-0.18579 -0.246833,0 -0.504282,0.1619 l -0.108819,-0.19906 q 0.299915,-0.18578 0.629025,-0.18578 0.355651,0 0.512244,0.2256 0.156593,0.22294 0.156593,0.74846 v 1.96138 z m -0.6131,-0.1619 q 0.270719,0 0.41935,-0.26541 0.151284,-0.26806 0.151284,-0.75642 v -0.29991 l -0.299915,0.0159 q -0.347689,0.0186 -0.517552,0.19375 -0.167209,0.17252 -0.167209,0.50694 0,0.31318 0.111473,0.45916 0.111473,0.14597 0.302569,0.14597 z" />
       <path
-         id="path1559"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 110.08365,269.08135 q 0.15571,0 0.27603,-0.0425 v 0.2831 q -0.15571,0.0708 -0.39988,0.0708 -0.59453,0 -0.59453,-0.88825 v -2.72489 h -0.3468 v -0.19817 l 0.33973,-0.0991 0.1097,-0.91301 h 0.23356 v 0.91301 h 0.60868 v 0.29726 h -0.60868 v 2.62935 q 0,0.38927 0.0849,0.53082 0.0849,0.14155 0.29726,0.14155 z" />
+         id="path1494"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 89.739333,271.84162 q 0.116781,0 0.207021,-0.0318 v 0.21232 q -0.116781,0.0531 -0.299915,0.0531 -0.445891,0 -0.445891,-0.66619 v -2.04366 h -0.260103 v -0.14863 l 0.254795,-0.0743 0.08228,-0.68476 h 0.175171 v 0.68476 h 0.456508 v 0.22295 h -0.456508 v 1.972 q 0,0.29196 0.0637,0.39812 0.0637,0.10617 0.222946,0.10617 z" />
       <path
-         id="path1561"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 112.05478,269.39277 q -0.60868,0 -0.93779,-0.51667 -0.32557,-0.52021 -0.32557,-1.44738 0,-0.98379 0.29018,-1.50046 0.29373,-0.5202 0.84224,-0.5202 0.47774,0 0.75377,0.45651 0.27603,0.45296 0.27603,1.22443 v 0.31141 h -1.81895 q 0.007,0.8387 0.2371,1.25628 0.23002,0.41758 0.69714,0.41758 0.36096,0 0.76085,-0.2371 v 0.32557 q -0.36804,0.23003 -0.775,0.23003 z m -0.15217,-3.68037 q -0.69361,0 -0.76085,1.38367 h 1.47569 q 0,-0.63344 -0.19463,-1.00856 -0.1911,-0.37511 -0.52021,-0.37511 z" />
+         id="path1496"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 91.217672,272.07518 q -0.456507,0 -0.70334,-0.3875 -0.244178,-0.39016 -0.244178,-1.08554 0,-0.73784 0.217637,-1.12534 0.220291,-0.39015 0.631679,-0.39015 0.358305,0 0.565326,0.34238 0.207021,0.33972 0.207021,0.91832 v 0.23356 h -1.364214 q 0.0053,0.62903 0.177825,0.94221 0.172518,0.31319 0.522861,0.31319 0.270719,0 0.570634,-0.17783 v 0.24418 q -0.276028,0.17252 -0.581251,0.17252 z m -0.114127,-2.76028 q -0.520206,0 -0.570634,1.03776 h 1.106765 q 0,-0.47509 -0.145976,-0.75642 -0.143322,-0.28134 -0.390155,-0.28134 z" />
       <path
-         id="path1563"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 114.74782,269.39277 q -1.11827,0 -1.11827,-1.98528 0,-0.97671 0.27957,-1.4863 0.27956,-0.51313 0.82454,-0.51313 0.25833,0 0.48836,0.14863 0.23356,0.14863 0.37157,0.4105 h 0.0283 l -0.0142,-0.4282 v -1.7234 h 0.33619 v 5.5064 h -0.27603 l -0.0283,-0.5379 h -0.0319 q -0.13802,0.29372 -0.35742,0.45297 -0.21941,0.15571 -0.50251,0.15571 z m 0.0212,-0.29372 q 0.40342,0 0.61929,-0.37158 0.21941,-0.37512 0.21941,-1.10057 v -0.21941 q 0,-0.87055 -0.21233,-1.27397 -0.20879,-0.40697 -0.64053,-0.40697 -0.41404,0 -0.59452,0.43528 -0.18048,0.43173 -0.18048,1.25274 0,0.82808 0.18756,1.25628 0.18756,0.4282 0.6016,0.4282 z" />
+         id="path1498"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 93.237453,272.07518 q -0.8387,0 -0.8387,-1.48896 0,-0.73254 0.209675,-1.11473 0.209675,-0.38484 0.618408,-0.38484 0.19375,0 0.366268,0.11147 0.175171,0.11147 0.278682,0.30788 h 0.02123 l -0.01062,-0.32115 v -1.29256 h 0.252141 v 4.1298 h -0.207021 l -0.02123,-0.40342 h -0.02389 q -0.10351,0.22029 -0.268065,0.33973 -0.164555,0.11678 -0.376884,0.11678 z m 0.01592,-0.22029 q 0.302569,0 0.46447,-0.27869 0.164555,-0.28133 0.164555,-0.82543 v -0.16455 q 0,-0.65291 -0.159247,-0.95548 -0.156592,-0.30522 -0.480394,-0.30522 -0.310531,0 -0.445891,0.32645 -0.13536,0.3238 -0.13536,0.93956 0,0.62106 0.140668,0.94221 0.140668,0.32115 0.451199,0.32115 z" />
       <path
-         id="path1565"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 69.606659,278.45214 q -0.290183,0 -0.530823,-0.15925 -0.237101,-0.16278 -0.360959,-0.44235 h -0.03185 l 0.02477,0.42112 v 1.8508 h -0.336188 v -5.58071 h 0.276028 l 0.03539,0.52728 h 0.03185 q 0.141552,-0.29018 0.360959,-0.44589 0.222945,-0.15571 0.484818,-0.15571 1.125344,0 1.125344,1.98528 0,0.95902 -0.276028,1.47922 -0.276028,0.52021 -0.803311,0.52021 z m -0.06724,-3.66621 q -0.421119,0 -0.626371,0.37157 -0.205251,0.37158 -0.205251,1.16427 v 0.10971 q 0,0.8847 0.20879,1.30228 0.20879,0.41404 0.636987,0.41404 0.396348,0 0.587444,-0.4105 0.194635,-0.41404 0.194635,-1.28459 0,-0.83162 -0.18048,-1.2492 -0.180479,-0.41758 -0.615754,-0.41758 z" />
+         id="path1500"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 59.381587,278.86971 q -0.217638,0 -0.398117,-0.11944 -0.177826,-0.12209 -0.27072,-0.33176 h -0.02389 l 0.01858,0.31584 v 1.3881 h -0.252141 v -4.18554 h 0.207021 l 0.02654,0.39546 h 0.02389 q 0.106165,-0.21763 0.27072,-0.33441 0.167209,-0.11678 0.363613,-0.11678 0.844008,0 0.844008,1.48895 0,0.71927 -0.207021,1.10942 -0.20702,0.39016 -0.602483,0.39016 z m -0.05043,-2.74966 q -0.31584,0 -0.469778,0.27868 -0.153939,0.27868 -0.153939,0.8732 v 0.0823 q 0,0.66353 0.156593,0.97671 0.156592,0.31053 0.47774,0.31053 0.297261,0 0.440583,-0.30787 0.145976,-0.31054 0.145976,-0.96345 0,-0.62371 -0.13536,-0.9369 -0.13536,-0.31318 -0.461815,-0.31318 z" />
       <path
-         id="path1567"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 72.593421,274.46743 q 0.180479,0 0.336187,0.0496 l -0.08139,0.33618 q -0.127397,-0.0531 -0.261872,-0.0531 -0.194635,0 -0.364498,0.20171 -0.166325,0.19818 -0.261873,0.5556 -0.09555,0.35742 -0.09555,0.78915 v 2.03482 h -0.336187 v -3.83961 h 0.276027 l 0.03539,0.67237 h 0.02477 q 0.26895,-0.74669 0.728997,-0.74669 z" />
+         id="path1502"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 61.621658,275.88118 q 0.13536,0 0.252141,0.0372 l -0.06105,0.25214 q -0.09555,-0.0398 -0.196404,-0.0398 -0.145976,0 -0.273374,0.15129 -0.124743,0.14863 -0.196404,0.41669 -0.07166,0.26807 -0.07166,0.59187 v 1.52611 H 60.82277 v -2.87971 h 0.207021 l 0.02654,0.50428 h 0.01858 q 0.201712,-0.56001 0.546747,-0.56001 z" />
       <path
-         id="path1569"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 75.672192,276.45271 q 0,0.96963 -0.307877,1.4863 -0.304339,0.51313 -0.874088,0.51313 -0.562672,0 -0.863472,-0.51313 -0.297261,-0.51667 -0.297261,-1.4863 0,-1.98528 1.174888,-1.98528 0.552055,0 0.859933,0.52021 0.307877,0.5202 0.307877,1.46507 z m -1.992355,0 q 0,0.83162 0.198174,1.25628 0.198174,0.42466 0.619293,0.42466 0.824545,0 0.824545,-1.68094 0,-1.66678 -0.824545,-1.66678 -0.431736,0 -0.62637,0.41758 -0.191097,0.41758 -0.191097,1.2492 z" />
+         id="path1504"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 63.930736,277.37013 q 0,0.72723 -0.230907,1.11473 -0.228254,0.38485 -0.655566,0.38485 -0.422004,0 -0.647604,-0.38485 -0.222945,-0.3875 -0.222945,-1.11473 0,-1.48895 0.881165,-1.48895 0.414042,0 0.64495,0.39015 0.230907,0.39015 0.230907,1.0988 z m -1.494265,0 q 0,0.62372 0.14863,0.94221 0.14863,0.3185 0.46447,0.3185 0.618408,0 0.618408,-1.26071 0,-1.25008 -0.618408,-1.25008 -0.323802,0 -0.469778,0.31318 -0.143322,0.31319 -0.143322,0.9369 z" />
       <path
-         id="path1571"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 76.234864,280.12246 q -0.14863,0 -0.237101,-0.0602 v -0.31849 q 0.113242,0.0566 0.222946,0.0566 0.166324,0 0.233562,-0.16279 0.07078,-0.15924 0.07078,-0.49543 v -4.60046 h 0.336188 v 4.55092 q 0,0.52728 -0.15217,0.77854 -0.152169,0.25125 -0.474201,0.25125 z m 0.24064,-6.6459 q 0,-0.15924 0.0637,-0.24771 0.06724,-0.0885 0.169863,-0.0885 0.09555,0 0.15217,0.0885 0.05662,0.0885 0.05662,0.24771 0,0.15217 -0.05662,0.24418 -0.05662,0.0885 -0.15217,0.0885 -0.102625,0 -0.169863,-0.0885 -0.0637,-0.092 -0.0637,-0.24418 z" />
+         id="path1506"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 64.35274,280.12245 q -0.111472,0 -0.177825,-0.0451 v -0.23887 q 0.08493,0.0425 0.167209,0.0425 0.124743,0 0.175171,-0.12209 0.05308,-0.11943 0.05308,-0.37157 v -3.45035 h 0.252141 v 3.41319 q 0,0.39546 -0.114127,0.58391 -0.114127,0.18844 -0.355652,0.18844 z m 0.18048,-4.98443 q 0,-0.11943 0.04777,-0.18578 0.05043,-0.0664 0.127398,-0.0664 0.07166,0 0.114127,0.0664 0.04247,0.0663 0.04247,0.18578 0,0.11413 -0.04247,0.18314 -0.04247,0.0663 -0.114127,0.0663 -0.07697,0 -0.127398,-0.0663 -0.04777,-0.069 -0.04777,-0.18314 z" />
       <path
-         id="path1573"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 78.973909,278.45214 q -0.608677,0 -0.937787,-0.51667 -0.325571,-0.5202 -0.325571,-1.44737 0,-0.98379 0.290183,-1.50046 0.293722,-0.52021 0.842238,-0.52021 0.477741,0 0.753768,0.45651 0.276028,0.45297 0.276028,1.22443 v 0.31142 h -1.818952 q 0.0071,0.8387 0.237101,1.25628 0.230023,0.41758 0.697147,0.41758 0.360959,0 0.760846,-0.2371 v 0.32557 q -0.368037,0.23002 -0.775001,0.23002 z m -0.15217,-3.68037 q -0.693608,0 -0.760845,1.38368 h 1.475687 q 0,-0.63345 -0.194635,-1.00857 -0.191097,-0.37511 -0.520207,-0.37511 z" />
+         id="path1508"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 66.407024,278.86971 q -0.456508,0 -0.70334,-0.3875 -0.244178,-0.39016 -0.244178,-1.08554 0,-0.73784 0.217637,-1.12534 0.220291,-0.39015 0.631679,-0.39015 0.358305,0 0.565326,0.34238 0.207021,0.33972 0.207021,0.91832 v 0.23356 h -1.364214 q 0.0053,0.62903 0.177825,0.94221 0.172517,0.31319 0.52286,0.31319 0.27072,0 0.570635,-0.17783 v 0.24418 q -0.276028,0.17252 -0.581251,0.17252 z m -0.114127,-2.76028 q -0.520206,0 -0.570634,1.03776 h 1.106765 q 0,-0.47509 -0.145976,-0.75643 -0.143322,-0.28133 -0.390155,-0.28133 z" />
       <path
-         id="path1575"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 81.716493,278.45214 q -0.576827,0 -0.870549,-0.49897 -0.290183,-0.50251 -0.290183,-1.47215 0,-0.98379 0.293722,-1.49692 0.29726,-0.51667 0.874088,-0.51667 0.35742,0 0.594521,0.13094 l -0.130936,0.29726 q -0.237101,-0.1097 -0.435275,-0.1097 -0.845777,0 -0.845777,1.68801 0,1.67386 0.845777,1.67386 0.251256,0 0.544978,-0.11324 v 0.28311 q -0.116781,0.0637 -0.286644,0.0991 -0.169863,0.0354 -0.293722,0.0354 z" />
+         id="path1510"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 68.463962,278.86971 q -0.432621,0 -0.652912,-0.37423 -0.217638,-0.37689 -0.217638,-1.10411 0,-0.73785 0.220292,-1.12269 0.222945,-0.3875 0.655566,-0.3875 0.268065,0 0.445891,0.0982 l -0.0982,0.22294 q -0.177826,-0.0823 -0.326456,-0.0823 -0.634333,0 -0.634333,1.26601 0,1.25539 0.634333,1.25539 0.188442,0 0.408733,-0.0849 v 0.21233 q -0.08759,0.0478 -0.214983,0.0743 -0.127398,0.0265 -0.220291,0.0265 z" />
       <path
-         id="path1577"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 83.684075,278.14072 q 0.155708,0 0.276028,-0.0425 v 0.2831 q -0.155708,0.0708 -0.399886,0.0708 -0.594522,0 -0.594522,-0.88824 v -2.72489 h -0.346804 v -0.19818 l 0.339727,-0.0991 0.109703,-0.91302 h 0.233562 v 0.91302 h 0.608676 v 0.29726 h -0.608676 v 2.62934 q 0,0.38927 0.08493,0.53082 0.08493,0.14155 0.297261,0.14155 z" />
+         id="path1512"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 69.939648,278.63614 q 0.116781,0 0.207021,-0.0318 v 0.21232 q -0.116781,0.0531 -0.299915,0.0531 -0.445891,0 -0.445891,-0.66619 v -2.04366 H 69.14076 v -0.14863 l 0.254795,-0.0743 0.08228,-0.68476 h 0.175171 v 0.68476 h 0.456508 v 0.22295 h -0.456508 v 1.972 q 0,0.29196 0.0637,0.39812 0.0637,0.10616 0.222945,0.10616 z" />
       <path
-         id="path1579"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 86.260335,278.38136 h -0.336188 v -3.83961 h 0.336188 z m -0.385731,-4.9048 q 0,-0.15924 0.0637,-0.24771 0.06724,-0.0885 0.169863,-0.0885 0.09555,0 0.152169,0.0885 0.05662,0.0885 0.05662,0.24771 0,0.15217 -0.05662,0.24418 -0.05662,0.0885 -0.152169,0.0885 -0.102626,0 -0.169863,-0.0885 -0.0637,-0.092 -0.0637,-0.24418 z" />
+         id="path1514"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 71.871843,278.81662 h -0.252141 v -2.87971 h 0.252141 z m -0.289298,-3.6786 q 0,-0.11943 0.04777,-0.18578 0.05043,-0.0664 0.127397,-0.0664 0.07166,0 0.114127,0.0664 0.04247,0.0663 0.04247,0.18578 0,0.11413 -0.04247,0.18314 -0.04247,0.0663 -0.114127,0.0663 -0.07697,0 -0.127397,-0.0663 -0.04777,-0.069 -0.04777,-0.18314 z" />
       <path
-         id="path1581"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 89.017074,278.38136 v -2.64703 q 0,-0.95548 -0.566211,-0.95548 -0.431736,0 -0.633448,0.35742 -0.198174,0.35742 -0.198174,1.13596 v 2.10913 h -0.336188 v -3.83961 h 0.283105 l 0.02831,0.53436 h 0.03185 q 0.12032,-0.29018 0.346804,-0.44943 0.226485,-0.15925 0.484818,-0.15925 0.445892,0 0.668837,0.3008 0.222946,0.29726 0.222946,0.95902 v 2.65411 z" />
+         id="path1516"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 73.939397,278.81662 v -1.98527 q 0,-0.71661 -0.424658,-0.71661 -0.323802,0 -0.475086,0.26806 -0.148631,0.26807 -0.148631,0.85197 v 1.58185 h -0.25214 v -2.87971 h 0.212329 l 0.02123,0.40077 h 0.02389 q 0.09024,-0.21763 0.260103,-0.33707 0.169863,-0.11943 0.363613,-0.11943 0.334418,0 0.501628,0.22559 0.167209,0.22295 0.167209,0.71927 v 1.99058 z" />
       <path
-         id="path1583"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 92.432033,278.14072 q 0.155708,0 0.276028,-0.0425 v 0.2831 q -0.155708,0.0708 -0.399886,0.0708 -0.594522,0 -0.594522,-0.88824 v -2.72489 h -0.346804 v -0.19818 l 0.339727,-0.0991 0.109703,-0.91302 h 0.233562 v 0.91302 h 0.608677 v 0.29726 h -0.608677 v 2.62934 q 0,0.38927 0.08493,0.53082 0.08493,0.14155 0.29726,0.14155 z" />
+         id="path1518"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 76.500617,278.63614 q 0.116781,0 0.207021,-0.0318 v 0.21232 q -0.116781,0.0531 -0.299915,0.0531 -0.445891,0 -0.445891,-0.66619 v -2.04366 h -0.260103 v -0.14863 l 0.254795,-0.0743 0.08228,-0.68476 h 0.175172 v 0.68476 h 0.456507 v 0.22295 h -0.456507 v 1.972 q 0,0.29196 0.0637,0.39812 0.0637,0.10616 0.222946,0.10616 z" />
       <path
-         id="path1585"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 95.047219,278.38136 v -2.64703 q 0,-0.52021 -0.138014,-0.73608 -0.134475,-0.2194 -0.442352,-0.2194 -0.406964,0 -0.612215,0.36096 -0.205252,0.36096 -0.205252,1.1395 v 2.10205 h -0.336187 v -5.5064 h 0.336187 v 1.78711 q 0,0.24418 -0.01416,0.40696 h 0.02831 q 0.113242,-0.28664 0.339726,-0.44235 0.230023,-0.15925 0.477741,-0.15925 0.488356,0 0.693608,0.3185 0.205251,0.31849 0.205251,0.9484 v 2.64703 z" />
+         id="path1520"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 78.462005,278.81662 v -1.98527 q 0,-0.39016 -0.103511,-0.55206 -0.100856,-0.16455 -0.331764,-0.16455 -0.305223,0 -0.459161,0.27072 -0.153939,0.27072 -0.153939,0.85462 v 1.57654 h -0.252141 v -4.1298 h 0.252141 v 1.34033 q 0,0.18314 -0.01062,0.30522 h 0.02123 q 0.08493,-0.21498 0.254794,-0.33176 0.172518,-0.11943 0.358306,-0.11943 0.366267,0 0.520206,0.23887 0.153938,0.23887 0.153938,0.7113 v 1.98527 z" />
       <path
-         id="path1587"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 97.489002,278.45214 q -0.608676,0 -0.937786,-0.51667 -0.325572,-0.5202 -0.325572,-1.44737 0,-0.98379 0.290184,-1.50046 0.293721,-0.52021 0.842238,-0.52021 0.477741,0 0.753768,0.45651 0.276028,0.45297 0.276028,1.22443 v 0.31142 H 96.56891 q 0.0071,0.8387 0.237101,1.25628 0.230023,0.41758 0.697147,0.41758 0.360959,0 0.760845,-0.2371 v 0.32557 q -0.368037,0.23002 -0.775001,0.23002 z m -0.152169,-3.68037 q -0.693608,0 -0.760846,1.38368 h 1.475687 q 0,-0.63345 -0.194635,-1.00857 -0.191096,-0.37511 -0.520206,-0.37511 z" />
+         id="path1522"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 80.293345,278.86971 q -0.456508,0 -0.70334,-0.3875 -0.244179,-0.39016 -0.244179,-1.08554 0,-0.73784 0.217637,-1.12534 0.220292,-0.39015 0.631679,-0.39015 0.358306,0 0.565326,0.34238 0.207021,0.33972 0.207021,0.91832 v 0.23356 h -1.364214 q 0.0053,0.62903 0.177826,0.94221 0.172517,0.31319 0.52286,0.31319 0.27072,0 0.570634,-0.17783 v 0.24418 q -0.276027,0.17252 -0.58125,0.17252 z m -0.114127,-2.76028 q -0.520206,0 -0.570635,1.03776 h 1.106766 q 0,-0.47509 -0.145977,-0.75643 -0.143322,-0.28133 -0.390154,-0.28133 z" />
       <path
-         id="path1589"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 101.58342,274.83901 h -0.6016 v 3.54235 h -0.33265 v -3.54235 h -0.48836 v -0.1911 l 0.48836,-0.14509 v -0.29018 q 0,-0.73254 0.1734,-1.05457 0.1734,-0.32203 0.6016,-0.32203 0.24772,0 0.44943,0.0885 l -0.11678,0.31141 q -0.18756,-0.0885 -0.33973,-0.0885 -0.1734,0 -0.26187,0.10263 -0.0885,0.10262 -0.13094,0.33265 -0.0425,0.23002 -0.0425,0.63698 v 0.32204 h 0.6016 z m 0.95902,3.54235 h -0.33619 v -3.83961 h 0.33619 z m -0.38574,-4.9048 q 0,-0.15924 0.0637,-0.24771 0.0672,-0.0885 0.16987,-0.0885 0.0955,0 0.15217,0.0885 0.0566,0.0885 0.0566,0.24771 0,0.15217 -0.0566,0.24418 -0.0566,0.0885 -0.15217,0.0885 -0.10263,0 -0.16987,-0.0885 -0.0637,-0.092 -0.0637,-0.24418 z" />
+         id="path1524"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 83.364153,276.15986 h -0.451199 v 2.65676 h -0.249487 v -2.65676 h -0.366268 v -0.14333 l 0.366268,-0.10881 v -0.21764 q 0,-0.5494 0.130051,-0.79093 0.130052,-0.24152 0.4512,-0.24152 0.185788,0 0.337072,0.0663 l -0.08759,0.23356 q -0.140668,-0.0663 -0.254795,-0.0663 -0.130051,0 -0.196404,0.077 -0.06635,0.077 -0.0982,0.24949 -0.03185,0.17251 -0.03185,0.47774 v 0.24152 h 0.451199 z m 0.719264,2.65676 h -0.25214 v -2.87971 h 0.25214 z m -0.289298,-3.6786 q 0,-0.11943 0.04777,-0.18578 0.05043,-0.0664 0.127398,-0.0664 0.07166,0 0.114126,0.0664 0.04247,0.0663 0.04247,0.18578 0,0.11413 -0.04247,0.18314 -0.04246,0.0663 -0.114126,0.0663 -0.07697,0 -0.127398,-0.0663 -0.04777,-0.069 -0.04777,-0.18314 z" />
       <path
-         id="path1591"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 103.91196,278.38136 h -0.33619 v -5.5064 h 0.33619 z" />
+         id="path1526"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 85.110558,278.81662 h -0.252141 v -4.1298 h 0.252141 z" />
       <path
-         id="path1593"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 106.02463,278.45214 q -0.60867,0 -0.93779,-0.51667 -0.32557,-0.5202 -0.32557,-1.44737 0,-0.98379 0.29019,-1.50046 0.29372,-0.52021 0.84224,-0.52021 0.47774,0 0.75376,0.45651 0.27603,0.45297 0.27603,1.22443 v 0.31142 h -1.81895 q 0.007,0.8387 0.2371,1.25628 0.23002,0.41758 0.69715,0.41758 0.36096,0 0.76084,-0.2371 v 0.32557 q -0.36803,0.23002 -0.775,0.23002 z m -0.15217,-3.68037 q -0.69361,0 -0.76084,1.38368 h 1.47568 q 0,-0.63345 -0.19463,-1.00857 -0.1911,-0.37511 -0.52021,-0.37511 z" />
+         id="path1528"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 86.695065,278.86971 q -0.456508,0 -0.70334,-0.3875 -0.244179,-0.39016 -0.244179,-1.08554 0,-0.73784 0.217637,-1.12534 0.220292,-0.39015 0.631679,-0.39015 0.358306,0 0.565326,0.34238 0.207021,0.33972 0.207021,0.91832 v 0.23356 h -1.364214 q 0.0053,0.62903 0.177826,0.94221 0.172517,0.31319 0.52286,0.31319 0.27072,0 0.570634,-0.17783 v 0.24418 q -0.276027,0.17252 -0.58125,0.17252 z m -0.114127,-2.76028 q -0.520206,0 -0.570635,1.03776 h 1.106766 q 0,-0.47509 -0.145977,-0.75643 -0.143322,-0.28133 -0.390154,-0.28133 z" />
       <path
-         id="path1595"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 110.64633,277.41881 q 0,0.48481 -0.2548,0.76084 -0.25479,0.27249 -0.73607,0.27249 -0.26187,0 -0.46005,-0.0672 -0.19817,-0.0672 -0.30787,-0.14863 v -0.39281 q 0.13093,0.13094 0.3468,0.21233 0.21587,0.0779 0.44235,0.0779 0.29726,0 0.46713,-0.19464 0.16986,-0.19463 0.16986,-0.5202 0,-0.2548 -0.12386,-0.4282 -0.12032,-0.17694 -0.46358,-0.39989 -0.39281,-0.24771 -0.5379,-0.39635 -0.14156,-0.14863 -0.22295,-0.33264 -0.0778,-0.18402 -0.0778,-0.43882 0,-0.41404 0.27956,-0.68299 0.27957,-0.27249 0.71131,-0.27249 0.46358,0 0.775,0.21941 l -0.17341,0.29372 q -0.29018,-0.19463 -0.61575,-0.19463 -0.29726,0 -0.4742,0.17694 -0.17694,0.1734 -0.17694,0.46004 0,0.2548 0.12032,0.4282 0.12032,0.16986 0.50959,0.41404 0.38219,0.25126 0.52374,0.40343 0.14156,0.14863 0.20879,0.33265 0.0708,0.18047 0.0708,0.41758 z" />
+         id="path1530"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 90.161336,278.09471 q 0,0.36361 -0.191097,0.57063 -0.191096,0.20437 -0.552055,0.20437 -0.196404,0 -0.345035,-0.0504 -0.14863,-0.0504 -0.230908,-0.11147 v -0.29461 q 0.0982,0.0982 0.260104,0.15925 0.1619,0.0584 0.331764,0.0584 0.222945,0 0.350343,-0.14598 0.127397,-0.14598 0.127397,-0.39015 0,-0.1911 -0.09289,-0.32115 -0.09024,-0.13271 -0.347689,-0.29992 -0.294606,-0.18578 -0.403425,-0.29726 -0.106164,-0.11147 -0.167209,-0.24948 -0.05839,-0.13802 -0.05839,-0.32911 0,-0.31054 0.209675,-0.51225 0.209675,-0.20436 0.533477,-0.20436 0.347689,0 0.581251,0.16455 l -0.130052,0.22029 q -0.217637,-0.14597 -0.461815,-0.14597 -0.222946,0 -0.355652,0.1327 -0.132705,0.13005 -0.132705,0.34504 0,0.19109 0.09024,0.32114 0.09024,0.1274 0.382192,0.31053 0.286644,0.18845 0.392809,0.30257 0.106164,0.11148 0.156592,0.24949 0.05308,0.13536 0.05308,0.31319 z" />
       <path
-         id="path1597"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 111.89907,278.37429 -0.95902,-3.83254 h 0.33972 l 0.58037,2.39578 q 0.10263,0.43173 0.19817,0.97317 h 0.0283 q 0.0672,-0.47066 0.18756,-0.98025 l 0.56621,-2.3887 h 0.33973 l -1.12181,4.56507 q -0.12385,0.50605 -0.32557,0.76085 -0.19817,0.25479 -0.53082,0.25479 -0.13447,0 -0.30434,-0.0602 v -0.30434 q 0.14155,0.0495 0.27603,0.0495 0.21233,0 0.33619,-0.18402 0.12386,-0.18048 0.2194,-0.58391 z" />
+         id="path1532"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 91.10089,278.81132 -0.719264,-2.87441 h 0.254795 l 0.435274,1.79684 q 0.07697,0.3238 0.148631,0.72988 h 0.02123 q 0.05043,-0.353 0.140668,-0.73519 l 0.424659,-1.79153 h 0.254794 l -0.841353,3.42381 q -0.09289,0.37954 -0.244179,0.57063 -0.14863,0.1911 -0.398117,0.1911 -0.100856,0 -0.228254,-0.0451 v -0.22826 q 0.106165,0.0372 0.207021,0.0372 0.159247,0 0.252141,-0.13801 0.09289,-0.13536 0.164555,-0.43793 z" />
       <path
-         id="path1599"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 115.23264,277.41881 q 0,0.48481 -0.2548,0.76084 -0.25479,0.27249 -0.73607,0.27249 -0.26187,0 -0.46005,-0.0672 -0.19817,-0.0672 -0.30788,-0.14863 v -0.39281 q 0.13094,0.13094 0.34681,0.21233 0.21587,0.0779 0.44235,0.0779 0.29726,0 0.46712,-0.19464 0.16987,-0.19463 0.16987,-0.5202 0,-0.2548 -0.12386,-0.4282 -0.12032,-0.17694 -0.46359,-0.39989 -0.3928,-0.24771 -0.5379,-0.39635 -0.14155,-0.14863 -0.22294,-0.33264 -0.0779,-0.18402 -0.0779,-0.43882 0,-0.41404 0.27957,-0.68299 0.27957,-0.27249 0.7113,-0.27249 0.46359,0 0.775,0.21941 l -0.1734,0.29372 q -0.29018,-0.19463 -0.61575,-0.19463 -0.29726,0 -0.4742,0.17694 -0.17694,0.1734 -0.17694,0.46004 0,0.2548 0.12032,0.4282 0.12031,0.16986 0.50958,0.41404 0.3822,0.25126 0.52375,0.40343 0.14155,0.14863 0.20879,0.33265 0.0708,0.18047 0.0708,0.41758 z" />
+         id="path1534"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 93.601067,278.09471 q 0,0.36361 -0.191096,0.57063 -0.191096,0.20437 -0.552055,0.20437 -0.196405,0 -0.345035,-0.0504 -0.14863,-0.0504 -0.230908,-0.11147 v -0.29461 q 0.0982,0.0982 0.260103,0.15925 0.161901,0.0584 0.331764,0.0584 0.222946,0 0.350343,-0.14598 0.127398,-0.14598 0.127398,-0.39015 0,-0.1911 -0.09289,-0.32115 -0.09024,-0.13271 -0.347689,-0.29992 -0.294607,-0.18578 -0.403425,-0.29726 -0.106165,-0.11147 -0.167209,-0.24948 -0.05839,-0.13802 -0.05839,-0.32911 0,-0.31054 0.209675,-0.51225 0.209675,-0.20436 0.533477,-0.20436 0.347689,0 0.58125,0.16455 l -0.130051,0.22029 q -0.217637,-0.14597 -0.461816,-0.14597 -0.222945,0 -0.355651,0.1327 -0.132706,0.13005 -0.132706,0.34504 0,0.19109 0.09024,0.32114 0.09024,0.1274 0.382193,0.31053 0.286644,0.18845 0.392808,0.30257 0.106165,0.11148 0.156593,0.24949 0.05308,0.13536 0.05308,0.31319 z" />
       <path
-         id="path1601"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 116.70832,278.14072 q 0.15571,0 0.27603,-0.0425 v 0.2831 q -0.15571,0.0708 -0.39989,0.0708 -0.59452,0 -0.59452,-0.88824 v -2.72489 h -0.3468 v -0.19818 l 0.33972,-0.0991 0.10971,-0.91302 h 0.23356 v 0.91302 h 0.60867 v 0.29726 h -0.60867 v 2.62934 q 0,0.38927 0.0849,0.53082 0.0849,0.14155 0.29726,0.14155 z" />
+         id="path1536"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 94.707831,278.63614 q 0.116781,0 0.207021,-0.0318 v 0.21232 q -0.116781,0.0531 -0.299915,0.0531 -0.445891,0 -0.445891,-0.66619 v -2.04366 h -0.260103 v -0.14863 l 0.254795,-0.0743 0.08228,-0.68476 h 0.175172 v 0.68476 h 0.456507 v 0.22295 h -0.456507 v 1.972 q 0,0.29196 0.0637,0.39812 0.0637,0.10616 0.222945,0.10616 z" />
       <path
-         id="path1603"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 118.67944,278.45214 q -0.60867,0 -0.93778,-0.51667 -0.32557,-0.5202 -0.32557,-1.44737 0,-0.98379 0.29018,-1.50046 0.29372,-0.52021 0.84224,-0.52021 0.47774,0 0.75377,0.45651 0.27602,0.45297 0.27602,1.22443 v 0.31142 h -1.81895 q 0.007,0.8387 0.2371,1.25628 0.23002,0.41758 0.69715,0.41758 0.36096,0 0.76084,-0.2371 v 0.32557 q -0.36803,0.23002 -0.775,0.23002 z m -0.15217,-3.68037 q -0.6936,0 -0.76084,1.38368 h 1.47569 q 0,-0.63345 -0.19464,-1.00857 -0.1911,-0.37511 -0.52021,-0.37511 z" />
+         id="path1538"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 96.186174,278.86971 q -0.456507,0 -0.70334,-0.3875 -0.244178,-0.39016 -0.244178,-1.08554 0,-0.73784 0.217637,-1.12534 0.220292,-0.39015 0.631679,-0.39015 0.358306,0 0.565326,0.34238 0.207021,0.33972 0.207021,0.91832 v 0.23356 h -1.364214 q 0.0053,0.62903 0.177826,0.94221 0.172517,0.31319 0.52286,0.31319 0.270719,0 0.570634,-0.17783 v 0.24418 q -0.276028,0.17252 -0.581251,0.17252 z m -0.114126,-2.76028 q -0.520207,0 -0.570635,1.03776 h 1.106765 q 0,-0.47509 -0.145976,-0.75643 -0.143322,-0.28133 -0.390154,-0.28133 z" />
       <path
-         id="path1605"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
-         d="m 123.69749,278.38136 v -2.61518 q 0,-0.9661 -0.56621,-0.9661 -0.38927,0 -0.56267,0.33973 -0.16987,0.33618 -0.16987,0.9944 v 2.24715 h -0.33265 v -2.61518 q 0,-0.48836 -0.13801,-0.72546 -0.13801,-0.24064 -0.4282,-0.24064 -0.38219,0 -0.55559,0.3468 -0.1734,0.34681 -0.1734,1.12535 v 2.10913 h -0.33619 v -3.83961 h 0.2831 l 0.0283,0.53436 h 0.0318 q 0.23003,-0.60868 0.78208,-0.60868 0.3185,0 0.50251,0.16987 0.18402,0.16986 0.26542,0.49543 0.13801,-0.35388 0.33972,-0.50959 0.20172,-0.15571 0.52375,-0.15571 0.43527,0 0.63698,0.33619 0.20172,0.33265 0.20172,1.06872 v 2.50902 z" />
+         id="path1540"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
+         d="m 99.949707,278.81662 v -1.96139 q 0,-0.72457 -0.424658,-0.72457 -0.291952,0 -0.422004,0.2548 -0.127397,0.25214 -0.127397,0.7458 v 1.68536 h -0.249487 v -1.96139 q 0,-0.36626 -0.10351,-0.54409 -0.103511,-0.18048 -0.321148,-0.18048 -0.286644,0 -0.416696,0.2601 -0.130051,0.26011 -0.130051,0.84401 v 1.58185 h -0.252141 v -2.87971 h 0.212329 l 0.02123,0.40077 h 0.02389 q 0.172517,-0.4565 0.586559,-0.4565 0.23887,0 0.376884,0.12739 0.138014,0.1274 0.199058,0.37158 0.103511,-0.26541 0.254795,-0.38219 0.151285,-0.11678 0.392809,-0.11678 0.326456,0 0.477741,0.25214 0.15128,0.24948 0.15128,0.80154 v 1.88176 z" />
     </g>
     <g
-       transform="matrix(1.2840056,0,0,1.2840056,-8.327001,-30.150376)"
+       transform="matrix(0.64577417,0,0,0.64577417,34.790784,91.314937)"
        id="g8110">
       <path
          id="rect815"
@@ -1214,15 +1210,15 @@ project in the file system">
          style="font-style:normal;font-weight:normal;font-size:10.58333302px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#fbbf24;fill-opacity:1;stroke:none;stroke-width:0.26458332"
          aria-label="CLI">
         <path
-           id="path1609"
+           id="path1544"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#fbbf24;fill-opacity:1;stroke-width:0.26458332"
            d="m 104.1931,131.65502 v 0.60634 q -1.01561,0.14653 -1.82406,0.14653 -1.07625,0 -1.73817,-0.51539 -0.656862,-0.52044 -0.889291,-1.40468 -0.156637,-0.61644 -0.156637,-1.71795 0,-1.10152 0.156637,-1.71796 0.237482,-0.88929 0.874131,-1.40468 0.63666,-0.51539 1.7028,-0.51539 0.80845,0 1.72301,0.14654 v 0.60633 q -0.94993,-0.14653 -1.72301,-0.14653 -1.56637,0 -1.94533,1.45521 -0.14148,0.55076 -0.14148,1.57648 0,1.02572 0.14148,1.57647 0.38907,1.45521 1.99586,1.45521 0.77308,0 1.82406,-0.14653 z" />
         <path
-           id="path1611"
+           id="path1546"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#fbbf24;fill-opacity:1;stroke-width:0.26458332"
            d="m 105.48157,132.32704 v -7.11435 h 0.64676 v 6.50801 h 3.23379 v 0.60634 z" />
         <path
-           id="path1613"
+           id="path1548"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:7.76111126px;font-family:'Monoid Nerd Font';-inkscape-font-specification:'Monoid Nerd Font';fill:#fbbf24;fill-opacity:1;stroke-width:0.26458332"
            d="m 113.88438,125.21269 v 0.60634 h -1.29351 v 5.90167 h 1.29351 v 0.60634 h -3.23379 v -0.60634 h 1.29352 v -5.90167 h -1.29352 v -0.60634 z" />
       </g>

--- a/docs/gfx/api.svg
+++ b/docs/gfx/api.svg
@@ -9,9 +9,9 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="200mm"
-   height="158.41367mm"
-   viewBox="0 0 199.99999 158.41367"
+   width="150mm"
+   height="112.4319mm"
+   viewBox="0 0 149.99999 112.4319"
    version="1.1"
    id="svg8"
    inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
@@ -319,15 +319,15 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="1.4"
-     inkscape:cx="166.64994"
-     inkscape:cy="268.59008"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="-59.344296"
+     inkscape:cy="196.70216"
      inkscape:document-units="mm"
-     inkscape:current-layer="layer1"
+     inkscape:current-layer="g7801"
      showgrid="false"
-     inkscape:window-width="2560"
-     inkscape:window-height="1387"
-     inkscape:window-x="1072"
+     inkscape:window-width="1080"
+     inkscape:window-height="1867"
+     inkscape:window-x="-8"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
      fit-margin-top="0"
@@ -342,7 +342,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -350,10 +350,10 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(-28.706368,-121.7088)">
+     transform="translate(-28.706368,-167.69056)">
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM)"
-       d="m 188.76319,177.55051 c -8.13331,-0.1585 -20.51322,1.86695 -20.76003,9.35231"
+       style="fill:none;stroke:#000000;stroke-width:0.57780254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#TriangleOutM)"
+       d="m 148.74898,203.1935 c -6.09998,-0.11888 -15.38491,1.40021 -15.57002,7.01423"
        id="path1020"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
@@ -361,11 +361,11 @@
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
        id="path4374"
-       d="m 188.76319,217.54896 c -8.13331,0.1585 -20.51322,-1.86695 -20.76003,-9.35231"
-       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4378)" />
+       d="m 148.74898,233.19234 c -6.09998,0.11887 -15.38491,-1.40022 -15.57002,-7.01424"
+       style="fill:none;stroke:#000000;stroke-width:0.57780254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4378)" />
     <g
        id="g8257"
-       transform="matrix(1.2840056,0,0,1.2840056,-6.5798686,-79.556336)">
+       transform="matrix(0.96300419,0,0,0.96300419,2.241691,10.363368)">
       <rect
          style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#005ca0;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
          id="rect827"
@@ -399,7 +399,7 @@
     </g>
     <g
        id="g864"
-       transform="matrix(1.2840056,0,0,1.2840056,-234.7989,-23.653332)">
+       transform="matrix(0.96300419,0,0,0.96300419,-168.92258,52.29062)">
       <rect
          style="fill:#dbe9fe;fill-opacity:1;fill-rule:nonzero;stroke:#3b82f6;stroke-width:0.60000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
          id="rect821"
@@ -422,7 +422,7 @@
     </g>
     <g
        id="g1005"
-       transform="matrix(1.2840056,0,0,1.2840056,178.45418,-55.047496)">
+       transform="matrix(0.96300419,0,0,0.96300419,141.01723,28.744998)">
       <g
          id="g993">
         <g
@@ -479,7 +479,7 @@
     </g>
     <g
        id="g1018"
-       transform="matrix(1.2840056,0,0,1.2840056,170.32501,-55.53282)">
+       transform="matrix(0.96300419,0,0,0.96300419,134.92035,28.381005)">
       <g
          id="g984">
         <g
@@ -544,14 +544,14 @@
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
        id="path4778"
-       d="m 128.72091,147.80019 v 39.29677"
-       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4782)" />
+       d="m 103.71727,180.88076 v 29.47258"
+       style="fill:none;stroke:#000000;stroke-width:0.57780254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker4782)" />
     <g
        id="g6777"
-       transform="matrix(1.2840056,0,0,1.2840056,-56.685115,-0.73911601)" />
+       transform="matrix(0.96300419,0,0,0.96300419,-35.337243,69.476282)" />
     <g
        id="g12869"
-       transform="matrix(1.2840056,0,0,1.2840056,-8.152768,-79.556336)">
+       transform="matrix(0.96300419,0,0,0.96300419,1.0620165,10.363368)">
       <rect
          ry="2.0408826"
          y="210.24072"
@@ -573,7 +573,7 @@
            style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:4.93888903px;font-family:'Fira Code';-inkscape-font-specification:'Fira Code, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:0.26458332">{}</tspan></text>
     </g>
     <g
-       transform="matrix(1.2840056,0,0,1.2840056,-282.72951,-12.694343)"
+       transform="matrix(0.96300419,0,0,0.96300419,-204.87054,60.509862)"
        id="g9228">
       <text
          id="text8853"
@@ -600,7 +600,7 @@
     </g>
     <g
        id="g7801"
-       transform="matrix(1.2840056,0,0,1.2840056,-105.16895,-147.0163)">
+       transform="matrix(0.96300419,0,0,0.96300419,-71.700119,-40.231605)">
       <rect
          ry="2.0408826"
          y="289.61523"
@@ -619,11 +619,11 @@
            x="156.08075"
            sodipodi:role="line"
            id="tspan975-2"
-           style="text-align:center;text-anchor:middle;stroke-width:0.26458332">Actions Pipeline</tspan></text>
+           style="text-align:center;text-anchor:middle;stroke-width:0.26458332">Action Pipeline</tspan></text>
     </g>
     <path
-       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker6805-2)"
-       d="m 72.216799,204.80631 v 17.55427"
+       style="fill:none;stroke:#000000;stroke-width:0.57780254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker6805-2)"
+       d="m 61.339191,223.63535 v 13.1657"
        id="path7645-9"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
@@ -631,44 +631,44 @@
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
        id="path7647-9"
-       d="m 117.84961,204.80631 v 17.55427"
-       style="fill:none;stroke:#000000;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker7249-4)" />
+       d="m 95.563799,223.63535 v 13.1657"
+       style="fill:none;stroke:#000000;stroke-width:0.57780254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker7249-4)" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:7.24749851px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.33972648"
-       x="148.12695"
-       y="157.2601"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.43562365px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.25479487"
+       x="118.2718"
+       y="187.97569"
        id="text973-5-6"><tspan
-         style="text-align:center;text-anchor:middle;stroke-width:0.33972648"
+         style="text-align:center;text-anchor:middle;stroke-width:0.25479487"
          sodipodi:role="line"
-         x="148.12695"
-         y="157.2601"
+         x="118.2718"
+         y="187.97569"
          id="tspan7982">User's Options</tspan></text>
     <path
-       style="fill:none;stroke:#be185d;stroke-width:0.77040339;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.7704034, 0.7704034;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker8419)"
-       d="M 95.067976,239.47786 V 259.2161"
+       style="fill:none;stroke:#be185d;stroke-width:0.57780254;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:0.57780254, 0.57780254;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#marker8419)"
+       d="m 78.477573,249.63901 v 14.80368"
        id="path8415"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cc" />
     <text
        id="text8741"
-       y="269.32199"
-       x="96.197334"
-       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:7.24749851px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#be185d;fill-opacity:1;stroke:none;stroke-width:0.33972648"
+       y="272.02209"
+       x="79.324593"
+       style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:condensed;font-size:5.43562365px;line-height:1.25;font-family:'Open Sans Condensed Light';-inkscape-font-specification:'Open Sans Condensed Light, Light Condensed';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#be185d;fill-opacity:1;stroke:none;stroke-width:0.25479487"
        xml:space="preserve"><tspan
          id="tspan8739"
-         y="269.32199"
-         x="96.197334"
+         y="272.02209"
+         x="79.324593"
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648">Created/updated</tspan><tspan
-         y="278.38138"
-         x="96.197334"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487">Created/updated</tspan><tspan
+         y="278.81662"
+         x="79.324593"
          sodipodi:role="line"
-         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.33972648"
+         style="text-align:center;text-anchor:middle;fill:#be185d;fill-opacity:1;stroke-width:0.25479487"
          id="tspan8743">project in the file system</tspan></text>
     <g
        id="g8110"
-       transform="matrix(1.2840056,0,0,1.2840056,-8.327001,-30.150376)">
+       transform="matrix(0.64577417,0,0,0.64577417,34.790784,91.314937)">
       <rect
          ry="3.7417734"
          y="118.76987"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,13 +29,19 @@ Contents
 .. toctree::
    :maxdepth: 2
 
-   Why PyScaffold? <reasons>
-   Features <features>
    Installation <install>
    Usage & Examples <usage>
    Advanced Usage & Features <advanced>
+   Why PyScaffold? <reasons>
+   Features <features>
    FAQ <faq>
+
+.. toctree::
+   :caption: Project
+   :maxdepth: 2
+
    Contributions & Help <contributing>
+   Developer Guide <dev-guide>
    Contributors <contributors>
    Changelog <changelog>
    License <license>

--- a/docs/project-structure.rst
+++ b/docs/project-structure.rst
@@ -22,10 +22,12 @@ The first entry is a file named ``file.txt`` with content ``Hello World!``
 while the second entry is a sub-directory named ``another-folder``. Finally,
 ``another-folder`` contains an empty file named ``empty-file.txt``.
 
-.. versionchanged:: 4.0
-    Prior to version 4.0, the project structure included the top level
-    directory of the project. Now it considers everything **under** the
-    project folder.
+.. note::
+
+   .. versionchanged:: 4.0
+       Prior to version 4.0, the project structure included the top level
+       directory of the project. Now it considers everything **under** the
+       project folder.
 
 Additionally, tuple values are also allowed in order to specify a
 **file operation** (or simply **file op**) that will be used to produce the file.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,9 +3,9 @@ appdirs
 configupdater
 furo
 packaging
+Pillow
 setuptools>=38.3
 setuptools_scm
 sphinx>=3.2.1
 sphinx-copybutton
-sphinx_rtd_theme
 tomlkit

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,4 +8,5 @@ setuptools>=38.3
 setuptools_scm
 sphinx>=3.2.1
 sphinx-copybutton
+sphinxemoji
 tomlkit

--- a/src/pyscaffold/structure.py
+++ b/src/pyscaffold/structure.py
@@ -137,6 +137,7 @@ def define_structure(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
         "AUTHORS.rst": (get_template("authors"), NO_OVERWRITE),
         "LICENSE.txt": (templates.license, NO_OVERWRITE),
         "CHANGELOG.rst": (get_template("changelog"), NO_OVERWRITE),
+        "CONTRIBUTING.rst": (get_template("contributing"), NO_OVERWRITE),
         # Code
         "src": {
             opts["package"]: {
@@ -153,6 +154,7 @@ def define_structure(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
         "docs": {
             "conf.py": get_template("sphinx_conf"),
             "authors.rst": get_template("sphinx_authors"),
+            "contributing.rst": get_template("sphinx_contributing"),
             "index.rst": (get_template("sphinx_index"), NO_OVERWRITE),
             "readme.rst": get_template("sphinx_readme"),
             "license.rst": get_template("sphinx_license"),

--- a/src/pyscaffold/templates/contributing.template
+++ b/src/pyscaffold/templates/contributing.template
@@ -1,0 +1,352 @@
+.. todo:: THIS IS SUPPOSED TO BE AN EXAMPLE. MODIFY IT ACCORDING TO YOUR NEEDS!
+
+   The document assumes you are using a source repository service that promotes a
+   contribution model similar to `GitHub's fork and pull request workflow`_.
+   While this is true for the majority of services (like GitHub, GitLab,
+   BitBucket), it might not be the case for private repositories (e.g., Gerrit).
+
+   Also notice that the code examples might refer to GitHub URLs or the text
+   might use GitHub specific terminology (e.g., *Pull Request* instead of *Merge
+   Request*).
+
+   Please make sure to check the document having this assumptions in mind
+   and update things accordingly.
+
+.. todo:: Provide the correct links/replacements at the bottom of the document.
+
+.. todo:: You might want to have a look on `PyScaffold's contributor's guide`_,
+
+   especially if your project is open source. The text should be very similar to
+   this template, but there are a few extra contents that you might decide to
+   also include, like mentioning labels of you issue tracker or automated
+   releases.
+
+
+============
+Contributing
+============
+
+Welcome to ``${name}`` contributor's guide.
+
+This document focuses on getting any potential contributor familiarized
+with the development processes, but `other kinds of contributions`_ are also
+appreciated.
+
+If are new to using git_ or have never collaborated in a project previously,
+please have a look at `contribution-guide.org`_. Other resources are also
+listed in the excellent `guide created by FreeCodeCamp`_ [#contrib1]_.
+
+Please notice, all users and contributors are expected to be **open,
+considerate, reasonable, and respectful**. When in doubt, `Python Software
+Foundation's Code of Conduct`_ is a good reference in terms of behavior
+guidelines.
+
+
+Issue Reports
+=============
+
+If you experience bugs or in general issues with ``${name}``, please have a look
+on the `issue tracker`_. If you don't see anything useful there, please feel
+free to fire an issue report.
+
+.. tip::
+   Please don't forget to include the closed issues in your search.
+   Sometimes a solution was already reported, and the problem is considered
+   **solved**.
+
+New issue reports should include information about your programming environment
+(e.g., operating system, Python version) and steps to reproduce the problem.
+Please try also to simplify the reproduction steps to a very minimal example
+that still illustrates the problem you are facing. By removing other factors,
+you help us to identify the root cause of the issue.
+
+
+Documentation Improvements
+==========================
+
+You can help improve ``${name}`` docs by making them more readable and coherent, or
+by adding missing information and correcting mistakes.
+
+``${name}`` documentation uses Sphinx_ as its main documentation compiler.
+This means that the docs are kept in the same repository as the project code, and
+that any documentation update is done in the same way was a code contribution.
+
+.. todo:: Don't forget to mention which markup language you are using.
+
+    e.g.,  reStructuredText_ or CommonMark_ with MyST_ extensions.
+
+.. todo:: If your project is hosted on GitHub, you can also mention the following tip:
+
+   .. tip::
+      Please notice that the `GitHub web interface`_ provides a quick way of
+      propose changes in ``${name}``'s files. While this mechanism can
+      be tricky for normal code contributions, it works perfectly fine for
+      contributing to the docs, and can be quite handy.
+
+      If you are interested in trying this method out, please navigate to
+      the ``docs`` folder in the source repository_, find which file you
+      would like to propose changes and click in the little pencil icon at the
+      top, to open `GitHub's code editor`_. Once you finish editing the file,
+      please write a message in the form at the bottom of the page describing
+      which changes have you made and what are the motivations behind them and
+      submit your proposal.
+
+When working on documentation changes in your local machine, you can
+compile them using |tox|_::
+
+    tox -e docs
+
+and use Python's built-in web server for a preview in your web browser
+(``http://localhost:8000``)::
+
+    python3 -m http.server --directory 'docs/_build/html'
+
+
+Code Contributions
+==================
+
+.. todo:: Please include a reference or explanation about the internals of the project.
+
+   An architecture description, design principles or at least a summary of the
+   main concepts will make it easy for potential contributors to get started
+   quickly.
+
+Submit an issue
+---------------
+
+Before you work on any non-trivial code contribution it's best to first create
+a report in the `issue tracker`_ to start a discussion on the subject.
+This often provides additional considerations and avoids unnecessary work.
+
+Create an environment
+---------------------
+
+Before you start coding, we recommend creating an isolated `virtual
+environment`_ to avoid any problems with your installed Python packages.
+This can easily be done via either |virtualenv|_::
+
+    virtualenv <PATH TO VENV>
+    source <PATH TO VENV>/bin/activate
+
+or Miniconda_::
+
+    conda create -n pyscaffold python=3 six virtualenv pytest pytest-cov
+    conda activate pyscaffold
+
+Clone the repository
+--------------------
+
+#. Create an user account on |the repository service| if you do not already have one.
+#. Fork the project repository_: click on the *Fork* button near the top of the
+   page. This creates a copy of the code under your account on |the repository service|.
+#. Clone this copy to your local disk::
+
+    git clone git@github.com:YourLogin/${name}.git
+    cd ${name}
+
+#. You should run::
+
+    pip install -U pip setuptools -e .
+
+   to be able run ``putup --help``.
+
+   .. todo:: if you are not using pre-commit, please remove the following item:
+
+#. Install |pre-commit|_::
+
+    pip install pre-commit
+    pre-commit install
+
+   ``${name}`` comes with a lot of hooks configured to automatically help the
+   developer to check the code being written.
+
+Implement your changes
+----------------------
+
+#. Create a branch to hold your changes::
+
+    git checkout -b my-feature
+
+   and start making changes. Never work on the master branch!
+
+#. Start your work on this branch. Don't forget to add docstrings_ to new
+   functions, modules and classes, especially if they are part of public APIs.
+
+#. Add yourself to the list of contributors in ``AUTHORS.rst``.
+
+#. When you’re done editing, do::
+
+    git add <MODIFIED FILES>
+    git commit
+
+   to record your changes in git_.
+
+   .. todo:: if you are not using pre-commit, please remove the following item:
+
+   Please make sure to see the validation messages from |pre-commit|_ and fix
+   any eventual issues.
+   This should automatically use flake8_/black_ to check/fix the code style
+   in a way that is compatible with the project.
+
+   .. important:: Don't forget to add unit tests and documentation in case your
+      contribution adds an additional feature and is not just a bugfix.
+
+      Moreover, writing a `descriptive commit message`_ is highly recommended.
+      In case of doubt, you can check the commit history with::
+
+         git log --graph --decorate --pretty=oneline --abbrev-commit --all
+
+      to check for recurring communication patterns.
+
+#. Please check that your changes don't break any unit tests with::
+
+    tox
+
+   (after having installed |tox|_ with ``pip install tox`` or ``pipx``).
+
+   You can also use |tox|_ to run several other pre-configured tasks in the
+   repository. Try ``tox -av`` to see a list of the available checks.
+
+Submit your contribution
+------------------------
+
+#. If everything works fine, push your local branch to |the repository service| with::
+
+    git push -u origin my-feature
+
+#. Go to the web page of your fork and click |contribute button|
+   to send your changes for review.
+
+   .. todo:: if you are using GitHub, you can uncomment the following paragraph
+
+      Find more detailed information `creating a PR`_. You might also want to open
+      the PR as a draft first and mark it as ready for review after the feedbacks
+      from the continuous integration (CI) system or any required fixes.
+
+
+Troubleshooting
+---------------
+
+The following tips can be used when facing problems to build or test the
+package:
+
+#. Make sure to fetch all the tags from the upstream repository_.
+   The command ``git describe --abbrev=0 --tags`` should return the version you
+   are expecting. If you are trying to run CI scripts in a fork repository,
+   make sure to push all the tags.
+   You can also try to remove all the egg files or the complete egg folder, i.e.,
+   ``.eggs``, as well as the ``*.egg-info`` folders in the ``src`` folder or
+   potentially in the root of your project.
+
+#. Sometimes |tox|_ misses out when new dependencies are added, especially to
+   ``setup.cfg`` and ``docs/requirements.txt``. If you find any problems with
+   missing dependencies when running a command with |tox|_, try to recreate the
+   ``tox`` environment using the ``-r`` flag. For example, instead of::
+
+    tox -e docs
+
+   Try running::
+
+    tox -r -e docs
+
+#. Make sure to have a reliable |tox|_ installation that uses the correct
+   Python version (e.g., 3.7+). When in doubt you can run::
+
+    tox --version
+    # OR
+    which tox
+
+   If you have trouble and are seeing weird errors upon running |tox|_, you can
+   also try to create a dedicated `virtual environment`_ with a |tox|_ binary
+   freshly installed. For example::
+
+    virtualenv .venv
+    source .venv/bin/activate
+    .venv/bin/pip install tox
+    .venv/bin/tox -e all
+
+#. `Pytest can drop you`_ in an interactive session in the case an error occurs.
+   In order to do that you need to pass a ``--pdb`` option (for example by
+   running ``tox -- -k <NAME OF THE FALLING TEST> --pdb``).
+   You can also setup breakpoints manually instead of using the ``--pdb`` option.
+
+
+Maintainer tasks
+================
+
+Releases
+--------
+
+.. todo:: This section assumes you are using PyPI to publicly release your package.
+
+   If instead you are using a different/private package index, please update
+   the instructions accordingly.
+
+If you are part of the group of maintainers and have correct user permissions
+on PyPI_, the following steps can be used to release a new version for
+``${name}``:
+
+#. Make sure all unit tests are successful.
+#. Tag the current commit on the main branch with a release tag, e.g., ``v1.2.3``.
+#. Push the new tag to the upstream repository_, e.g., ``git push upstream v1.2.3``
+#. Clean up the ``dist`` and ``build`` folders with ``tox -e clean``
+   (or ``rm -rf dist build``)
+   to avoid confusion with old builds and Sphinx docs.
+#. Run ``tox -e build`` and check that the files in ``dist`` have
+   the correct version (no ``.dirty`` or git_ hash) according to the git_ tag.
+   Also check the sizes of the distributions, if they are too big (e.g., >
+   500KB), unwanted clutter may have been accidentally included.
+#. Run ``tox -e publish -- --repository pypi`` and check that everything was
+   uploaded to PyPI_ correctly.
+
+
+
+.. [#contrib1] Even though, these resources focus on open source projects and
+   communities, the general ideas behind collaborating with other developers
+   to collectively create software are general and can be applied to all sorts
+   of environments, including private companies and proprietary code bases.
+
+
+.. <-- strart -->
+.. todo:: Please review and change the following definitions:
+
+.. |the repository service| replace:: GitHub
+.. |contribute button| replace:: "Create pull request"
+
+.. _repository: https://github.com/<USERNAME>/${name}
+.. _issue tracker: https://github.com/<USERNAME>/${name}/issues
+.. <-- end -->
+
+
+.. |virtualenv| replace:: ``virtualenv``
+.. |pre-commit| replace:: ``pre-commit``
+.. |tox| replace:: ``tox``
+
+
+.. _black: https://pypi.org/project/black/
+.. _CommonMark: https://commonmark.org/
+.. _contribution-guide.org: http://www.contribution-guide.org/
+.. _creating a PR: https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
+.. _descriptive commit message: https://chris.beams.io/posts/git-commit
+.. _docstrings: https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
+.. _first-contributions tutorial: https://github.com/firstcontributions/first-contributions
+.. _flake8: https://flake8.pycqa.org/en/stable/
+.. _git: https://git-scm.com
+.. _GitHub's fork and pull request workflow: https://guides.github.com/activities/forking/
+.. _guide created by FreeCodeCamp: https://github.com/FreeCodeCamp/how-to-contribute-to-open-source
+.. _Miniconda: https://docs.conda.io/en/latest/miniconda.html
+.. _MyST: https://myst-parser.readthedocs.io/en/latest/syntax/syntax.html
+.. _other kinds of contributions: https://opensource.guide/how-to-contribute
+.. _pre-commit: https://pre-commit.com/
+.. _PyPI: https://pypi.org/
+.. _PyScaffold's contributor's guide: https://pyscaffold.org/en/stable/contributing.html
+.. _Pytest can drop you: https://docs.pytest.org/en/stable/usage.html#dropping-to-pdb-python-debugger-at-the-start-of-a-test
+.. _Python Software Foundation's Code of Conduct: https://www.python.org/psf/conduct/
+.. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/
+.. _Sphinx: https://www.sphinx-doc.org/en/master/
+.. _tox: https://tox.readthedocs.io/en/stable/
+.. _virtual environment: https://realpython.com/python-virtual-environments-a-primer/
+.. _virtualenv: https://virtualenv.pypa.io/en/stable/
+
+.. _GitHub web interface: https://docs.github.com/en/github/managing-files-in-a-repository/managing-files-on-github/editing-files-in-your-repository
+.. _GitHub's code editor: https://docs.github.com/en/github/managing-files-in-a-repository/managing-files-on-github/editing-files-in-your-repository

--- a/src/pyscaffold/templates/contributing.template
+++ b/src/pyscaffold/templates/contributing.template
@@ -3,13 +3,14 @@
    The document assumes you are using a source repository service that promotes a
    contribution model similar to `GitHub's fork and pull request workflow`_.
    While this is true for the majority of services (like GitHub, GitLab,
-   BitBucket), it might not be the case for private repositories (e.g., Gerrit).
+   BitBucket), it might not be the case for private repositories (e.g., when
+   using Gerrit).
 
    Also notice that the code examples might refer to GitHub URLs or the text
    might use GitHub specific terminology (e.g., *Pull Request* instead of *Merge
    Request*).
 
-   Please make sure to check the document having this assumptions in mind
+   Please make sure to check the document having these assumptions in mind
    and update things accordingly.
 
 .. todo:: Provide the correct links/replacements at the bottom of the document.
@@ -18,7 +19,7 @@
 
    especially if your project is open source. The text should be very similar to
    this template, but there are a few extra contents that you might decide to
-   also include, like mentioning labels of you issue tracker or automated
+   also include, like mentioning labels of your issue tracker or automated
    releases.
 
 
@@ -32,7 +33,7 @@ This document focuses on getting any potential contributor familiarized
 with the development processes, but `other kinds of contributions`_ are also
 appreciated.
 
-If are new to using git_ or have never collaborated in a project previously,
+If you are new to using git_ or have never collaborated in a project previously,
 please have a look at `contribution-guide.org`_. Other resources are also
 listed in the excellent `guide created by FreeCodeCamp`_ [#contrib1]_.
 
@@ -45,7 +46,7 @@ guidelines.
 Issue Reports
 =============
 
-If you experience bugs or in general issues with ``${name}``, please have a look
+If you experience bugs or general issues with ``${name}``, please have a look
 on the `issue tracker`_. If you don't see anything useful there, please feel
 free to fire an issue report.
 
@@ -196,7 +197,7 @@ Implement your changes
 
          git log --graph --decorate --pretty=oneline --abbrev-commit --all
 
-      to check for recurring communication patterns.
+      to look for recurring communication patterns.
 
 #. Please check that your changes don't break any unit tests with::
 

--- a/src/pyscaffold/templates/sphinx_conf.template
+++ b/src/pyscaffold/templates/sphinx_conf.template
@@ -145,6 +145,9 @@ pygments_style = "sphinx"
 # If true, keep warnings as "system message" paragraphs in the built documents.
 # keep_warnings = False
 
+# If this is True, todo emits a warning for each TODO entries. The default is False.
+todo_emit_warnings = True
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/src/pyscaffold/templates/sphinx_contributing.template
+++ b/src/pyscaffold/templates/sphinx_contributing.template
@@ -1,0 +1,1 @@
+.. include:: ../CONTRIBUTING.rst

--- a/src/pyscaffold/templates/sphinx_index.template
+++ b/src/pyscaffold/templates/sphinx_index.template
@@ -28,6 +28,7 @@ Contents
    :maxdepth: 2
 
    Overview <readme>
+   Contributions & Help <contributing>
    License <license>
    Authors <authors>
    Changelog <changelog>
@@ -44,15 +45,15 @@ Indices and tables
 .. _toctree: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
 .. _references: https://www.sphinx-doc.org/en/stable/markup/inline.html
-.. _Python domain syntax: https://sphinx-doc.org/domains.html#the-python-domain
+.. _Python domain syntax: https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#the-python-domain
 .. _Sphinx: https://www.sphinx-doc.org/
 .. _Python: https://docs.python.org/
-.. _Numpy: https://docs.scipy.org/doc/numpy
+.. _Numpy: https://numpy.org/doc/stable
 .. _SciPy: https://docs.scipy.org/doc/scipy/reference/
 .. _matplotlib: https://matplotlib.org/contents.html#
 .. _Pandas: https://pandas.pydata.org/pandas-docs/stable
 .. _Scikit-Learn: https://scikit-learn.org/stable
-.. _autodoc: https://www.sphinx-doc.org/en/stable/ext/autodoc.html
-.. _Google style: https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
+.. _autodoc: https://www.sphinx-doc.org/en/master/ext/autodoc.html
+.. _Google style: https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings
 .. _NumPy style: https://numpydoc.readthedocs.io/en/latest/format.html
-.. _classical style: https://www.sphinx-doc.org/en/stable/domains.html#info-field-lists
+.. _classical style: https://www.sphinx-doc.org/en/master/domains.html#info-field-lists


### PR DESCRIPTION
This PR depends on #466 and is the second step towards #376.

Any improvement suggestions are welcome. I decided to replicate the entire sections about the core concepts in both `docs/dev-guide` and `docs/extensions`, since extension developers don't need to know how PyScaffold works internally, and it might be confusing for them if we simply include a link pointing out to a more complex process. But I admit it is not ideal...