### PR TITLE
Prevent multi-line descriptions for crashing putup

### DIFF
--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -135,10 +135,20 @@ def setup_cfg(opts: ScaffoldOpts) -> str:
     Returns:
         str: file content as string
     """
+
     template = get_template("setup_cfg")
-    cfg_str = template.substitute(opts)
+
+    # template assumes oneliner `description`, this workaround avoids parsing errors:
+    desc = opts.get("description", "").splitlines() or [""]
+    cfg_str = template.substitute({**opts, "description": desc[0]})
+
     updater = ConfigUpdater()
     updater.read_string(cfg_str)
+
+    # fix the workaround for multiline description
+    if desc[0] != opts.get("description", ""):
+        updater["metadata"]["description"].set_values(desc)
+
     requirements = deps.add(deps.RUNTIME, opts.get("requirements", []))
     updater["options"]["install_requires"].set_values(requirements)
 

--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -138,14 +138,15 @@ def setup_cfg(opts: ScaffoldOpts) -> str:
 
     template = get_template("setup_cfg")
 
-    # template assumes oneliner `description`, this workaround avoids parsing errors:
+    # template needs single-line `description`,
+    # thus we pass only the first line of a multi-line description...
     desc = opts.get("description", "").splitlines() or [""]
     cfg_str = template.substitute({**opts, "description": desc[0]})
 
     updater = ConfigUpdater()
     updater.read_string(cfg_str)
 
-    # fix the workaround for multiline description
+    # ... and finally the multi-line string for the full description.
     if desc[0] != opts.get("description", ""):
         updater["metadata"]["description"].set_values(desc)
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,11 +1,12 @@
 import sys
 from configparser import ConfigParser
+from pathlib import Path
 
 import pytest
 
 from pyscaffold import actions, api
 from pyscaffold import dependencies as deps
-from pyscaffold import templates
+from pyscaffold import info, templates
 
 
 def test_get_template():
@@ -80,3 +81,18 @@ def test_setup_cfg():
         assert dep in install_requires
     # Assert PyScaffold section
     assert setup_cfg["pyscaffold"].get("version")
+
+
+def test_setup_cfg_2line_description(tmpfolder):
+    # When a 2 line description is found (e.g. by reading an existing setup.cfg file)
+    _, opts = actions.get_default_options({}, {"project_path": tmpfolder})
+    opts["description"] = "2 line\ndescription"
+    # Then the rendered template should still be valid
+    text = templates.setup_cfg(opts)
+    setup_cfg = ConfigParser()
+    setup_cfg.read_string(text)
+    assert setup_cfg["metadata"]["description"].strip() == "2 line\ndescription"
+
+    Path(tmpfolder, "setup.cfg").write_text(text)
+    opts = info.project({})
+    assert opts["description"].strip() == "2 line\ndescription"


### PR DESCRIPTION
## Purpose

Users can decide to edit `setup.cfg` and change the description field to be a multi-line string.
This can break updates, because the current `setup.cfg` template depends on the fact it is a sinlge line (the INI/CFG syntax is broken otherwise).

This issue is related to #506.

## Approach
When rendering the template use just the first line of the description.
Then use ConfigUpdater to fix it, if necessary, with `set_values([ ... list of lines ...])`.