### PR TITLE
Modernise usage and mentions to `setup.py` in favour of `build`.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -112,7 +112,7 @@ linux_mac_task:
       brew_cache:
         folder: "$HOME/Library/Caches/Homebrew"
       install_script:
-        - brew install python gnu-tar
+        - brew install python
         - brew cleanup
   <<: *REGULAR_TASK_TEMPLATE
 

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -29,4 +29,5 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m pip install --upgrade pip setuptools tox
-        python -m tox -e clean,build,publish -- --verbose --repository pypi
+        python -m tox -e clean,build
+        python -m tox publish -- --verbose --repository pypi

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -291,8 +291,7 @@ you are trying to run the CI scripts in a fork repository, make sure to push
 all the tags.
 You can also try to remove all the egg files or the complete egg folder, i.e.,
 ``.eggs``, as well as the ``*.egg-info`` folders in the ``src`` folder or
-potentially in the root of your project. Afterwards run ``python setup.py
-egg_info --egg-base .`` again.
+potentially in the root of your project.
 
 ..
 

--- a/README.rst
+++ b/README.rst
@@ -117,9 +117,8 @@ All configuration can be done in ``setup.cfg`` like changing the description,
 URL, classifiers, installation requirements and so on as defined by setuptools_.
 That means in most cases it is not necessary to tamper with ``setup.py``.
 
-In order to build a source or wheel distribution, just run
-``tox -e build`` (``python setup.py sdist`` or ``python setup.py bdist_wheel``
-if you don't use tox_).
+In order to build a source or wheel distribution, just run ``tox -e build``
+(if you don't use tox_, you can also install ``build`` and run ``python -m build``).
 
 .. rubric:: Package and Files Data
 
@@ -147,8 +146,7 @@ the information of tags to infer the version of your project with the help of
 setuptools_scm_.
 To use this feature, you need to tag with the format ``MAJOR.MINOR[.PATCH]``
 , e.g. ``0.0.1`` or ``0.1``.
-Run ``python setup.py --version`` to retrieve the current PEP440_-compliant
-version.
+.. Run ``python -m setuptools_scm`` to retrieve the current PEP440_-compliant version.
 This version will be used when building a package and is also accessible
 through ``my_project.__version__``.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -304,7 +304,7 @@ Best Practices and Common Errors with Version Numbers
 How do I get a clean version like 3.2.4 when I have 3.2.3.post0.dev9+g6817bd7?
     Just commit all your changes and create a new tag using ``git tag v3.2.4``.
     In order to build an old version checkout an old tag, e.g. ``git checkout -b v3.2.3 v3.2.3``
-    and run ``tox -e build``.
+    and run ``tox -e build`` (or install the ``build`` package and run ``python -m build --wheel``).
 
 Why do I see `unknown` as version?
     In most cases this happens if your source code is no longer a proper Git repository, maybe because
@@ -313,7 +313,7 @@ Why do I see `unknown` as version?
     for developers of your Python project, which have Git installed and use a proper Git repository anyway.
     Users of your project should always install it using the distribution you built for them e.g.
     ``pip install my_project-3.2.3-py3-none-any.whl``.  You build such a distribution by running
-    ``tox -e build`` and then find it under ``./dist``.
+    ``tox -e build`` (or ``python -m build --wheel`` after installing ``build``) and then find it under ``./dist``.
 
 Is there a good versioning scheme I should follow?
     The most common practice is to use `Semantic Versioning`_. Following this practice avoids the so called

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -171,7 +171,8 @@ File Organisation and Directory Structure
 
 Why does PyScaffold ≥ 3 have a ``src`` folder which holds the actual Python package?
    This avoids quite many problems compared to the case when the actual Python package resides in the same folder as
-   ``setup.py``. A nice `blog post by Ionel`_ gives a thorough explanation why this is so. In a nutshell, the most severe
+   your configuration and test files.
+   A nice `blog post by Ionel`_ gives a thorough explanation why this is so. In a nutshell, the most severe
    problem comes from the fact that Python imports a package by first looking at the current working directory and then
    into the ``PYTHONPATH`` environment variable. If your current working directory is the root of your project directory
    you are thus not testing the installation of your package but the local package directly. Eventually, this always
@@ -303,16 +304,16 @@ Best Practices and Common Errors with Version Numbers
 How do I get a clean version like 3.2.4 when I have 3.2.3.post0.dev9+g6817bd7?
     Just commit all your changes and create a new tag using ``git tag v3.2.4``.
     In order to build an old version checkout an old tag, e.g. ``git checkout -b v3.2.3 v3.2.3``
-    and run ``tox -e build`` or ``python setup.py bdist_wheel``.
+    and run ``tox -e build``.
 
 Why do I see `unknown` as version?
     In most cases this happens if your source code is no longer a proper Git repository, maybe because
-    you moved or copied it or Git is not even installed. In general using ``pip install -e .``,
-    ``python setup.py install`` or ``python setup.py develop`` to install your package is only recommended
+    you moved or copied it or Git is not even installed.
+    In general using ``pip install -e .`` to install your package is only recommended
     for developers of your Python project, which have Git installed and use a proper Git repository anyway.
     Users of your project should always install it using the distribution you built for them e.g.
     ``pip install my_project-3.2.3-py3-none-any.whl``.  You build such a distribution by running
-    ``tox -e build`` (or ``python setup.py bdist_wheel``) and then find it under ``./dist``.
+    ``tox -e build`` and then find it under ``./dist``.
 
 Is there a good versioning scheme I should follow?
     The most common practice is to use `Semantic Versioning`_. Following this practice avoids the so called
@@ -342,10 +343,13 @@ How can I build a distribution if I have only the source code without a proper g
        setuptools-scm was unable to detect version for 'your/project'.
 
     This means that ``setuptools-scm`` could not find an intact git repository. If you still want to build
-    a distribution from the source code there is a workaround. In ``setup.cfg`` in the section ``[metadata]``
-    define a version manually with e.g. ``version = 1.0``. Now remove from ``pyproject.toml`` the requirement
-    ``use_scm_version={"version_scheme": "no-guess-dev"}`` if you use isolated builds with ``tox`` and/or
-    ``"setuptools_scm[toml]>=5"`` from ``setup.cfg`` if you use ``python setup.py bdist_wheel`` to build.
+    a distribution from the source code there is a workaround:
+    you can try setting setuptools_scm_ environment variables, e.g. ``SETUPTOOLS_SCM_PRETEND_VERSION=1.0``.
+    If that is not enough, try completely removing it. In ``setup.cfg`` in the section ``[metadata]``
+    define a version manually with e.g. ``version = 1.0``. Now remove from ``pyproject.toml`` the
+    ``setuptools_scm`` build requirement and the ``[tool.setuptools_scm]`` table.
+    Also remove ``use_scm_version={"version_scheme": "no-guess-dev"}`` from ``setup.py``.
+
 
 .. _blog post by Ionel: https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure
 .. _src layout: https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -25,11 +25,9 @@ compliant way, by just running::
     tox -e build
 
 Alternatively, if you are not a huge fan of isolated builds, or prefer running
-the commands yourself, you can execute ``python setup.py bdist_wheel``. Source
-distributions, i.e. ``sdist``, are obsolete and no longer recommended as they
-ignore several options in ``setup.cfg``. If ``universal=1`` in the ``[bdist_wheel]``
-section of ``setup.cfg``, a generated wheel distribution will be as flexible as
-a source distribution and can be installed on every architecture.
+the commands yourself, you can execute ``python -m build --no-isolation .``.
+Source distributions, i.e. ``sdist``, are only recommended if you absolutely need them.
+They are tricky to configure and may ignore several options in ``setup.cfg``.
 
 .. rubric:: Uploading to PyPI
 
@@ -138,7 +136,7 @@ Your project is already an initialised Git repository and setuptools_ uses the
 information of tags to infer the version of your project with the help of
 `setuptools_scm`_.  To use this feature you need to tag with the format
 ``MAJOR.MINOR[.PATCH]`` , e.g. ``0.0.1`` or ``0.1``.
-Run ``python setup.py --version`` to retrieve the current `PEP 440`_-compliant version.
+.. Run ``python -m setuptools_scm`` to retrieve the current `PEP 440`_-compliant version.
 This version will be used when building a package and is also accessible through
 ``my_project.__version__``. If you want to upload to PyPI_ you have to tag the current commit
 before uploading since PyPI_ does not allow local versions, e.g. ``0.0.dev5+gc5da6ad``,

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -25,7 +25,7 @@ compliant way, by just running::
     tox -e build
 
 Alternatively, if you are not a huge fan of isolated builds, or prefer running
-the commands yourself, you can execute ``python -m build --no-isolation .``.
+the commands yourself, you can execute ``python -m build --wheel --no-isolation``.
 Source distributions, i.e. ``sdist``, are only recommended if you absolutely need them.
 They are tricky to configure and may ignore several options in ``setup.cfg``.
 

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -39,7 +39,8 @@ Let's start:
    In most cases you will not need to make changes to the new ``setup.py`` file provided by PyScaffold.
    The only exceptions are if your project uses compiled resources, e.g. Cython.
 
-#. In order to check that everything works, run ``pip install .`` and ``tox -e build`` (or ``python setup.py sdist``).
+#. In order to check that everything works, run ``pip install .`` and ``tox -e build``
+   (or ``python -m build --wheel`` after installing ``build``).
    If those two commands don't work, check ``pyproject.toml``, ``setup.cfg``, ``setup.py`` as well as your package under ``src`` again.
    Were all modules moved correctly? Is there maybe some ``__init__.py`` file missing?
    Be aware that projects containing a ``pyproject.toml`` file will build in a

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,11 +76,15 @@ ds =
     pyscaffoldext-dsproject>=0.5
 # Add here test dependencies (used by tox)
 testing =
+    # Used for building/installing during tests
     setuptools
+    setuptools_scm[toml]
+    wheel
+    build
+    #
     tomlkit     # as dependency in `-e fast`
     certifi     # tries to prevent certificate problems on windows
     tox         # system tests use tox inside tox
-    build       # system tests use it to build projects
     pre-commit  # system tests run pre-commit
     sphinx      # system tests build docs
     flake8      # system tests run flake8
@@ -122,7 +126,7 @@ addopts =
     --verbose
 #    In order to use xdist, the developer can add, for example, the following
 #    arguments:
-#    --dist=load --numprocesses=auto
+#    --numprocesses=auto
 norecursedirs =
     dist
     build

--- a/src/pyscaffold/extensions/venv.py
+++ b/src/pyscaffold/extensions/venv.py
@@ -75,13 +75,7 @@ def run(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
             logger.report("skip", venv_path)
             return struct, opts
 
-        for creator in (create_with_virtualenv, create_with_stdlib):
-            with suppress(ImportError):
-                creator(venv_path, opts.get("pretend"))
-                break
-        else:
-            # no break statement found, so no creator function executed correctly
-            raise NotInstalled()
+        create(venv_path, opts.get("pretend"))
 
     return struct, opts
 
@@ -161,6 +155,19 @@ def create_with_stdlib(path: Path, pretend=False):
         venv.create(str(path), with_pip=True)
 
     logger.report("venv", path)
+
+
+def create(path: Path, pretend=False):
+    """Create the virtual environment with the first technique available.
+    (``virtualenv`` is preferred because it is faster).
+    """
+    for creator in (create_with_virtualenv, create_with_stdlib):
+        with suppress(ImportError):
+            creator(path, pretend)
+            break
+    else:
+        # no break statement found, so no creator function executed correctly
+        raise NotInstalled()
 
 
 class NotInstalled(ImportError):

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -83,7 +83,7 @@ linux_mac_task:
       brew_cache:
         folder: "$HOME/Library/Caches/Homebrew"
       install_script:
-        - brew install python gnu-tar
+        - brew install python
         - brew cleanup
   <<: *REGULAR_TASK_TEMPLATE
 

--- a/src/pyscaffold/templates/gitlab_ci.template
+++ b/src/pyscaffold/templates/gitlab_ci.template
@@ -30,8 +30,7 @@ before_script:
   - git config --global user.email "you@example.com"
   - git config --global user.name "Your Name"
   # Install dependencies for the testing environment
-  - pip install -U pip setuptools
-  - pip install -U tox
+  - pip install -U pip setuptools tox
 
 .test_script: &test_script
   script:
@@ -67,5 +66,5 @@ docs:
 #  type: deploy
 #  environment: production
 #  script:
-#    - python setup.py
+#    - tox -e build
 #    - dpl --provider=heroku --app=$HEROKU_APP_NAME --api-key=$HEROKU_PRODUCTION_KEY

--- a/src/pyscaffold/templates/tox_ini.template
+++ b/src/pyscaffold/templates/tox_ini.template
@@ -24,17 +24,15 @@ commands =
 description =
     build: Build the package in isolation according to PEP517, see https://github.com/pypa/build
     clean: Remove old distribution files and temporary build artifacts (./build and ./dist)
-# NOTE: build is still experimental, please refer to the links for updates/issues
 # https://setuptools.pypa.io/en/stable/build_meta.html#how-to-use-it
-# https://github.com/pypa/pep517/issues/91
 skip_install = True
 changedir = {toxinidir}
 deps =
     build: build[virtualenv]
 commands =
     clean: python -c 'from shutil import rmtree; rmtree("build", True); rmtree("dist", True)'
-    build: python -m build .
-# By default `build` produces wheels, you can also explicitly use the flags `--sdist` and `--wheel`
+    build: python -m build {posargs:--wheel}
+    # You can also explicitly use the `--sdist` flag if you really want to
 
 
 [testenv:{docs,doctests,linkcheck}]

--- a/tests/demoapp/setup.cfg
+++ b/tests/demoapp/setup.cfg
@@ -2,10 +2,10 @@
 name = demoapp
 description = A demo application for PyScaffold's unit testing
 author = Florian Wilhelm
-author-email = Florian.Wilhelm@blue-yonder.com
+author_email = Florian.Wilhelm@blue-yonder.com
 license = new BSD
 url = https://pyscaffold.org/
-long-description = file: README.rst
+long_description = file: README.rst
 platforms = any
 classifiers =
     Development Status :: 5 - Production/Stable

--- a/tests/demoapp_data/setup.cfg
+++ b/tests/demoapp_data/setup.cfg
@@ -2,10 +2,10 @@
 name = demoapp_data
 description = A demo application with data for PyScaffold's unit testing
 author = Florian Wilhelm
-author-email = Florian.Wilhelm@blue-yonder.com
+author_email = Florian.Wilhelm@blue-yonder.com
 license = new BSD
 url = https://pyscaffold.org/
-long-description = file: README.rst
+long_description = file: README.rst
 platforms = any
 classifiers =
     Development Status :: 5 - Production/Stable

--- a/tests/system/helpers.py
+++ b/tests/system/helpers.py
@@ -92,9 +92,6 @@ def run_common_tasks(tests=True, flake8=True):
     run(sphinx_cmd("doctest"))
     run(sphinx_cmd("html"))
 
-    run(f"{PYTHON} setup.py --version")
-    run(f"{PYTHON} setup.py sdist")
-    run(f"{PYTHON} setup.py bdist")
     run(f"{PYTHON} -m build .")
 
     if flake8 and environ.get("COVERAGE") == "true":

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -98,7 +98,7 @@ class DemoApp:
 
         # setuptools-scm is used for tests
         if os.name == "os":
-            # Windows which lacks some certificates
+            # Windows lacks some certificates
             self.pip("install", "-q", "certifi", "setuptools_scm")
         else:
             self.pip("install", "-q", "setuptools_scm")

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -37,7 +37,7 @@ def test_shell_command_error2exit_decorator():
 
 
 def test_command_exists():
-    assert shell.command_exists("tar")
+    assert shell.command_exists("python")
     assert not shell.command_exists("ldfgyupmqzbch174")
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,17 +47,15 @@ commands =
 description =
     build: Build the package in isolation according to PEP517, see https://github.com/pypa/build
     clean: Remove old distribution files and temporary build artifacts (./build and ./dist)
-# NOTE: build is still experimental, please refer to the links for updates/issues
 # https://setuptools.pypa.io/en/latest/build_meta.html#how-to-use-it
-# https://github.com/pypa/pep517/issues/91
 skip_install = True
 changedir = {toxinidir}
 deps =
     build: build[virtualenv]
 commands =
     clean: python -c 'from shutil import rmtree; rmtree("build", True); rmtree("dist", True)'
-    build: python -m build .
-# By default `build` produces wheels, you can also explicitly use the flags `--sdist` and `--wheel`
+    build: python -m build {posargs:--wheel}
+    # You can also explicitly use the `--sdist` flag if you really want to
 
 
 [testenv:{docs,doctests,linkcheck}]


### PR DESCRIPTION
## Purpose
There have been a bunch of changes in packaging practices for Python
since the last time we looked into `test_install`, between them:

- direct invocation of `python setup.py` is now [deprecated]
  (the existence of the file itself does not seem to be deprecated, but running it directly is)
- `setuptools_scm` also deprecated `python setup.py --version`
- `bdist`s, that were already deprecated, should be no longer used by today standards...
- PyPA is actively promoting `python -m build` as main interface

The purpose of this PR is to modernise `test_install` (and hopefully make it faster).

## Approach

- Use `python -m build {--wheel,--sdist}` instead of `python setup.py {sdist,bdist_wheel}`
- Remove `bdist` tests 🎉 
- Remove calls to `python setup.py --version`

I also took the opportunity to use the `venv` module we have in place for the `--venv` extension (reasons: more coverage for that module + I never liked pytest-virtualenv ...).

## Side Effects

- We no longer need to manually manage confusing `tar` files
- Which means that we don't need to install `gnu-tar` in the OS X test on the CI
- Less time creating venvs during tests

[deprecated]: https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html