### PR TITLE
Add demo gif to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,15 @@ we have setup for you, like::
    tox -e publish -- --repository pypi  # to release your package to PyPI
    tox -av  # to list all the tasks available
 
+The following figure demonstrates the usage of `putup` with the new experimental
+interactive mode for setting up a simple project named `myproj`.
+It uses the `--cirrus` flag to add CI support (via `Cirrus CI`_), and
+tox_ to run automated project tasks like building the `myproj` package.
+
+.. image:: https://pyscaffold.org/en/latest/_images/demo.gif
+    :alt: Creating a simple package with PyScaffold
+    :target: https://asciinema.org/a/qzh5ZYKl1q5xYEnM4CHT04HdW?autoplay=1
+
 Type ``putup -h`` to learn about more configuration options. PyScaffold assumes
 that you have Git_ installed and set up on your PC,
 meaning at least your name and email are configured.

--- a/README.rst
+++ b/README.rst
@@ -93,9 +93,10 @@ we have setup for you, like::
    tox -av  # to list all the tasks available
 
 The following figure demonstrates the usage of ``putup`` with the new experimental
-interactive mode for setting up a simple project named ``myproj``.
+interactive mode for setting up a simple project.
 It uses the `--cirrus` flag to add CI support (via `Cirrus CI`_), and
-tox_ to run automated project tasks like building the ``myproj`` package.
+tox_ to run automated project tasks like building a package file for
+distribution (or publishing).
 
 .. image:: https://pyscaffold.org/en/latest/_images/demo.gif
     :alt: Creating a simple package with PyScaffold
@@ -105,7 +106,7 @@ Type ``putup -h`` to learn about more configuration options. PyScaffold assumes
 that you have Git_ installed and set up on your PC,
 meaning at least your name and email are configured.
 
-The project template in ``my_project`` provides you with following features:
+The project template provides you with following features:
 
 
 Configuration & Packaging

--- a/README.rst
+++ b/README.rst
@@ -92,10 +92,10 @@ we have setup for you, like::
    tox -e publish -- --repository pypi  # to release your package to PyPI
    tox -av  # to list all the tasks available
 
-The following figure demonstrates the usage of `putup` with the new experimental
-interactive mode for setting up a simple project named `myproj`.
+The following figure demonstrates the usage of ``putup`` with the new experimental
+interactive mode for setting up a simple project named ``myproj``.
 It uses the `--cirrus` flag to add CI support (via `Cirrus CI`_), and
-tox_ to run automated project tasks like building the `myproj` package.
+tox_ to run automated project tasks like building the ``myproj`` package.
 
 .. image:: https://pyscaffold.org/en/latest/_images/demo.gif
     :alt: Creating a simple package with PyScaffold

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -52,9 +52,10 @@ have tox_ installed and see what we have prepared for you out of the box::
    tox -av  # to list all the tasks available
 
 The following figure demonstrates the usage of ``putup`` with the new experimental
-interactive mode for setting up a simple project named ``myproj``.
+interactive mode for setting up a simple project.
 It uses the `--cirrus` flag to add CI support (via `Cirrus CI`_), and
-tox_ to run automated project tasks like building the ``myproj`` package.
+tox_ to run automated project tasks like building a package file for
+distribution (or publishing).
 
 .. image:: gfx/demo.gif
     :alt: Creating a simple package with PyScaffold

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -51,10 +51,10 @@ have tox_ installed and see what we have prepared for you out of the box::
    tox -e publish -- --repository pypi  # to release your package to PyPI
    tox -av  # to list all the tasks available
 
-The following figure demonstrates the usage of `putup` with the new experimental
-interactive mode for setting up a simple project named `myproj`.
+The following figure demonstrates the usage of ``putup`` with the new experimental
+interactive mode for setting up a simple project named ``myproj``.
 It uses the `--cirrus` flag to add CI support (via `Cirrus CI`_), and
-tox_ to run automated project tasks like building the `myproj` package.
+tox_ to run automated project tasks like building the ``myproj`` package.
 
 .. image:: gfx/demo.gif
     :alt: Creating a simple package with PyScaffold


### PR DESCRIPTION
This is a follow up on #478. Now that the gif is published in RTD, we can use the image URL on the README.

I also notice that I did a mistake 😝. The document mentions `my_project`, but I have recorded the demo with `myproj`... If editing the gif was not so painful I would change it, but that is a task for the future...

Meanwhile I tried to de-emphasize the name difference to avoid adding confusion to the text. In practice I removed the direct references to `myproj` in the paragraph preceding the gif. 