### PR TITLE
Prevent accidental creation of nested projects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,12 +3,14 @@ Changelog
 =========
 
 
-..
-    Development version
-    ===================
+Development version
+===================
 
-    Version 4.X.X, 2021-XX-XX
-    -------------------------
+Version 4.X.X, 2021-XX-XX
+-------------------------
+
+- Added verification to prevent users from creating projects nested inside
+  existing repositories, unless ``--force`` is explicitly given, :issue:`544`, :pr:`545`.
 
 
 Current versions

--- a/src/pyscaffold/actions.py
+++ b/src/pyscaffold/actions.py
@@ -300,7 +300,7 @@ def verify_project_dir(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
         raise DirectoryDoesNotExist(
             f"Project {project_path} does not exist and thus cannot be updated!"
         )
-    elif repo.is_git_repo(parent_path):
+    elif repo.is_git_repo(parent_path) and not opts["force"]:
         raise NestedRepository(parent_path)
 
     return struct, opts

--- a/src/pyscaffold/exceptions.py
+++ b/src/pyscaffold/exceptions.py
@@ -176,3 +176,19 @@ class ErrorLoadingExtension(DirectErrorForUser):
         message = cast(str, self.__doc__)
         message = message.format(extension=extension, version=pyscaffold_version)
         super().__init__(message)
+
+
+class NestedRepository(DirectErrorForUser):
+    """The directory '{directory}' is already part of a git repository.
+
+    PyScaffold avoids creating nested projects to prevent errors with
+    `setuptools-scm`.
+
+    If you know what you are doing you can try running `putup` again with
+    the`--force` flag, but please be aware that you will have to manually
+    customise the configuration for `setuptools-scm`. For more information,
+    have a look on:
+
+    - https://github.com/pypa/setuptools_scm
+    - https://github.com/pyscaffold/pyscaffold/issues/423
+    """

--- a/src/pyscaffold/exceptions.py
+++ b/src/pyscaffold/exceptions.py
@@ -6,7 +6,8 @@ import functools
 import logging
 import sys
 import traceback
-from typing import Optional, Sequence, cast
+from pathlib import Path
+from typing import Optional, Sequence, Union, cast
 
 if sys.version_info[:2] >= (3, 8):
     # TODO: Import directly (no need for conditional) when `python_requires = >= 3.8`
@@ -192,3 +193,7 @@ class NestedRepository(DirectErrorForUser):
     - https://github.com/pypa/setuptools_scm
     - https://github.com/pyscaffold/pyscaffold/issues/423
     """
+
+    def __init__(self, directory: Union[str, Path]):
+        message = cast(str, self.__doc__)
+        super().__init__(message.format(directory=directory))

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -71,6 +71,13 @@ def test_verify_nested_repository(tmpfolder, git_mock):
         verify_project_dir({}, opts)
 
 
+def test_verify_nested_repository_when_forcing(tmpfolder, git_mock):
+    Path(tmpfolder, ".git").mkdir()  # Pretend parent is a git repo using git_mock
+    opts = dict(project_path=Path(tmpfolder, "my-project"), update=False, force=True)
+    # No error should be raised if `force` is True
+    verify_project_dir({}, opts)
+
+
 def custom_action(structure, options):
     return structure, options
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -12,6 +12,7 @@ from pyscaffold.exceptions import (
     DirectoryDoesNotExist,
     GitNotConfigured,
     GitNotInstalled,
+    NestedRepository,
 )
 from pyscaffold.structure import define_structure
 
@@ -60,6 +61,13 @@ def test_verify_project_dir_when_project_exist_but_not_updating(tmpfolder, git_m
     tmpfolder.ensure("my-project", dir=True)
     opts = dict(project_path=Path("my-project"), update=False, force=False)
     with pytest.raises(DirectoryAlreadyExists):
+        verify_project_dir({}, opts)
+
+
+def test_verify_nested_repository(tmpfolder, git_mock):
+    Path(tmpfolder, ".git").mkdir()  # Pretend parent is a git repo using git_mock
+    opts = dict(project_path=Path(tmpfolder, "my-project"), update=False, force=False)
+    with pytest.raises(NestedRepository):
         verify_project_dir({}, opts)
 
 


### PR DESCRIPTION
## Purpose
This PR attempts to prevent users from accidentally creating nested projects, which may result in problems with `setuptools-scm`, as described in #544.

## Approach
The `pyscaffold.actions.verify_project_dir` was modified to also look for nested repositories and raise an error when relevant.

If the `--force` option is given, PyScaffold will understand that the users know what they are doing and create the project without complaining.

