### PR TITLE
Add contributing templates to generated package (4th step #376)

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -23,7 +23,7 @@ reference in terms of community guidelines.
 
 .. tip::
    If you are new to open source or have never contributed before to a software
-   community, please have a look at `contribution-guide.org`_ and the
+   project, please have a look at `contribution-guide.org`_ and the
    `How to Contribute to Open Source`_ guide.
    Other resources are also listed in the excellent `guide created by FreeCodeCamp`_.
 
@@ -43,10 +43,10 @@ be done!
 |:beetle:| Issue Reports
 ------------------------
 
-If you experience bugs or in general issues with PyScaffold, please have a look
+If you experience bugs or general issues with PyScaffold, please have a look
 on our `issue tracker`_.
 
-.. tip::
+.. note::
    Please don't forget to include the closed issues in your search_.
    Sometimes another person has already experienced your problem and reported a
    solution. If you don't see anything useful there, feel free to fire a
@@ -225,7 +225,7 @@ Implement your changes
 
          git log --graph --decorate --pretty=oneline --abbrev-commit --all
 
-      to check for recurring communication patterns.
+      to look for recurring communication patterns.
 
 #. Please check that your changes don't break any unit tests with::
 
@@ -391,7 +391,7 @@ upload to PyPI, the following extra steps can be used:
 #. Run ``tox -e publish -- --repository pypi`` and check that everything was
    uploaded to `PyPI`_ correctly.
 
-.. tip::
+.. important::
    When working in a new **external extension**, it is important that the first
    distribution is manually uploaded to PyPI_, to make sure it will have the
    correct ownership.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,19 +5,19 @@ Contributing
 PyScaffold was started by `Blue Yonder`_ developers to help automating and
 standardizing the process of project setups. Nowadays it is a pure community
 project driven by volunteer work.
-Every little gesture is really appreciated (including |:bug:| issue reports!),
+Every little gesture is really appreciated (including issue reports!),
 and if you are interested in joining our continuous effort for making PyScaffold
 better, welcome aboard! We are pleased to help you in this journey |:ship:|.
 
 .. note::
-   This document is an attempt to get any potential contributor familiarised
+   This document is an attempt to get any potential contributor familiarized
    with PyScaffold's community processes, but by no means is intended to be a
    complete reference.
 
    Please feel free to contact us for help and guidance in our `GitHub discussions`_ page.
 
 Please notice, all the members of the PyScaffold community (and in special
-contributors) are expected to be **open, considerate, reasonable and respectful**.
+contributors) are expected to be **open, considerate, reasonable, and respectful**.
 When in doubt, `Python Software Foundation's Code of Conduct`_ is a good
 reference in terms of community guidelines.
 
@@ -25,7 +25,7 @@ reference in terms of community guidelines.
    If you are new to open source or have never contributed before to a software
    community, please have a look at `contribution-guide.org`_ and the
    `How to Contribute to Open Source`_ guide.
-   Other resources are also listed in the excelent `guide created by FreeCodeCamp`_.
+   Other resources are also listed in the excellent `guide created by FreeCodeCamp`_.
 
 
 How to contribute to PyScaffold?
@@ -34,7 +34,7 @@ How to contribute to PyScaffold?
 This guide focus on issue reports, documentation improvements, and code
 contributions, but there are many other ways to contribute to PyScaffold,
 even if you are not an experienced programmer or don't have the time to code.
-Skills like graphical design, event planing, teaching, mentoring, public outreach,
+Skills like graphical design, event planning, teaching, mentoring, public outreach,
 tech evangelism, code review, between `many others`_ are greatly appreciated.
 Please `reach us out`_, we would love to have you on board and discuss what can
 be done!
@@ -44,70 +44,119 @@ be done!
 ------------------------
 
 If you experience bugs or in general issues with PyScaffold, please have a look
-on our `issue tracker`_ (sometimes another person have already experienced your
-problem and reported a solution). If you don't see anything useful there, please feel
-free to fire an issue report.
+on our `issue tracker`_.
+
+.. tip::
+   Please don't forget to include the closed issues in your search_.
+   Sometimes another person has already experienced your problem and reported a
+   solution. If you don't see anything useful there, feel free to fire a
+   new issue report |:wink:|
+
+New issue reports should include information about your programming environment
+(e.g., operating system, Python version) and steps to reproduce the problem.
+Please try also to simplify the reproduction steps to a very minimal example
+that still illustrates the problem you are facing. By removing other factors,
+you help us to identify the root cause of the issue.
 
 
 |:books:| Documentation Improvements
 ------------------------------------
 
-Did you find any problems with our documentation and have some time to spare?
-Any spelling error? Or is there any complicated topic that you didn't find
-particularly well explained?
 You can help us improve our docs by making them more readable and coherent, or
-by adding missing information and correcting mistakes.
+by adding missing information and correcting mistakes (including spelling and
+grammar errors).
+
+Already known and discussed documentation issues that would benefit from
+contributions are marked in our `issue tracker`_ with the **documentation**
+label (we also do the same for all existing extensions under the `PyScaffold
+organization`_ on GitHub). But you are also welcomed to propose completely new
+changes (e.g., if you find new problems or would like to see a complicated topic
+better explained).
 
 PyScaffold's documentation is written in `reStructuredText`_ and uses `Sphinx`_
-as its main documentation compiler. This means that the docs are kept in the
-same repository as the project code, and that any documentation update is done
-via GitHub pull requests, as if it was a code contribution.
+as its main documentation compiler [#contrib1]_. This means that the docs are
+kept in the same repository as the project code, and that any documentation
+update is done via GitHub pull requests, as if it was a code contribution.
 
 While that might be scary for new programmers, it is actually a very nice way
 of getting started in the open source community, since doc contributions are
 not as difficult to make as other code contributions (for example, they don't
 require any automated testing).
 
-Please have a look in the steps described bellow and in case of doubts, contact
+Please have a look in the steps described below and in case of doubts, contact
 us at the `GitHub discussions`_ page for help.
+
+When working on changes to PyScaffold's docs in your local machine, you can
+compile them using |tox|_::
+
+    tox -e docs
+
+and use Python's built-in web server for a preview in your web browser
+(``http://localhost:8000``)::
+
+    python3 -m http.server --directory 'docs/_build/html'
 
 .. tip::
    Please notice that the `GitHub web interface`_ provides a quick way of
    propose changes in PyScaffold's files, that do not require you to have a lot
-   of experience with git_ or programing in general.  While this mechanism can
+   of experience with git_ or programing in general. While this mechanism can
    be tricky for normal code contributions, it works perfectly fine for
    contributing to the docs, and can be quite handy.
 
    If you are interested in trying this method out, please navigate to
-   PyScaffold's `docs` folder in the `main repository`_, find which file you
+   PyScaffold's ``docs`` folder in the `main repository`_, find which file you
    would like to propose changes and click in the little pencil icon at the
    top, to open `GitHub's code editor`_. Once you finish editing the file,
    please write a nice message in the form at the bottom of the page describing
-   which changes have you made and what are the motivations behind them, and
+   which changes have you made and what are the motivations behind them and
    submit your proposal.
 
 
 |:computer:| Code Contributions
 -------------------------------
 
+PyScaffold uses `GitHub's fork and pull request workflow`_ for code
+contributions, which means that anyone can propose changes in the code base.
+
+Once proposed changes are submitted, our continuous integration (CI) service,
+`Cirrus-CI`_, will run a series of automated checks to make sure everything is
+OK and the pull request (PR) itself will be reviewed by one of PyScaffold
+maintainers, before being merged in the code base. In some cases, changes might
+be required to fix problems pointed out by the CI, or the maintainers might
+want to discuss a bit about the PR and suggest adjustments. Please don't worry
+if that happens, this kind of iterative development is very common in the open
+source community and usually makes the software better. Besides, we will do our
+best to provide feedback (and support for eventual doubts) as soon as we can.
+
+If you are unsure about what to contribute, please have a look in our `issue
+tracker`_ (or the issue tracker of any extension under the `PyScaffold
+organization`_ on GitHub). Contributions on issues marked with the **help
+wanted** label are particularly appreciated. Moreover, the **good first issue**
+label marks issues that do not require a huge understanding on how the project
+works and therefore can be tackled by new members of the community. Please also
+notice that some issues are not ready yet for a follow up implementation or bug
+fix, these are usually signed with other labels_, such as **needs discussion**
+and **waiting response**. When in doubt, please engage in the conversation by
+posting a message to the open issue.
+
 Understanding how PyScaffold works
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The main aspects of PyScaffold internals are explained in our
-:doc:`/dev-guide`. Please make sure to check it out for a brief overview of the
-project and how it is organized.
+If you have a change in mind, but don't know how to implement it, please have a
+look in our :doc:`/dev-guide`. It explains the main aspects of PyScaffold
+internals and provide a brief overview of how the project is organized.
 
 Submit an issue
 ~~~~~~~~~~~~~~~
 
 Before you work on any non-trivial code contribution it's best to first create
-an issue report to start a discussion on the subject. This often provides
-additional considerations and avoids unnecessary work.
+an `issue report`_ to start a discussion on the subject.
+This often provides additional considerations and avoids unnecessary work.
 
 Create an environment
 ~~~~~~~~~~~~~~~~~~~~~
 
-Before you start coding we recommend to create an isolated `virtual
+Before you start coding, we recommend creating an isolated `virtual
 environment`_ to avoid any problems with your installed Python packages.
 This can easily be done via either |virtualenv|_::
 
@@ -122,7 +171,7 @@ or Miniconda_::
 Clone the repository
 ~~~~~~~~~~~~~~~~~~~~
 
-#. `Create a Gitub account`_  if you do not already have one.
+#. `Create a GitHub account`_  if you do not already have one.
 #. Fork the `project repository`_: click on the *Fork* button near the top of the
    page. This creates a copy of the code under your account on the GitHub server.
 #. Clone this copy to your local disk::
@@ -144,13 +193,17 @@ Clone the repository
    PyScaffold project comes with a lot of hooks configured to
    automatically help the developer to check the code being written.
 
+Implement your changes
+~~~~~~~~~~~~~~~~~~~~~~
+
 #. Create a branch to hold your changes::
 
     git checkout -b my-feature
 
    and start making changes. Never work on the master branch!
 
-#. Start your work on this branch.
+#. Start your work on this branch. Don't forget to add docstrings_ to new
+   functions, modules and classes, especially if they are part of public APIs.
 
 #. Add yourself to the list of contributors in ``AUTHORS.rst``.
 
@@ -159,18 +212,26 @@ Clone the repository
     git add <MODIFIED FILES>
     git commit
 
-   to record your changes in Git. Please make sure to see the validation
-   messages from |pre-commit|_ and fix any eventual issue.
+   to record your changes in git_. Please make sure to see the validation
+   messages from |pre-commit|_ and fix any eventual issues.
    This should automatically use flake8_/black_ to check/fix the code style
    in a way that is compatible with PyScaffold.
+
+   .. important:: Don't forget to add unit tests and documentation in case your
+      contribution adds an additional feature and is not just a bugfix.
+
+      Moreover, writing a `descriptive commit message`_ is highly recommended.
+      In case of doubt, you can check the commit history with::
+
+         git log --graph --decorate --pretty=oneline --abbrev-commit --all
+
+      to check for recurring communication patterns.
 
 #. Please check that your changes don't break any unit tests with::
 
     tox
 
    (after having installed |tox|_ with ``pip install tox`` or ``pipx``).
-   Don't forget to also add unit tests in case your contribution
-   adds an additional feature and is not just a bugfix.
 
    To speed up running the tests, you can try to run them in parallel, using
    ``pytest-xdist``. This plugin is already added to the test dependencies, so
@@ -192,18 +253,21 @@ Clone the repository
    You can also use |tox|_ to run several other pre-configured tasks in the
    repository. Try ``tox -av`` to see a list of the available checks.
 
+Submit your contribution
+~~~~~~~~~~~~~~~~~~~~~~~~
+
 #. If everything works fine, push your local branch to GitHub with::
 
     git push -u origin my-feature
 
-#. Go to the web page of your PyScaffold fork, and click
+#. Go to the web page of your PyScaffold fork and click
    "Create pull request" to send your changes to the maintainers for review.
    Find more detailed information `creating a PR`_. You might also want to open
    the PR as a draft first and mark it as ready for review after the feedbacks
    from the continuous integration (CI) system or any required fixes.
 
 #. If you are submitting a change related to an existing CI
-   system template (e.g. travis, cirrus, or even tox and pre-commit),
+   system template (e.g., travis, cirrus, or even tox and pre-commit),
    please consider first submitting a companion PR to PyScaffold's
    `ci-tester`_, with the equivalent files changes, so we are sure it works.
 
@@ -224,7 +288,7 @@ Make sure to fetch all the tags from the upstream repository, the command ``git
 describe --abbrev=0 --tags`` should return the version you are expecting. If
 you are trying to run the CI scripts in a fork repository, make sure to push
 all the tags.
-You can also try to remove all the egg files or the complete egg folder, i.e.
+You can also try to remove all the egg files or the complete egg folder, i.e.,
 ``.eggs``, as well as the ``*.egg-info`` folders in the ``src`` folder or
 potentially in the root of your project. Afterwards run ``python setup.py
 egg_info --egg-base .`` again.
@@ -248,7 +312,7 @@ installed. For example::
     I have found a weird error when running |tox|_. It seems like some dependency
     is not being installed.
 
-Sometimes |tox|_ misses out when new dependencies are added, specially to
+Sometimes |tox|_ misses out when new dependencies are added, especially to
 ``setup.cfg`` and ``docs/requirements.txt``. If you find any problems with
 missing dependencies when running a command with |tox|_, try to recreate the
 ``tox`` environment using the ``-r`` flag. For example, instead of::
@@ -264,9 +328,9 @@ Try running::
     I am trying to debug the automatic test suite, but it is very hard to
     understand what is happening.
 
-`Pytest can drop you`_ in a interactive session in the case an error occurs.
+`Pytest can drop you`_ in an interactive session in the case an error occurs.
 In order to do that you need to pass a ``--pdb`` option (for example by running
-``tox -- -k NAME_OF_THE_FALLING_TEST --pdb``).
+``tox -- -k <NAME OF THE FALLING TEST> --pdb``).
 While ``pdb`` does not have the best user interface in the world, if you feel
 courageous, it is possible to use an alternate implementation like `ptpdb`_ and
 `bpdb`_ (please notice some of them might require additional options, such as
@@ -280,12 +344,26 @@ You can also setup breakpoints manually instead of using the ``--pdb`` option.
 
 If you are an experienced developer and wants to help, but do not have the time
 to create complete pull requests, you can still help by `reviewing existing open
-pull requests`_, or going through the open issues and evaluating them according to `our
-labels`_ and even suggesting possible solutions or workarounds.
+pull requests`_, or going through the open issues and evaluating them according to our
+labels_ and even suggesting possible solutions or workarounds.
 
 
 |:hammer_and_wrench:| Maintainer tasks
 --------------------------------------
+
+PyScaffold maintainers not only carry out most of the source code development,
+but also are responsible for planning new releases, reviewing pull requests,
+and managing CI tools between many other tasks. If you are interested in
+becoming a maintainer, the best is to keep "hanging out" in the community,
+helping with the issues, proposing PRs and doing some code review (either in
+the `main repository`_ or the extensions under the `PyScaffold organization`_
+on GitHub).  Eventually, one of the existing maintainers will approach you and
+ask you to join |:wink:|.
+
+This section describes some technical aspects of recurring tasks
+and is meant as a guide for new maintainers (or old ones that need a memory
+refresher).
+
 
 Releases
 ~~~~~~~~
@@ -296,8 +374,8 @@ Therefore, as a PyScaffold maintainer, the following steps are all you need
 to release a new version:
 
 #. Make sure all unit tests on `Cirrus-CI`_ are green.
-#. Tag the current commit on the master branch with a release tag, e.g. ``v1.2.3``.
-#. Push the new tag to the upstream repository, e.g. ``git push upstream v1.2.3``
+#. Tag the current commit on the master branch with a release tag, e.g., ``v1.2.3``.
+#. Push the new tag to the upstream repository, e.g., ``git push upstream v1.2.3``
 #. After a few minutes check if the new version was uploaded to PyPI_
 
 If, for some reason, you need to manually create a new distribution file and
@@ -307,7 +385,7 @@ upload to PyPI, the following extra steps can be used:
    (or ``rm -rf dist build``)
    to avoid confusion with old builds and Sphinx docs.
 #. Run ``tox -e build`` and check that the files in ``dist`` have
-   the correct version (no ``.dirty`` or Git hash) according to the Git tag.
+   the correct version (no ``.dirty`` or git_ hash) according to the git_ tag.
    Also sizes of the distributions should be less than 500KB, otherwise unwanted
    clutter may have been included.
 #. Run ``tox -e publish -- --repository pypi`` and check that everything was
@@ -318,10 +396,60 @@ upload to PyPI, the following extra steps can be used:
    distribution is manually uploaded to PyPI_, to make sure it will have the
    correct ownership.
 
-After successful releases (specially of new major versions), it is a good
+After successful releases (especially of new major versions), it is a good
 practice to re-generate our example repository. To manually do that, please
 visit our `GitHub actions`_ page and run the **Make Demo Repo** workflow
 (please check if it was not automatically triggered already).
+
+
+Working on multiple branches and splitting complex changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+PyScaffold follows `semantic versioning`_. As a consequence, most of the times
+the ``master`` (or ``main``) branch for either the `main repository`_ or the
+extensions under the `PyScaffold organization`_ on GitHub, should be pointing
+out to the latest published minor version, or the next minor version still
+under development. We also tend (but are not committed to) keep some level of
+support for the previous major version, which means that once a major version
+is superseded, the maintainers should create a new branch pointing to this
+previous version.
+
+For this reason, `Read the Docs`_ should always be configured to show the
+**stable** version by default instead of **latest**. The **stable** version
+corresponds to the latest commit that received a git_ tag, while the **latest**
+version points to the **master**/**main** branch.
+
+During the transition period between major versions, it is common practice to
+create a new *development* version that is kept apart from the master branch
+and will only be merged when everything is ready for release. For example, a
+``v4.0.x`` branch was used for all the development related to PyScaffold v4,
+while the ``master`` branch was still being used for bug fixes to v3.
+
+When working in complex features or refactoring, it might also be interesting
+to create a new long-living branch that will receive multiple PRs from other
+short-lived auxiliary branch splitting the changes into smaller steps. Please
+be aware that splitting complex changes into smaller PRs can be very tricky.
+Whenever possible, try to create independent PRs, i.e., PRs that can be merged
+independently into a long-living branch, without causing conflicts between
+themselves. When that is not possible, please coordinate a review and merge
+strategy with the other maintainers reviewing your code.
+
+One possible strategy is to create a single PR, but ask your reviewers to
+consider each commit (that should be small) as if it was an independent PR.
+A different strategy is to use **stacked PRs**, as described by the following
+references:
+
+- `Timothy Andrew's Blog <https://timothyandrew.dev/blog/git-stack>`_
+- `Div's Blog <https://divyanshu013.dev/blog/code-review-stacked-prs>`_
+- `LogRocket's Blog <https://blog.logrocket.com/using-stacked-pull-requests-in-github>`_
+
+Please also notice that independently of the strategy you and the reviewers
+agree on, it might be worthy to ask them to just review the PRs without merging
+(so you are responsible for closing the PRs and bringing their code to the
+long-lived branch via git ``merge``, ``pull`` or ``cherry-pick``).
+This might avoid confusion since GitHub does not provide any special mechanism
+for dealing with dependencies between PRs. Moreover, the merging might be just
+easier via git_ CLI.
 
 
 |:mega:| Spread the Word
@@ -331,9 +459,16 @@ Finally, another way to contribute to PyScaffold is to recommend it. You can
 speak about it with your work colleagues, in a conference, or even writing a
 blog post about the project.
 
-If you need to pitch PyScaffold to you boss or co-workers, please checkout our
-docs. We have enumerated a few :doc:`reasons for using PyScaffold </reasons>`
-in our website, that can be handy to have around |:wink:|.
+If you need to pitch PyScaffold to your boss or co-workers, please check out
+our docs. We have enumerated a few :doc:`reasons for using PyScaffold
+</reasons>` in our website, that can be handy to have around |:wink:|.
+
+
+
+.. [#contrib1] The same is valid for the extensions under the `PyScaffold
+   organization`_ on GitHub, although some extension, like
+   `pyscaffoldext-markdown`_ and `pyscaffoldext-dsproject`_ use CommonMark_
+   with MyST_ extensions as an alternative to reStructuredText_.
 
 
 
@@ -341,11 +476,49 @@ in our website, that can be handy to have around |:wink:|.
 .. |pre-commit| replace:: ``pre-commit``
 .. |tox| replace:: ``tox``
 
+.. _black: https://pypi.org/project/black/
 .. _Blue Yonder: https://blueyonder.com/
+.. _bpdb: https://docs.bpython-interpreter.org/en/latest/bpdb.html?highlight=bpdb
+.. _ci-tester: https://github.com/pyscaffold/ci-tester
 .. _Cirrus-CI: https://cirrus-ci.com/github/pyscaffold/pyscaffold
-.. _Create a Gitub account: https://github.com/join
-.. _Git: https://git-scm.com/
+.. _CommonMark: https://commonmark.org/
+.. _contribution-guide.org: http://www.contribution-guide.org/
+.. _Create a GitHub account: https://github.com/join
+.. _creating a PR: https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
+.. _descriptive commit message: https://chris.beams.io/posts/git-commit
+.. _docstrings: https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
+.. _flake8: https://flake8.pycqa.org/en/stable/
+.. _git: https://git-scm.com/
 .. _GitHub actions: https://github.com/pyscaffold/pyscaffold/actions
+.. _GitHub's fork and pull request workflow: https://guides.github.com/activities/forking/
+.. _guide created by FreeCodeCamp: https://github.com/FreeCodeCamp/how-to-contribute-to-open-source
+.. _issue tracker: https://github.com/pyscaffold/pyscaffold/issues
+.. _issue report: https://github.com/pyscaffold/pyscaffold/issues
+.. _labels: https://github.com/pyscaffold/pyscaffold/labels
+.. _Miniconda: https://docs.conda.io/en/latest/miniconda.html
+.. _MyST: https://myst-parser.readthedocs.io/en/latest/syntax/syntax.html
+.. _pre-commit: https://pre-commit.com/
+.. _ptpdb: https://pypi.org/project/ptpdb/
+.. _PyPI: https://pypi.org
+.. _PyScaffold organization: https://github.com/pyscaffold
+.. _pyscaffoldext-dsproject: https://github.com/pyscaffold/pyscaffoldext-dsproject
+.. _pyscaffoldext-markdown: https://github.com/pyscaffold/pyscaffoldext-markdown
+.. _Pytest can drop you: https://docs.pytest.org/en/stable/usage.html#dropping-to-pdb-python-debugger-at-the-start-of-a-test
+.. _pytest: https://docs.pytest.org/en/stable/
+.. _Python Software Foundation's Code of Conduct: https://www.python.org/psf/conduct/
+.. _Read the Docs: https://docs.readthedocs.io/en/stable/versions.html
+.. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/
+.. _reviewing existing open pull requests: https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews
+.. _search: https://github.com/pyscaffold/pyscaffold/issues?q=
+.. _semantic versioning: https://semver.org
+.. _Sphinx: https://www.sphinx-doc.org/en/master/
+.. _tox: https://tox.readthedocs.io/en/stable/
+.. _Travis: https://travis-ci.org/pyscaffold/pyscaffold
+.. _virtual environment: https://realpython.com/python-virtual-environments-a-primer/
+.. _virtualenv: https://virtualenv.pypa.io/en/stable/
+
+.. _project repository: https://github.com/pyscaffold/pyscaffold
+.. _main repository: https://github.com/pyscaffold/pyscaffold
 
 .. _GitHub discussions: https://github.com/pyscaffold/pyscaffold/discussions
 .. _reach us out: https://github.com/pyscaffold/pyscaffold/discussions
@@ -356,31 +529,3 @@ in our website, that can be handy to have around |:wink:|.
 .. _How to Contribute to Open Source: https://opensource.guide/how-to-contribute
 .. _ways of contributing: https://opensource.guide/how-to-contribute/
 .. _many others: https://opensource.guide/how-to-contribute/
-
-.. _Miniconda: https://docs.conda.io/en/latest/miniconda.html
-.. _PyPI: https://pypi.org/
-.. _Pytest can drop you: https://docs.pytest.org/en/stable/usage.html#dropping-to-pdb-python-debugger-at-the-start-of-a-test
-.. _Python Software Foundation's Code of Conduct: https://www.python.org/psf/conduct/
-.. _Sphinx: https://www.sphinx-doc.org/en/master/
-.. _Travis: https://travis-ci.org/pyscaffold/pyscaffold
-.. _black: https://pypi.org/project/black/
-.. _bpdb: https://docs.bpython-interpreter.org/en/latest/bpdb.html?highlight=bpdb
-.. _ci-tester: https://github.com/pyscaffold/ci-tester
-.. _contribution-guide.org: http://www.contribution-guide.org/
-.. _creating a PR: https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
-.. _flake8: https://flake8.pycqa.org/en/stable/
-.. _guide created by FreeCodeCamp: https://github.com/FreeCodeCamp/how-to-contribute-to-open-source
-.. _issue tracker: https://github.com/pyscaffold/pyscaffold/issues
-.. _our labels: https://github.com/pyscaffold/pyscaffold/labels
-.. _pre-commit: https://pre-commit.com/
-
-.. _project repository: https://github.com/pyscaffold/pyscaffold
-.. _main repository: https://github.com/pyscaffold/pyscaffold
-
-.. _ptpdb: https://pypi.org/project/ptpdb/
-.. _pytest: https://docs.pytest.org/en/stable/
-.. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/
-.. _reviewing existing open pull requests: https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews
-.. _tox: https://tox.readthedocs.io/en/stable/
-.. _virtual environment: https://realpython.com/python-virtual-environments-a-primer/
-.. _virtualenv: https://virtualenv.pypa.io/en/stable/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -440,6 +440,7 @@ A different strategy is to use **stacked PRs**, as described by the following
 references:
 
 - `Timothy Andrew's Blog <https://timothyandrew.dev/blog/git-stack>`_
+- `Doctor McKayla's Blog <https://www.michaelagreiler.com/stacked-pull-requests/>`_
 - `Div's Blog <https://divyanshu013.dev/blog/code-review-stacked-prs>`_
 - `LogRocket's Blog <https://blog.logrocket.com/using-stacked-pull-requests-in-github>`_
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -451,6 +451,13 @@ This might avoid confusion since GitHub does not provide any special mechanism
 for dealing with dependencies between PRs. Moreover, the merging might be just
 easier via git_ CLI.
 
+.. note::
+   PyScaffold's repositories also contain ``archives/*`` branches. These
+   branches correspond to old experiments and alternative feature
+   implementations that, although not merged, are kept for reference as
+   interesting (or very complex) pieces of code that might be useful in the
+   future.
+
 
 |:mega:| Spread the Word
 ------------------------

--- a/src/pyscaffold/structure.py
+++ b/src/pyscaffold/structure.py
@@ -137,6 +137,7 @@ def define_structure(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
         "AUTHORS.rst": (get_template("authors"), NO_OVERWRITE),
         "LICENSE.txt": (templates.license, NO_OVERWRITE),
         "CHANGELOG.rst": (get_template("changelog"), NO_OVERWRITE),
+        "CONTRIBUTING.rst": (get_template("contributing"), NO_OVERWRITE),
         # Code
         "src": {
             opts["package"]: {
@@ -153,6 +154,7 @@ def define_structure(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
         "docs": {
             "conf.py": get_template("sphinx_conf"),
             "authors.rst": get_template("sphinx_authors"),
+            "contributing.rst": get_template("sphinx_contributing"),
             "index.rst": (get_template("sphinx_index"), NO_OVERWRITE),
             "readme.rst": get_template("sphinx_readme"),
             "license.rst": get_template("sphinx_license"),

--- a/src/pyscaffold/templates/contributing.template
+++ b/src/pyscaffold/templates/contributing.template
@@ -1,0 +1,352 @@
+.. todo:: THIS IS SUPPOSED TO BE AN EXAMPLE. MODIFY IT ACCORDING TO YOUR NEEDS!
+
+   The document assumes you are using a source repository service that promotes a
+   contribution model similar to `GitHub's fork and pull request workflow`_.
+   While this is true for the majority of services (like GitHub, GitLab,
+   BitBucket), it might not be the case for private repositories (e.g., Gerrit).
+
+   Also notice that the code examples might refer to GitHub URLs or the text
+   might use GitHub specific terminology (e.g., *Pull Request* instead of *Merge
+   Request*).
+
+   Please make sure to check the document having this assumptions in mind
+   and update things accordingly.
+
+.. todo:: Provide the correct links/replacements at the bottom of the document.
+
+.. todo:: You might want to have a look on `PyScaffold's contributor's guide`_,
+
+   especially if your project is open source. The text should be very similar to
+   this template, but there are a few extra contents that you might decide to
+   also include, like mentioning labels of you issue tracker or automated
+   releases.
+
+
+============
+Contributing
+============
+
+Welcome to ``${name}`` contributor's guide.
+
+This document focuses on getting any potential contributor familiarized
+with the development processes, but `other kinds of contributions`_ are also
+appreciated.
+
+If are new to using git_ or have never collaborated in a project previously,
+please have a look at `contribution-guide.org`_. Other resources are also
+listed in the excellent `guide created by FreeCodeCamp`_ [#contrib1]_.
+
+Please notice, all users and contributors are expected to be **open,
+considerate, reasonable, and respectful**. When in doubt, `Python Software
+Foundation's Code of Conduct`_ is a good reference in terms of behavior
+guidelines.
+
+
+Issue Reports
+=============
+
+If you experience bugs or in general issues with ``${name}``, please have a look
+on the `issue tracker`_. If you don't see anything useful there, please feel
+free to fire an issue report.
+
+.. tip::
+   Please don't forget to include the closed issues in your search.
+   Sometimes a solution was already reported, and the problem is considered
+   **solved**.
+
+New issue reports should include information about your programming environment
+(e.g., operating system, Python version) and steps to reproduce the problem.
+Please try also to simplify the reproduction steps to a very minimal example
+that still illustrates the problem you are facing. By removing other factors,
+you help us to identify the root cause of the issue.
+
+
+Documentation Improvements
+==========================
+
+You can help improve ``${name}`` docs by making them more readable and coherent, or
+by adding missing information and correcting mistakes.
+
+``${name}`` documentation uses Sphinx_ as its main documentation compiler.
+This means that the docs are kept in the same repository as the project code, and
+that any documentation update is done in the same way was a code contribution.
+
+.. todo:: Don't forget to mention which markup language you are using.
+
+    e.g.,  reStructuredText_ or CommonMark_ with MyST_ extensions.
+
+.. todo:: If your project is hosted on GitHub, you can also mention the following tip:
+
+   .. tip::
+      Please notice that the `GitHub web interface`_ provides a quick way of
+      propose changes in ``${name}``'s files. While this mechanism can
+      be tricky for normal code contributions, it works perfectly fine for
+      contributing to the docs, and can be quite handy.
+
+      If you are interested in trying this method out, please navigate to
+      the ``docs`` folder in the source repository_, find which file you
+      would like to propose changes and click in the little pencil icon at the
+      top, to open `GitHub's code editor`_. Once you finish editing the file,
+      please write a message in the form at the bottom of the page describing
+      which changes have you made and what are the motivations behind them and
+      submit your proposal.
+
+When working on documentation changes in your local machine, you can
+compile them using |tox|_::
+
+    tox -e docs
+
+and use Python's built-in web server for a preview in your web browser
+(``http://localhost:8000``)::
+
+    python3 -m http.server --directory 'docs/_build/html'
+
+
+Code Contributions
+==================
+
+.. todo:: Please include a reference or explanation about the internals of the project.
+
+   An architecture description, design principles or at least a summary of the
+   main concepts will make it easy for potential contributors to get started
+   quickly.
+
+Submit an issue
+---------------
+
+Before you work on any non-trivial code contribution it's best to first create
+a report in the `issue tracker`_ to start a discussion on the subject.
+This often provides additional considerations and avoids unnecessary work.
+
+Create an environment
+---------------------
+
+Before you start coding, we recommend creating an isolated `virtual
+environment`_ to avoid any problems with your installed Python packages.
+This can easily be done via either |virtualenv|_::
+
+    virtualenv <PATH TO VENV>
+    source <PATH TO VENV>/bin/activate
+
+or Miniconda_::
+
+    conda create -n pyscaffold python=3 six virtualenv pytest pytest-cov
+    conda activate pyscaffold
+
+Clone the repository
+--------------------
+
+#. Create an user account on |the repository service| if you do not already have one.
+#. Fork the project repository_: click on the *Fork* button near the top of the
+   page. This creates a copy of the code under your account on |the repository service|.
+#. Clone this copy to your local disk::
+
+    git clone git@github.com:YourLogin/${name}.git
+    cd ${name}
+
+#. You should run::
+
+    pip install -U pip setuptools -e .
+
+   to be able run ``putup --help``.
+
+   .. todo:: if you are not using pre-commit, please remove the following item:
+
+#. Install |pre-commit|_::
+
+    pip install pre-commit
+    pre-commit install
+
+   ``${name}`` comes with a lot of hooks configured to automatically help the
+   developer to check the code being written.
+
+Implement your changes
+----------------------
+
+#. Create a branch to hold your changes::
+
+    git checkout -b my-feature
+
+   and start making changes. Never work on the master branch!
+
+#. Start your work on this branch. Don't forget to add docstrings_ to new
+   functions, modules and classes, especially if they are part of public APIs.
+
+#. Add yourself to the list of contributors in ``AUTHORS.rst``.
+
+#. When you’re done editing, do::
+
+    git add <MODIFIED FILES>
+    git commit
+
+   to record your changes in git_.
+
+   .. todo:: if you are not using pre-commit, please remove the following item:
+
+   Please make sure to see the validation messages from |pre-commit|_ and fix
+   any eventual issues.
+   This should automatically use flake8_/black_ to check/fix the code style
+   in a way that is compatible with the project.
+
+   .. important:: Don't forget to add unit tests and documentation in case your
+      contribution adds an additional feature and is not just a bugfix.
+
+      Moreover, writing a `descriptive commit message`_ is highly recommended.
+      In case of doubt, you can check the commit history with::
+
+         git log --graph --decorate --pretty=oneline --abbrev-commit --all
+
+      to check for recurring communication patterns.
+
+#. Please check that your changes don't break any unit tests with::
+
+    tox
+
+   (after having installed |tox|_ with ``pip install tox`` or ``pipx``).
+
+   You can also use |tox|_ to run several other pre-configured tasks in the
+   repository. Try ``tox -av`` to see a list of the available checks.
+
+Submit your contribution
+------------------------
+
+#. If everything works fine, push your local branch to |the repository service| with::
+
+    git push -u origin my-feature
+
+#. Go to the web page of your fork and click |contribute button|
+   to send your changes for review.
+
+   .. todo:: if you are using GitHub, you can uncomment the following paragraph
+
+      Find more detailed information `creating a PR`_. You might also want to open
+      the PR as a draft first and mark it as ready for review after the feedbacks
+      from the continuous integration (CI) system or any required fixes.
+
+
+Troubleshooting
+---------------
+
+The following tips can be used when facing problems to build or test the
+package:
+
+#. Make sure to fetch all the tags from the upstream repository_.
+   The command ``git describe --abbrev=0 --tags`` should return the version you
+   are expecting. If you are trying to run CI scripts in a fork repository,
+   make sure to push all the tags.
+   You can also try to remove all the egg files or the complete egg folder, i.e.,
+   ``.eggs``, as well as the ``*.egg-info`` folders in the ``src`` folder or
+   potentially in the root of your project.
+
+#. Sometimes |tox|_ misses out when new dependencies are added, especially to
+   ``setup.cfg`` and ``docs/requirements.txt``. If you find any problems with
+   missing dependencies when running a command with |tox|_, try to recreate the
+   ``tox`` environment using the ``-r`` flag. For example, instead of::
+
+    tox -e docs
+
+   Try running::
+
+    tox -r -e docs
+
+#. Make sure to have a reliable |tox|_ installation that uses the correct
+   Python version (e.g., 3.7+). When in doubt you can run::
+
+    tox --version
+    # OR
+    which tox
+
+   If you have trouble and are seeing weird errors upon running |tox|_, you can
+   also try to create a dedicated `virtual environment`_ with a |tox|_ binary
+   freshly installed. For example::
+
+    virtualenv .venv
+    source .venv/bin/activate
+    .venv/bin/pip install tox
+    .venv/bin/tox -e all
+
+#. `Pytest can drop you`_ in an interactive session in the case an error occurs.
+   In order to do that you need to pass a ``--pdb`` option (for example by
+   running ``tox -- -k <NAME OF THE FALLING TEST> --pdb``).
+   You can also setup breakpoints manually instead of using the ``--pdb`` option.
+
+
+Maintainer tasks
+================
+
+Releases
+--------
+
+.. todo:: This section assumes you are using PyPI to publicly release your package.
+
+   If instead you are using a different/private package index, please update
+   the instructions accordingly.
+
+If you are part of the group of maintainers and have correct user permissions
+on PyPI_, the following steps can be used to release a new version for
+``${name}``:
+
+#. Make sure all unit tests are successful.
+#. Tag the current commit on the main branch with a release tag, e.g., ``v1.2.3``.
+#. Push the new tag to the upstream repository_, e.g., ``git push upstream v1.2.3``
+#. Clean up the ``dist`` and ``build`` folders with ``tox -e clean``
+   (or ``rm -rf dist build``)
+   to avoid confusion with old builds and Sphinx docs.
+#. Run ``tox -e build`` and check that the files in ``dist`` have
+   the correct version (no ``.dirty`` or git_ hash) according to the git_ tag.
+   Also check the sizes of the distributions, if they are too big (e.g., >
+   500KB), unwanted clutter may have been accidentally included.
+#. Run ``tox -e publish -- --repository pypi`` and check that everything was
+   uploaded to PyPI_ correctly.
+
+
+
+.. [#contrib1] Even though, these resources focus on open source projects and
+   communities, the general ideas behind collaborating with other developers
+   to collectively create software are general and can be applied to all sorts
+   of environments, including private companies and proprietary code bases.
+
+
+.. <-- strart -->
+.. todo:: Please review and change the following definitions:
+
+.. |the repository service| replace:: GitHub
+.. |contribute button| replace:: "Create pull request"
+
+.. _repository: https://github.com/<USERNAME>/${name}
+.. _issue tracker: https://github.com/<USERNAME>/${name}/issues
+.. <-- end -->
+
+
+.. |virtualenv| replace:: ``virtualenv``
+.. |pre-commit| replace:: ``pre-commit``
+.. |tox| replace:: ``tox``
+
+
+.. _black: https://pypi.org/project/black/
+.. _CommonMark: https://commonmark.org/
+.. _contribution-guide.org: http://www.contribution-guide.org/
+.. _creating a PR: https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
+.. _descriptive commit message: https://chris.beams.io/posts/git-commit
+.. _docstrings: https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
+.. _first-contributions tutorial: https://github.com/firstcontributions/first-contributions
+.. _flake8: https://flake8.pycqa.org/en/stable/
+.. _git: https://git-scm.com
+.. _GitHub's fork and pull request workflow: https://guides.github.com/activities/forking/
+.. _guide created by FreeCodeCamp: https://github.com/FreeCodeCamp/how-to-contribute-to-open-source
+.. _Miniconda: https://docs.conda.io/en/latest/miniconda.html
+.. _MyST: https://myst-parser.readthedocs.io/en/latest/syntax/syntax.html
+.. _other kinds of contributions: https://opensource.guide/how-to-contribute
+.. _pre-commit: https://pre-commit.com/
+.. _PyPI: https://pypi.org/
+.. _PyScaffold's contributor's guide: https://pyscaffold.org/en/stable/contributing.html
+.. _Pytest can drop you: https://docs.pytest.org/en/stable/usage.html#dropping-to-pdb-python-debugger-at-the-start-of-a-test
+.. _Python Software Foundation's Code of Conduct: https://www.python.org/psf/conduct/
+.. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/
+.. _Sphinx: https://www.sphinx-doc.org/en/master/
+.. _tox: https://tox.readthedocs.io/en/stable/
+.. _virtual environment: https://realpython.com/python-virtual-environments-a-primer/
+.. _virtualenv: https://virtualenv.pypa.io/en/stable/
+
+.. _GitHub web interface: https://docs.github.com/en/github/managing-files-in-a-repository/managing-files-on-github/editing-files-in-your-repository
+.. _GitHub's code editor: https://docs.github.com/en/github/managing-files-in-a-repository/managing-files-on-github/editing-files-in-your-repository

--- a/src/pyscaffold/templates/contributing.template
+++ b/src/pyscaffold/templates/contributing.template
@@ -3,13 +3,14 @@
    The document assumes you are using a source repository service that promotes a
    contribution model similar to `GitHub's fork and pull request workflow`_.
    While this is true for the majority of services (like GitHub, GitLab,
-   BitBucket), it might not be the case for private repositories (e.g., Gerrit).
+   BitBucket), it might not be the case for private repositories (e.g., when
+   using Gerrit).
 
    Also notice that the code examples might refer to GitHub URLs or the text
    might use GitHub specific terminology (e.g., *Pull Request* instead of *Merge
    Request*).
 
-   Please make sure to check the document having this assumptions in mind
+   Please make sure to check the document having these assumptions in mind
    and update things accordingly.
 
 .. todo:: Provide the correct links/replacements at the bottom of the document.
@@ -18,7 +19,7 @@
 
    especially if your project is open source. The text should be very similar to
    this template, but there are a few extra contents that you might decide to
-   also include, like mentioning labels of you issue tracker or automated
+   also include, like mentioning labels of your issue tracker or automated
    releases.
 
 
@@ -32,7 +33,7 @@ This document focuses on getting any potential contributor familiarized
 with the development processes, but `other kinds of contributions`_ are also
 appreciated.
 
-If are new to using git_ or have never collaborated in a project previously,
+If you are new to using git_ or have never collaborated in a project previously,
 please have a look at `contribution-guide.org`_. Other resources are also
 listed in the excellent `guide created by FreeCodeCamp`_ [#contrib1]_.
 
@@ -45,7 +46,7 @@ guidelines.
 Issue Reports
 =============
 
-If you experience bugs or in general issues with ``${name}``, please have a look
+If you experience bugs or general issues with ``${name}``, please have a look
 on the `issue tracker`_. If you don't see anything useful there, please feel
 free to fire an issue report.
 
@@ -196,7 +197,7 @@ Implement your changes
 
          git log --graph --decorate --pretty=oneline --abbrev-commit --all
 
-      to check for recurring communication patterns.
+      to look for recurring communication patterns.
 
 #. Please check that your changes don't break any unit tests with::
 

--- a/src/pyscaffold/templates/sphinx_conf.template
+++ b/src/pyscaffold/templates/sphinx_conf.template
@@ -145,6 +145,9 @@ pygments_style = "sphinx"
 # If true, keep warnings as "system message" paragraphs in the built documents.
 # keep_warnings = False
 
+# If this is True, todo emits a warning for each TODO entries. The default is False.
+todo_emit_warnings = True
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/src/pyscaffold/templates/sphinx_contributing.template
+++ b/src/pyscaffold/templates/sphinx_contributing.template
@@ -1,0 +1,1 @@
+.. include:: ../CONTRIBUTING.rst

--- a/src/pyscaffold/templates/sphinx_index.template
+++ b/src/pyscaffold/templates/sphinx_index.template
@@ -28,6 +28,7 @@ Contents
    :maxdepth: 2
 
    Overview <readme>
+   Contributions & Help <contributing>
    License <license>
    Authors <authors>
    Changelog <changelog>
@@ -44,15 +45,15 @@ Indices and tables
 .. _toctree: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
 .. _references: https://www.sphinx-doc.org/en/stable/markup/inline.html
-.. _Python domain syntax: https://sphinx-doc.org/domains.html#the-python-domain
+.. _Python domain syntax: https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#the-python-domain
 .. _Sphinx: https://www.sphinx-doc.org/
 .. _Python: https://docs.python.org/
-.. _Numpy: https://docs.scipy.org/doc/numpy
+.. _Numpy: https://numpy.org/doc/stable
 .. _SciPy: https://docs.scipy.org/doc/scipy/reference/
 .. _matplotlib: https://matplotlib.org/contents.html#
 .. _Pandas: https://pandas.pydata.org/pandas-docs/stable
 .. _Scikit-Learn: https://scikit-learn.org/stable
-.. _autodoc: https://www.sphinx-doc.org/en/stable/ext/autodoc.html
-.. _Google style: https://github.com/google/styleguide/blob/gh-pages/pyguide.md#38-comments-and-docstrings
+.. _autodoc: https://www.sphinx-doc.org/en/master/ext/autodoc.html
+.. _Google style: https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings
 .. _NumPy style: https://numpydoc.readthedocs.io/en/latest/format.html
-.. _classical style: https://www.sphinx-doc.org/en/stable/domains.html#info-field-lists
+.. _classical style: https://www.sphinx-doc.org/en/master/domains.html#info-field-lists


### PR DESCRIPTION
This PR depends on #468 and is the 4th step towards #376.

In particular the new `CONTRIBUTING.rst` template is added to newly generated projects.

I tried to keep the tone of the file neutral in a way that it could be used by both open source and proprietary projects, but that is a bit challenging. Moreover, some details of the `CONTIBUTING.rst` depend on the development stack (e.g., if the code is being hosted in GitHub, if the package index is PyPI and etc), so I added quite a few `TODO` notes throughout the document. I am not exactly sure about this approach, so any suggestion is welcome.