### PR TITLE
Remove explicit COVERALLS_REPO_TOKEN

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -193,7 +193,6 @@ coverage_task:
   container: {image: "python:3.6-buster"}
   env:
     COVERAGE: yes
-    COVERALLS_REPO_TOKEN: ENCRYPTED[7ada9fe1105610d2b5ac314f5eb4cc2fea3d42a5fa1e1bfa263000277146022b71b80f7d2f00dc6058e08bd1c9034be7]
   depends_on:
     - test (Linux - 3.6)
     - test (Linux - 3.7)


### PR DESCRIPTION
… rely, instead, on environment variable overwritten by Cirrus GUI

This should fix issue #449.
As discussed in the issue, the idea is to use the GUI to provide the env var, which [should be readable by all contributors](https://github.com/cirruslabs/cirrus-ci-docs/discussions/866#discussioncomment-1051665)