### PR TITLE
Add missing -e flag to the publish-package GitHub workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -30,4 +30,4 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools tox
         python -m tox -e clean,build
-        python -m tox publish -- --verbose --repository pypi
+        python -m tox -e publish -- --verbose --repository pypi


### PR DESCRIPTION
## Purpose

This Pull Request adds the missing `-e` option to the `tox -e publish` command. It fixes the issue reported in [pyscaffold#551](https://github.com/pyscaffold/pyscaffold/issues/551).

It is a straightforward fix that should not affect anything else, so I believe further details are unnecessary.