### PR TITLE
Fix type check errors

### DIFF
--- a/src/pyscaffold/extensions/config.py
+++ b/src/pyscaffold/extensions/config.py
@@ -62,7 +62,7 @@ def save(struct: "Structure", opts: "ScaffoldOpts") -> "ActionParams":
         file = Path(opts["save_config"])
 
     if file.exists():
-        config.read(file, encoding="utf-8")
+        config.read(str(file), encoding="utf-8")
     else:
         config.read_string(
             "# PyScaffold's configuration file, see:\n"

--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -193,7 +193,7 @@ def project(
         "author": metadata.get("author"),
         "email": metadata.get("author_email") or metadata.get("author-email"),
         "url": metadata.get("url"),
-        "description": metadata.get("description", "").strip(),
+        "description": cast(str, metadata.get("description", "")).strip(),
         "license": license and best_fit_license(license),
     }
     existing = {k: v for k, v in existing.items() if v}  # Filter out non stored values
@@ -205,7 +205,7 @@ def project(
     # Complement the cli extensions with the ones from configuration
     not_found_ext: Set[str] = set()
     if "extensions" in pyscaffold:
-        cfg_extensions = parse_extensions(pyscaffold.pop("extensions", ""))
+        cfg_extensions = parse_extensions(pyscaffold.pop("extensions", None) or "")
         opt_extensions = {ext.name for ext in opts.setdefault("extensions", [])}
         add_extensions = cfg_extensions - opt_extensions
 
@@ -262,7 +262,7 @@ def read_setupcfg(path: PathLike, filename=SETUP_CFG) -> ConfigUpdater:
         path = path / (filename or SETUP_CFG)
 
     updater = ConfigUpdater()
-    updater.read(path, encoding="utf-8")
+    updater.read(str(path), encoding="utf-8")
 
     logger.report("read", path)
 
@@ -299,7 +299,7 @@ def get_curr_version(project_path: PathLike):
         Version: version specifier
     """
     setupcfg = read_setupcfg(project_path).to_dict()
-    return Version(setupcfg["pyscaffold"]["version"])
+    return Version(str(setupcfg["pyscaffold"]["version"]))
 
 
 (RAISE_EXCEPTION,) = list(Enum("default", "RAISE_EXCEPTION"))  # type: ignore

--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -10,7 +10,7 @@ import string
 import sys
 from types import ModuleType
 from types import SimpleNamespace as Object
-from typing import Any, Dict, Set, Union
+from typing import Any, Dict, Set, Union, cast
 
 from configupdater import ConfigUpdater
 
@@ -173,7 +173,7 @@ def add_pyscaffold(config: ConfigUpdater, opts: ScaffoldOpts) -> ConfigUpdater:
 
     # Add the new extensions alongside the existing ones
     extensions = {ext.name for ext in opts.get("extensions", []) if ext.persist}
-    old = pyscaffold.get("extensions", Object(value="")).value
+    old = cast(str, pyscaffold.get("extensions", Object(value="")).value)
     new = list(sorted(parse_extensions(old) | extensions))
     if new:
         pyscaffold.set("extensions")


### PR DESCRIPTION
Recently we added a `py.typed` file to `configupdater`, which means that now mypy also uses the type hints information of that dependency in its checks.

The changes implemented here target some [type errors](https://cirrus-ci.com/task/5341047447355392?logs=typecheck) identified in #529.