### PR TITLE
Prevent `None` extension parameters from crashing putup

### DIFF
--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -169,8 +169,10 @@ def add_pyscaffold(config: ConfigUpdater, opts: ScaffoldOpts) -> ConfigUpdater:
         pyscaffold["extensions"].set_values(new)
 
     # Add extension-related opts, i.e. opts which start with an extension name
-    allowed = {k: v for k, v in opts.items() if any(map(k.startswith, extensions))}
-    pyscaffold.update(allowed)
+    allowed = ((k, v) for k, v in opts.items() if any(map(k.startswith, extensions)))
+    allowed_ = {k: "" if v is None else v for k, v in allowed}
+    # ^  TODO: remove workaround for None values once ConfigUpdater solves #68
+    pyscaffold.update(allowed_)
 
     return config
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -235,6 +235,21 @@ def test_update_setup_cfg(tmpfolder):
     assert "options" in cfg
 
 
+def test_update_none_param(tmpfolder):
+    invalid = """\
+    [metadata]
+    [pyscaffold]
+    version = 4
+    """
+    Path(tmpfolder, "setup.cfg").write_text(dedent(invalid))
+    extensions = [Object(name="x_foo_bar_x", persist=True)]
+    _, opts = actions.get_default_options({}, {"extensions": extensions})
+    opts["x_foo_bar_x_param"] = None
+    # No parser exception should be found
+    update.update_setup_cfg({}, opts)
+    assert Path(tmpfolder, "setup.cfg").read_text()
+
+
 def test_add_dependencies(tmpfolder):
     # Given an existing setup.cfg
     Path(tmpfolder, "setup.cfg").write_text("[options]\n")


### PR DESCRIPTION
## Purpose
As shown in #506, ConfigUpdater will crash when trying to persist `option = None`.
This is problematic when an extension defines a "persitible" parameter that can assume `None`, since it may crash putup.

These changes implement a workaround for that.

## Approach
Force the parameter to be persisted as an empty string instead of None?
This might be controversial, but it is the safest approach for an `INI` format, since `INI` files are opaque in terms of types for option values (in the end of the day they are always strings and it is up for the users to interpret those strings the way they see fit).

## Alternative (not implemented) and Cons:
We could use `allow_no_value=True`, however other tools using the `setup.cfg` (e.g. setuptools, isort, pytest, mypy, etc...), might not like this (the default value for `allow_no_value` in ConfigParser is `False`), and therefore parser errors might crash them.
