### PR TITLE
Merge '## Description' into previous section in README template

### DIFF
--- a/src/pyscaffold/templates/readme.template
+++ b/src/pyscaffold/templates/readme.template
@@ -32,11 +32,8 @@
 ${title}
 
 
-${description}
+    ${description}
 
-
-Description
-===========
 
 A longer description of your project goes here...
 


### PR DESCRIPTION
It also adds indentation to `${description}`, so it is formatted in a "highlighted" way, as to indicate that paragraph is a summary of the package's purpose (see: [pyscaffoldext-cookiecutter](https://github.com/pyscaffold/pyscaffoldext-cookiecutter))

Closes #498.