### PR TITLE
Remove mention to `putup` in the CONTRIBUTING template

### DIFF
--- a/src/pyscaffold/templates/contributing.template
+++ b/src/pyscaffold/templates/contributing.template
@@ -149,7 +149,7 @@ Clone the repository
 
     pip install -U pip setuptools -e .
 
-   to be able run ``putup --help``.
+   to be able import the package under development in the Python REPL.
 
    .. todo:: if you are not using pre-commit, please remove the following item:
 
@@ -168,7 +168,7 @@ Implement your changes
 
     git checkout -b my-feature
 
-   and start making changes. Never work on the master branch!
+   and start making changes. Never work on the main branch!
 
 #. Start your work on this branch. Don't forget to add docstrings_ to new
    functions, modules and classes, especially if they are part of public APIs.


### PR DESCRIPTION
Previously we were mentioning `putup` in the generated CONTRIBUTING (probably I forgot to change it after copying and pasting from PyScaffold's own CONTRIBUTING).

This PR changes that for something more generic.

Additionally it also replaces the reference to `master` with `main`.

(Currently GitHub instruct users to rename their master branch to main in the first push. Moreover `main` is more generic if we consider it as an adjective instead of a noun and therefore can also refer to `master` since it is the main branch after all...)