### PR TITLE
Fix problem with Win10 shell

### DIFF
--- a/src/pyscaffold/file_system.py
+++ b/src/pyscaffold/file_system.py
@@ -11,7 +11,6 @@ import errno
 import os
 import shutil
 import stat
-import sys
 from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
@@ -19,6 +18,7 @@ from tempfile import mkstemp
 from typing import Callable, Optional, Union
 
 from .log import logger
+from .shell import IS_WINDOWS
 
 PathLike = Union[str, os.PathLike]
 
@@ -199,11 +199,7 @@ def is_pathname_valid(pathname: str) -> bool:
         # Directory guaranteed to exist. If the current OS is Windows, this is
         # the drive to which Windows was installed (e.g., the "%HOMEDRIVE%"
         # environment variable); else, the typical root directory.
-        root_dirname = (
-            os.environ.get("HOMEDRIVE", "C:")
-            if sys.platform == "win32"
-            else os.path.sep
-        )
+        root_dirname = os.environ.get("HOMEDRIVE", "C:") if IS_WINDOWS else os.path.sep
         assert os.path.isdir(root_dirname)  # ...Murphy and her ironclad Law
 
         # Append a path separator to this directory if needed.

--- a/src/pyscaffold/shell.py
+++ b/src/pyscaffold/shell.py
@@ -177,7 +177,7 @@ def get_git_cmd(**args):
     if IS_WINDOWS:  # pragma: no cover
         # ^  CI setup does not aggregate Windows coverage
         for shell in (True, False):
-            git = ShellCommand("git", shell=shell, env=env, **args)
+            git = ShellCommand("git.exe", shell=shell, env=env, **args)
             try:
                 git("--version")
             except ShellCommandException:

--- a/src/pyscaffold/shell.py
+++ b/src/pyscaffold/shell.py
@@ -67,12 +67,10 @@ class ShellCommand:
         command: str,
         shell: bool = True,
         cwd: Optional[str] = None,
-        env: Optional[Dict[str, str]] = None,
     ):
         self._command = command
         self._shell = shell
         self._cwd = cwd
-        self._env = env
 
     def run(self, *args, **kwargs) -> subprocess.CompletedProcess:
         """Execute command with the given arguments via :obj:`subprocess.run`."""
@@ -89,7 +87,11 @@ class ShellCommand:
             "stdout": subprocess.PIPE,
             "stderr": subprocess.STDOUT,
             "universal_newlines": True,
-            "env": self._env,
+            "env": {
+                **os.environ,
+                # try to disable i18n
+                **dict(LC_ALL="C", LANGUAGE=""),
+            },
             **kwargs,  # allow overwriting defaults
         }
         if self._shell:

--- a/src/pyscaffold/shell.py
+++ b/src/pyscaffold/shell.py
@@ -175,7 +175,7 @@ def get_git_cmd(**args):
             git = ShellCommand(cmd, shell=shell, env=env, **args)
             try:
                 git("--version")
-            except ShellCommandException:
+            except (ShellCommandException, FileNotFoundError):
                 continue
             return git
         else:
@@ -184,7 +184,7 @@ def get_git_cmd(**args):
         git = ShellCommand("git", **args)
         try:
             git("--version")
-        except ShellCommandException:
+        except (ShellCommandException, FileNotFoundError):
             return None
         return git
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -162,3 +162,9 @@ def test_join():
     # Join should be the opposite of split
     args = ["/my path/to exec", '"other args"', "asdf", "42", "'a b c'"]
     assert shlex.split(shell.join(args)) == args
+
+
+def test_non_existent_file_exception():
+    cmd = shell.ShellCommand("non_existent_cmd", shell=False)
+    with pytest.raises(shell.ShellCommandException):
+        cmd()


### PR DESCRIPTION
This fixes the problem with the Windows shell in issue #556. The basic solution is to add some more environment variables as stolen from setuptools-scm's `utils.do_ex` and in case of Windows try to find out if it is better to call a command with `shell=True` or `shell=False`. It seems that this differs from time to time.

**Note**: Only review and merge after having merged PR #559 into master as I needed to rebase it on #559 so the diff is actual way smaller. 