### PR TITLE
Ensure *--update* includes added extensions in setup.cfg

### DIFF
--- a/src/pyscaffold/actions.py
+++ b/src/pyscaffold/actions.py
@@ -227,6 +227,8 @@ def get_default_options(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
     opts.setdefault("package", make_valid_identifier(opts["name"]))
     opts.setdefault("author", info.username())
     opts.setdefault("email", info.email())
+    opts.setdefault("description", "")
+    opts.setdefault("url", "")
     opts.setdefault("release_date", date.today().strftime("%Y-%m-%d"))
     # All kinds of derived parameters
     year = datetime.strptime(opts["release_date"], "%Y-%m-%d").year

--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -9,6 +9,7 @@ import os
 import string
 import sys
 from types import ModuleType
+from types import SimpleNamespace as Object
 from typing import Any, Dict, Set, Union
 
 from configupdater import ConfigUpdater
@@ -161,10 +162,11 @@ def add_pyscaffold(config: ConfigUpdater, opts: ScaffoldOpts) -> ConfigUpdater:
 
     # Add the new extensions alongside the existing ones
     extensions = {ext.name for ext in opts.get("extensions", []) if ext.persist}
-    old = pyscaffold.pop("extensions", "")
-    old = parse_extensions(getattr(old, "value", old))  # coerce configupdater return
-    pyscaffold.set("extensions")
-    pyscaffold["extensions"].set_values(sorted(old | extensions))
+    old = pyscaffold.get("extensions", Object(value="")).value
+    new = list(sorted(parse_extensions(old) | extensions))
+    if new:
+        pyscaffold.set("extensions")
+        pyscaffold["extensions"].set_values(new)
 
     # Add extension-related opts, i.e. opts which start with an extension name
     allowed = {k: v for k, v in opts.items() if any(map(k.startswith, extensions))}

--- a/src/pyscaffold/update.py
+++ b/src/pyscaffold/update.py
@@ -107,12 +107,12 @@ def add_entrypoints(setupcfg: ConfigUpdater, opts: ScaffoldOpts):
 def update_setup_cfg(setupcfg: ConfigUpdater, opts: ScaffoldOpts):
     """Update `pyscaffold` in setupcfg and ensure some values are there as expected"""
     if "options" not in setupcfg:
-        setupcfg["metadata"].add_after.section("options")
+        template = templates.setup_cfg(opts)
+        new_section = ConfigUpdater().read_string(template)["options"]
+        setupcfg["metadata"].add_after.section(new_section.detach())
 
-    if "pyscaffold" not in setupcfg:
-        setupcfg.add_section("pyscaffold")
-
-    setupcfg["pyscaffold"]["version"] = pyscaffold_version
+    # Add "PyScaffold" section if missing and update saved extensions
+    setupcfg = templates.add_pyscaffold(setupcfg, opts)
     return setupcfg, opts
 
 


### PR DESCRIPTION
Prior to this change, new extensions added with `--update` were not being added to the `[pyscaffold]` section of `setup.cfg`.
