### PR TITLE
Avoid 'tool of choice' term in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@
 
 |
 
-PyScaffold is the tool of choice for bootstrapping high quality Python
+PyScaffold is a project generator for bootstrapping high quality Python
 packages, ready to be shared on PyPI_ and installable via pip_.
 It is easy to use and encourages the adoption of the best tools and
 practices of the Python ecosystem, helping you and your team

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,7 @@
 
 |
 
-PyScaffold is the tool of choice for bootstrapping high-quality Python
+PyScaffold is a project generator for bootstrapping high-quality Python
 packages, ready to be shared on PyPI_ and installable via pip_.
 It is easy to use and encourages the adoption of the best tools and
 practices of the Python ecosystem, helping you and your team


### PR DESCRIPTION
In the discussion on https://discuss.python.org/t/pyscaffold-joining-cooperating-with-pypa/10789
it was pointed out that people would be more comfortable if we don't use the expression "tool-of-choice", which is a good point.