### PR TITLE
Add PyScaffold badge to generated projects

### DIFF
--- a/src/pyscaffold/templates/readme.template
+++ b/src/pyscaffold/templates/readme.template
@@ -1,3 +1,34 @@
+.. These are examples of badges you might want to add to your README:
+   please update the URLs accordingly
+
+    .. image:: https://api.cirrus-ci.com/github/<USER>/${name}.svg?branch=main
+        :alt: Built Status
+        :target: https://cirrus-ci.com/github/<USER>/${name}
+    .. image:: https://readthedocs.org/projects/${name}/badge/?version=latest
+        :alt: ReadTheDocs
+        :target: https://${name}.readthedocs.io/en/stable/
+    .. image:: https://img.shields.io/coveralls/github/<USER>/${name}/main.svg
+        :alt: Coveralls
+        :target: https://coveralls.io/r/<USER>/${name}
+    .. image:: https://img.shields.io/pypi/v/${name}.svg
+        :alt: PyPI-Server
+        :target: https://pypi.org/project/${name}/
+    .. image:: https://img.shields.io/conda/vn/conda-forge/${name}.svg
+        :alt: Conda-Forge
+        :target: https://anaconda.org/conda-forge/${name}
+    .. image:: https://pepy.tech/badge/${name}/month
+        :alt: Monthly Downloads
+        :target: https://pepy.tech/project/${name}
+    .. image:: https://img.shields.io/twitter/url/http/shields.io.svg?style=social&label=Twitter
+        :alt: Twitter
+        :target: https://twitter.com/${name}
+
+.. image:: https://img.shields.io/badge/-PyScaffold-005CA0?logo=pyscaffold
+    :alt: Project generated with PyScaffold
+    :target: https://pyscaffold.org/
+
+|
+
 ${title}
 
 


### PR DESCRIPTION
This targets #473 and also add a few examples of other badges that might be used.