### PR TITLE
Improve `sphinx.ext.extlinks` configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,6 +97,7 @@ master_doc = "index"
 # General information about the project.
 project = "PyScaffold"
 copyright = "2014, Blue Yonder"
+repository = "https://github.com/pyscaffold/pyscaffold/"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -304,12 +305,11 @@ intersphinx_mapping = {
     "configupdater": ("https://configupdater.readthedocs.io/en/stable/", None),
 }
 extlinks = {
-    "issue": ("https://github.com/pyscaffold/pyscaffold/issues/%s", "issue #"),
-    "pr": ("https://github.com/pyscaffold/pyscaffold/pull/%s", "PR #"),
-    "discussion": (
-        "https://github.com/pyscaffold/pyscaffold/discussions/%s",
-        "discussion #",
-    ),
+    "issue": (f"{repository}/issues/%s", "issue #%s"),
+    "pr": (f"{repository}/pull/%s", "PR #%s"),
+    "discussion": (f"{repository}/discussions/%s", "discussion #%s"),
+    "pypi": ("https://pypi.org/project/%s", "%s"),
+    "github": ("https://github.com/%s", "%s")
 }
 
 print(f"loading configurations for {project} {version} ...", file=sys.stderr)


### PR DESCRIPTION
## Purpose
Recently I have been looking into Sphinx extlinks config for another project and I noticed that the  [docs](https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html) say:

> If caption is a string, then it must contain %s exactly once.

Which we are not currently doing, which gives me the impression that we are relying on an undocumented behaviour.

## Approach
This PR tries to fix that by adding `%s` in the configurations.

(I also went ahead and refactored the GitHub links and added 2 new ext links for `github` and `pypi`)

---
#### Note for a future PR:
Sphinx itself adds a role for [PEPs](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html) and RFCs, so we don't have to add the links manually...