### PR TITLE
Raise exception in the case extension is not installed

### DIFF
--- a/src/pyscaffold/api.py
+++ b/src/pyscaffold/api.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from . import __version__ as VERSION
 from . import actions, info
-from .exceptions import NoPyScaffoldProject
+from .exceptions import DirectErrorForUser, NoPyScaffoldProject
 
 # -------- Options --------
 
@@ -176,6 +176,8 @@ def _read_existing_config(opts):
         try:
             opts = info.project(opts)
             # ^  In case of an update read and parse setup.cfg inside project
+        except DirectErrorForUser:
+            raise
         except Exception as e:
             raise NoPyScaffoldProject from e
 

--- a/src/pyscaffold/exceptions.py
+++ b/src/pyscaffold/exceptions.py
@@ -6,7 +6,7 @@ import functools
 import logging
 import sys
 import traceback
-from typing import Optional, cast
+from typing import Optional, Sequence, cast
 
 if sys.version_info[:2] >= (3, 8):
     # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`
@@ -139,6 +139,18 @@ class ImpossibleToFindConfigDir(RuntimeError):
     def __init__(self, message=None, *args, **kwargs):
         message = message or self.__class__.__doc__
         super().__init__(message, *args, **kwargs)
+
+
+class ExtensionNotFound(ImportError):
+    """The following extensions were not found: {extensions}.
+    Please make sure you have the required versions installed.
+    You can look for official extensions at https://github.com/pyscaffold.
+    """
+
+    def __init__(self, extensions: Sequence[str]):
+        message = cast(str, self.__doc__)
+        message = message.format(extensions=extensions, version=pyscaffold_version)
+        super().__init__(message)
 
 
 class ErrorLoadingExtension(RuntimeError):

--- a/src/pyscaffold/exceptions.py
+++ b/src/pyscaffold/exceptions.py
@@ -53,17 +53,27 @@ class ActionNotFound(KeyError):
         super().__init__(message, *args, **kwargs)
 
 
-class DirectoryAlreadyExists(RuntimeError):
+class DirectErrorForUser(RuntimeError):
+    """Parent class for exceptions that can be shown directly as error messages
+    to the final users.
+    """
+
+    def __init__(self, message=None, *args, **kwargs):
+        message = message or self.__class__.__doc__
+        super().__init__(message, *args, **kwargs)
+
+
+class DirectoryAlreadyExists(DirectErrorForUser):
     """The project directory already exists, but no ``update`` or ``force``
     option was used.
     """
 
 
-class DirectoryDoesNotExist(RuntimeError):
+class DirectoryDoesNotExist(DirectErrorForUser):
     """No directory was found to be updated."""
 
 
-class GitNotInstalled(RuntimeError):
+class GitNotInstalled(DirectErrorForUser):
     """PyScaffold requires git to run."""
 
     DEFAULT_MESSAGE = "Make sure git is installed and working."
@@ -72,7 +82,7 @@ class GitNotInstalled(RuntimeError):
         super().__init__(message, *args, **kwargs)
 
 
-class GitNotConfigured(RuntimeError):
+class GitNotConfigured(DirectErrorForUser):
     """PyScaffold tries to read user.name and user.email from git config."""
 
     DEFAULT_MESSAGE = (
@@ -86,7 +96,7 @@ class GitNotConfigured(RuntimeError):
         super().__init__(message, *args, **kwargs)
 
 
-class GitDirtyWorkspace(RuntimeError):
+class GitDirtyWorkspace(DirectErrorForUser):
     """Workspace of git is empty."""
 
     DEFAULT_MESSAGE = (
@@ -104,7 +114,7 @@ class InvalidIdentifier(RuntimeError):
     """
 
 
-class PyScaffoldTooOld(RuntimeError):
+class PyScaffoldTooOld(DirectErrorForUser):
     """PyScaffold cannot update a pre 3.0 version"""
 
     DEFAULT_MESSAGE = (
@@ -116,7 +126,7 @@ class PyScaffoldTooOld(RuntimeError):
         super().__init__(message, *args, **kwargs)
 
 
-class NoPyScaffoldProject(RuntimeError):
+class NoPyScaffoldProject(DirectErrorForUser):
     """PyScaffold cannot update a project that it hasn't generated"""
 
     DEFAULT_MESSAGE = "Could not update project. Was it generated with PyScaffold?"
@@ -129,19 +139,15 @@ class ShellCommandException(RuntimeError):
     """Outputs proper logging when a ShellCommand fails"""
 
 
-class ImpossibleToFindConfigDir(RuntimeError):
+class ImpossibleToFindConfigDir(DirectErrorForUser):
     """An expected error occurred when trying to find the config dir.
 
     This might be related to not being able to read the $HOME env var in Unix
     systems, or %USERPROFILE% in Windows, or even the username.
     """
 
-    def __init__(self, message=None, *args, **kwargs):
-        message = message or self.__class__.__doc__
-        super().__init__(message, *args, **kwargs)
 
-
-class ExtensionNotFound(RuntimeError):
+class ExtensionNotFound(DirectErrorForUser):
     """The following extensions were not found: {extensions}.
     Please make sure you have the required versions installed.
     You can look for official extensions at https://github.com/pyscaffold.
@@ -153,7 +159,7 @@ class ExtensionNotFound(RuntimeError):
         super().__init__(message)
 
 
-class ErrorLoadingExtension(RuntimeError):
+class ErrorLoadingExtension(DirectErrorForUser):
     """There was an error loading '{extension}'.
     Please make sure you have installed a version of the extension that is compatible
     with PyScaffold {version}. You can also try unininstalling it.

--- a/src/pyscaffold/exceptions.py
+++ b/src/pyscaffold/exceptions.py
@@ -141,7 +141,7 @@ class ImpossibleToFindConfigDir(RuntimeError):
         super().__init__(message, *args, **kwargs)
 
 
-class ExtensionNotFound(ImportError):
+class ExtensionNotFound(RuntimeError):
     """The following extensions were not found: {extensions}.
     Please make sure you have the required versions installed.
     You can look for official extensions at https://github.com/pyscaffold.

--- a/src/pyscaffold/extensions/__init__.py
+++ b/src/pyscaffold/extensions/__init__.py
@@ -19,6 +19,11 @@ else:
 
 ENTRYPOINT_GROUP = "pyscaffold.cli"
 
+NO_LONGER_NEEDED = {"pyproject", "tox"}
+"""Extensions that are no longer needed and are now part of PyScaffold itself"""
+
+# TODO: NO_LONGER_SUPPORTED = {"no_pyproject"}
+
 
 class Extension:
     """Base class for PyScaffold's extensions

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -5,8 +5,9 @@ from pathlib import Path
 from unittest.mock import MagicMock as Mock
 
 import pytest
+from configupdater import ConfigUpdater
 
-from pyscaffold import cli, exceptions, info, repo, structure, templates
+from pyscaffold import actions, cli, exceptions, info, repo, structure, templates
 
 
 def test_username_with_git(git_mock):
@@ -145,6 +146,16 @@ def test_project_old_setupcfg(tmpfolder):
     demoapp = Path(__file__).parent / "demoapp"
     with pytest.raises(exceptions.PyScaffoldTooOld):
         info.project({}, config_path=demoapp)
+
+
+def test_project_extensions_not_found(tmpfolder):
+    _, opts = actions.get_default_options({}, {})
+    cfg = ConfigUpdater().read_string(templates.setup_cfg(opts))
+    cfg["pyscaffold"]["extensions"] = "x_foo_bar_x"
+    (tmpfolder / "setup.cfg").write(str(cfg))
+    with pytest.raises(exceptions.ExtensionNotFound) as exc:
+        info.project(opts)
+    assert "x_foo_bar_x" in str(exc.value)
 
 
 @pytest.mark.no_fake_config_dir


### PR DESCRIPTION
## Purpose
There are situations that the user tries to update a previously generated project with PyScaffold, but the extensions are not installed in the current venv.

Currently PyScaffold silently ignores the missing extensions, which can lead to crashes like #506.

## Approach
This PR tries to make this situation obvious and ask for the user to install the missing extensions.

I believe that it is better to panic and raise an exception instead of proceed running PyScaffold, because there are cases that the extensions completely change the desired behaviour (e.g. `namespace` indirectly via `custom_extension`).
