### PR TITLE
Replace beetle emoji by bug

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -41,8 +41,8 @@ Please `reach us out`_, we would love to have you on board and discuss what can
 be done!
 
 
-|:beetle:| Issue Reports
-------------------------
+|:bug:| Issue Reports
+---------------------
 
 If you experience bugs or general issues with PyScaffold, please have a look
 on our `issue tracker`_.


### PR DESCRIPTION
This is a purely cosmetic and vanity change 😝 
I notice that only Firefox is able to render the `:beetle:` 🪲  emoji correctly.
Therefore the solution is to rely on the `:bug:` 🐛  emoji for the contributing guides.