### PR TITLE
Remove bdist_wheel section from setup.cfg template

### DIFF
--- a/src/pyscaffold/templates/setup_cfg.template
+++ b/src/pyscaffold/templates/setup_cfg.template
@@ -94,10 +94,6 @@ testpaths = tests
 #     slow: mark tests as slow (deselect with '-m "not slow"')
 #     system: mark end-to-end system tests
 
-[bdist_wheel]
-# Use this option if your package is pure-python
-universal = 1
-
 [devpi:upload]
 # Options for the devpi: PyPI server and packaging tool
 # VCS export must be deactivated since we are using setuptools-scm

--- a/tests/system/test_common.py
+++ b/tests/system/test_common.py
@@ -164,8 +164,12 @@ def test_tox_build(cwd, tox, putup):
         # when we can call tox
         # then tasks will execute
         run(f"{tox} -e build")
+        # and a pure Python distribution is created
+        assert len(list(Path("dist").glob("*py3-none-any.whl"))) > 0
         try:
             run(f"{tox} -e clean")
+            assert not Path("dist").exists()
+            assert not Path("build").exists()
         except CalledProcessError as ex:
             msg = (ex.stdout or "") + (ex.stderr or "")
             if os.name == "nt" and ("unicodeescape" in msg):


### PR DESCRIPTION
[Packaging guides] and [wheels docs] seem to suggest that the `bdist_wheel` section is required to support Python 2 and Python 3 at the same time. Since Python 2 was retired, it makes sense to remove it.

PyScaffold's own `setup.cfg` file does not have this section and things work fine (setuptools seem to default to a pure Python 3 package).

Closes #497.

[packaging guides]: https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels
[wheels docs]: https://wheel.readthedocs.io/en/stable/quickstart.html