### PR TITLE
Issue 483

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,7 @@ Version 4.1, 2021-09-XX
 - Added 0BSD license template
 - Added ``CONTRIBUTING.rst`` template, :issue:`376`
 - Added PyScaffold badge to ``README`` template, :issue:`473`
-- Updated Cirrus CI config and templates, including better ``coveralls`` integration, :pr:`449`
+- Updated Cirrus CI config and templates, including better ``coveralls`` integration, :issue:`449`
 - Adopted global ``isolated_build`` for ``tox`` configuration, :issue:`483`, :pr:`491`
 
 Version 3.3, 2020-12-24

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Changelog
 Current versions
 ================
 
-Version 4.1, 2021-08-XX
+Version 4.1, 2021-09-XX
 -------------------------
 
 - Added *linkcheck* task to ``tox.ini``, :pr:`456`
@@ -23,6 +23,7 @@ Version 4.1, 2021-08-XX
 - Added ``CONTRIBUTING.rst`` template, :issue:`376`
 - Added PyScaffold badge to ``README`` template, :issue:`473`
 - Updated Cirrus CI config and templates, including better ``coveralls`` integration, :pr:`449`
+- Adopted global ``isolated_build`` for ``tox`` configuration, :issue:`483`, :pr:`491`
 
 Version 3.3, 2020-12-24
 -----------------------

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -430,7 +430,7 @@ checkout `conda-build tutorials`_ for further information.
 .. _pip: https://pip.pypa.io/en/stable/
 .. _PyPI: https://pypi.org/
 .. _conda: https://docs.conda.io/en/latest/
-.. _Anaconda: https://anaconda.org/about
+.. _Anaconda: https://docs.anaconda.com/anacondaorg/
 .. _channels: https://docs.conda.io/projects/conda/en/latest/user-guide/concepts/channels.html
 .. _custom channels: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/create-custom-channels.html
 .. _conda-forge: https://conda-forge.org

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -394,7 +394,7 @@ Check out our :ref:`Configuration <default-cfg>` section to get started.
 .. _Django project: https://www.djangoproject.com/
 .. _Cookiecutter: https://cookiecutter.readthedocs.io/en/stable/
 .. _pip-tools: https://github.com/jazzband/pip-tools/
-.. _Pipenv: https://docs.pipenv.org
+.. _Pipenv: https://pipenv.pypa.io/en/stable
 .. _PyPI: https://pypi.org/
 .. _TestPyPI: https://test.pypi.org/
 .. _twine: https://twine.readthedocs.io/en/stable/
@@ -429,4 +429,4 @@ Check out our :ref:`Configuration <default-cfg>` section to get started.
 .. _Mozilla Public License 2.0: https://choosealicense.com/licenses/mpl-2.0/
 .. _editable installs: https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs
 .. _virtual environment: https://towardsdatascience.com/virtual-environments-104c62d48c54
-.. _Travis CI: https://travis-ci.com
+.. _Travis CI: https://docs.travis-ci.com

--- a/src/pyscaffold/templates/pre-commit-config.template
+++ b/src/pyscaffold/templates/pre-commit-config.template
@@ -41,7 +41,7 @@ repos:
 
 ## If like to embrace black styles even in the docs:
 # - repo: https://github.com/asottile/blacken-docs
-#   rev: v1.10.0
+#   rev: v1.11.0
 #   hooks:
 #   - id: blacken-docs
 #     additional_dependencies: [black]

--- a/src/pyscaffold/templates/tox_ini.template
+++ b/src/pyscaffold/templates/tox_ini.template
@@ -5,11 +5,11 @@
 [tox]
 minversion = 3.15
 envlist = default
+isolated_build = ${isolated_build}
 
 
 [testenv]
 description = Invoke pytest to run automated tests
-isolated_build = ${isolated_build}
 setenv =
     TOXINIDIR = {toxinidir}
 passenv =
@@ -42,7 +42,6 @@ description =
     docs: Invoke sphinx-build to build the docs
     doctests: Invoke sphinx-build to run doctests
     linkcheck: Check for broken links in the documentation
-usedevelop = True
 setenv =
     DOCSDIR = {toxinidir}/docs
     BUILDDIR = {toxinidir}/docs/_build

--- a/tox.ini
+++ b/tox.ini
@@ -4,11 +4,11 @@
 [tox]
 minversion = 3.15
 envlist = default
+isolated_build = True
 
 
 [testenv]
 description = Invoke pytest to run automated tests
-isolated_build = True
 setenv =
     TOXINIDIR = {toxinidir}
 passenv =
@@ -65,7 +65,6 @@ description =
     docs: Invoke sphinx-build to build the docs
     doctests: Invoke sphinx-build to run doctests
     linkcheck: Check for broken links in the documentation
-usedevelop = True
 setenv =
     DOCSDIR = {toxinidir}/docs
     BUILDDIR = {toxinidir}/docs/_build


### PR DESCRIPTION
This PR should fix #483. As described in the issue the solution proposed is to use `isolated_build` also for `docs` tasks with tox.

It seems that recent versions of tox just accept the `isolated_build` option as a global config and not per-environment, which is consistent with their most updated docs.
