### PR TITLE
Skip error if extensions are not installed

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,9 +1,12 @@
 from pathlib import Path
 from shutil import copytree
 
+import pytest
+
 from pyscaffold import cli
 from pyscaffold import file_system as fs
 from pyscaffold import shell
+from pyscaffold.exceptions import ExtensionNotFound
 
 
 def copy_example(name, target_dir) -> Path:
@@ -13,15 +16,18 @@ def copy_example(name, target_dir) -> Path:
 
 
 def test_issue506(tmpfolder):
-    # Given a project exists with the same `setup.cfg` from issue506
-    with fs.chdir(copy_example("issue-506", tmpfolder)):
-        shell.git("init", ".")
-        shell.git("add", ".")
-        shell.git("commit", "-m", "Add code before update")
-        # when we run the update
-        cli.run([".", "--update", "--force"])
-        # then no error should be raised when updating
-        # and the extension should load correctly (e.g. namespace)
-        assert Path("src/pyscaffoldext/company/__init__.py").exists()
-        assert not Path("src/pyscaffoldext/__init__.py").exists()
-        assert not Path("src/company").exists()
+    try:
+        # Given a project exists with the same `setup.cfg` from issue506
+        with fs.chdir(copy_example("issue-506", tmpfolder)):
+            shell.git("init", ".")
+            shell.git("add", ".")
+            shell.git("commit", "-m", "Add code before update")
+            # when we run the update
+            cli.main([".", "--update", "--force"])
+            # then no error should be raised when updating
+            # and the extension should load correctly (e.g. namespace)
+            assert Path("src/pyscaffoldext/company/__init__.py").exists()
+            assert not Path("src/pyscaffoldext/__init__.py").exists()
+            assert not Path("src/company").exists()
+    except ExtensionNotFound as ex:
+        pytest.skip(f"Test cannot succeed without extensions.\n{ex}")


### PR DESCRIPTION
This will prevent errors in the case we cannot have the `all` extras installed (e.g. on the conda-forge CI or when working in a new PyScaffold major version).
