### PR TITLE
Always log shell ops and fixes issue 556

### DIFF
--- a/src/pyscaffold/actions.py
+++ b/src/pyscaffold/actions.py
@@ -318,7 +318,7 @@ def init_git(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
     """
     path = opts.get("project_path", ".")
     if not opts["update"] and not repo.is_git_repo(path):
-        repo.init_commit_repo(path, struct, log=True, pretend=opts.get("pretend"))
+        repo.init_commit_repo(path, struct, pretend=opts.get("pretend"))
 
     return struct, opts
 

--- a/src/pyscaffold/extensions/namespace.py
+++ b/src/pyscaffold/extensions/namespace.py
@@ -132,7 +132,7 @@ def move_old_package(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
             directory structure as dictionary of dictionaries and input options
     """
     project_path = Path(opts.get("project_path", "."))
-    with chdir(project_path, log=True, **opts):
+    with chdir(project_path, **opts):
         old_path = Path("src", opts["package"])
         namespace_path = opts["qual_pkg"].replace(".", os.sep)
         target = Path("src", namespace_path)
@@ -155,6 +155,6 @@ def move_old_package(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
                     namespace_path,
                 )
 
-            move(old_path, target=target, log=True, pretend=opts["pretend"])
+            move(old_path, target=target, pretend=opts["pretend"])
 
     return struct, opts

--- a/src/pyscaffold/extensions/pre_commit.py
+++ b/src/pyscaffold/extensions/pre_commit.py
@@ -117,7 +117,7 @@ def install(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
     if pre_commit:
         try:
             with chdir(opts.get("project_path", "."), **opts):
-                pre_commit("install", log=True, pretend=opts.get("pretend"))
+                pre_commit("install", pretend=opts.get("pretend"))
             logger.warning(SUCCESS_MSG)
             return struct, opts
         except ShellCommandException:

--- a/tests/test_file_system.py
+++ b/tests/test_file_system.py
@@ -22,7 +22,7 @@ def test_chdir(caplog, tmpdir, isolated_logger):
     curr_dir = os.getcwd()
     dname = uniqstr()  # Use a unique name to get easily identifiable logs
     temp_dir = str(tmpdir.mkdir(dname))
-    with fs.chdir(temp_dir, log=True):
+    with fs.chdir(temp_dir):
         new_dir = os.getcwd()
     assert new_dir == os.path.realpath(temp_dir)
     assert curr_dir == os.getcwd()
@@ -176,15 +176,8 @@ def test_move_log(tmpfolder, caplog):
     # Given a file or directory exists,
     tmpfolder.join(fname1).write("text")
     tmpfolder.join(fname2).write("text")
-    # When it is moved without log kwarg,
-    tmpfolder.join(dname).ensure_dir()
-    fs.move(fname1, target=dname)
-    # Then no log should be created.
-    logs = caplog.text
-    assert not re.search(f"move.+{fname1}.+to.+{dname}", logs)
-    # When it is moved with log kwarg,
-    fs.move(fname2, target=dname, log=True)
-    # Then log should be created.
+    fs.move(fname2, target=dname)
+    # log should be created.
     logs = caplog.text
     assert re.search(f"move.+{fname2}.+to.+{dname}", logs)
 


### PR DESCRIPTION
This should eventually fix #556. As in the discussion of the issue also the problem of debugging came up, the first step is to always log shell operations. This actually reduces code complexity as we always log and let the log level decide what we show. This behaviour for `ShellCommand` is then more consistent to how the rest of PyScaffold works.
