### PR TITLE
Handle comments in setup.cfg install_requires section.

### DIFF
--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -261,7 +261,7 @@ def read_setupcfg(path: PathLike, filename=SETUP_CFG) -> ConfigUpdater:
     if path.is_dir():
         path = path / (filename or SETUP_CFG)
 
-    updater = ConfigUpdater(inline_comment_prefixes=('#'))
+    updater = ConfigUpdater(inline_comment_prefixes=("#"))
     updater.read(path, encoding="utf-8")
 
     logger.report("read", path)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,14 +1,13 @@
 import logging
 import os
 import re
-import textwrap
 from configparser import ConfigParser
-from configupdater import ConfigUpdater
 from pathlib import Path
 from textwrap import dedent
 from types import SimpleNamespace as Object
 
 import pytest
+from configupdater import ConfigUpdater
 from packaging.version import Version
 
 from pyscaffold import __path__ as pyscaffold_paths
@@ -363,20 +362,27 @@ def test_replace_find_with_find_namespace(tmpfolder):
     assert cfg["options.packages.find"]["where"].value == "src"
     assert cfg["options.packages.find"]["exclude"].value.strip() == "tests"
 
+
 def test_add_dependencies_with_comments(tmpfolder):
     updater = ConfigUpdater()
-    Path(tmpfolder, "setup.cfg").write_text(dedent("""
-    [options]
-    install_requires =
-        importlib-metadata; python_version<"3.8"
-        #Adding some comments here that are perfectly valid.
-        some-other-dependency
-    """))
+    Path(tmpfolder, "setup.cfg").write_text(
+        dedent(
+            """
+            [options]
+            install_requires =
+                importlib-metadata; python_version<"3.8"
+                #Adding some comments here that are perfectly valid.
+                some-other-dependency
+            """
+        )
+    )
     add_dependencies(updater, {"project_path": tmpfolder, "pretend": False})
     actual_setup_cfg = Path(tmpfolder, "setup.cfg").read_text()
-    assert actual_setup_cfg == dedent("""
-    [options]
-    install_requires =
-        importlib-metadata; python_version<"3.8"
-        some-other-dependency
-    """)
+    assert actual_setup_cfg == dedent(
+        """
+        [options]
+        install_requires =
+            importlib-metadata; python_version<"3.8"
+            some-other-dependency
+        """
+    )


### PR DESCRIPTION
## Purpose
Add support for handing of comments within the install_requirements section in setup.cfg
```
[options]
install_requires =
    importlib-metadata; python_version<"3.8"
    #Adding some comments here that are perfectly valid.
    some-other-dependency
```
https://github.com/pyscaffold/pyscaffold/issues/516

## Approach
_How does this change address the problem?_'

This is a work in progress and is just a test that exercises the case and shows the failure.

#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

## Resources & Links

_Links to blog posts, patterns, libraries or addons used to solve this problem_
