### PR TITLE
Mark counter in skeleton explicitly as unused

### DIFF
--- a/src/pyscaffold/templates/skeleton.template
+++ b/src/pyscaffold/templates/skeleton.template
@@ -51,7 +51,7 @@ def fib(n):
     """
     assert n > 0
     a, b = 1, 1
-    for i in range(n - 1):
+    for _i in range(n - 1):
         a, b = b, a + b
     return a
 


### PR DESCRIPTION
Some IDEs might complain that the `i` variable in the for loop of `skeleton.py` is not used. In general, linters accept unused vars when they are explicitly marked with a `_` prefix.

This is also the case of [`flake8-bugbear`](https://pypi.org/project/flake8-bugbear/):

> B007: Loop control variable not used within the loop body.
> If this is intended, start the name with an underscore.