### PR TITLE
Build sdists by default again

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,14 +14,10 @@ Changelog
 Current versions
 ================
 
-Version 4.1.3, 2022-01-11
+Version 4.1.4, 2022-01-13
 -------------------------
 
-- Fix pre-commit error: The unauthenticated git protocol on port 9418 is no longer supported, :issue:`565`
-
-.. note::
-
-    PyScaffold 4.1 is the last release to support Python 3.6
+- Ensure build configuration produces ``sdist`` as it is needed by conda, :issue:`570`
 
 
 Version 3.3, 2020-12-24
@@ -47,6 +43,15 @@ Version 3.3, 2020-12-24
 
 Older versions
 ==============
+
+Version 4.1.3, 2022-01-11
+-------------------------
+
+- Fix pre-commit error: The unauthenticated git protocol on port 9418 is no longer supported, :issue:`565`
+
+.. note::
+
+    PyScaffold 4.1 is the last release to support Python 3.6
 
 Version 4.1.2, 2022-01-04
 -------------------------

--- a/src/pyscaffold/templates/tox_ini.template
+++ b/src/pyscaffold/templates/tox_ini.template
@@ -31,8 +31,7 @@ deps =
     build: build[virtualenv]
 commands =
     clean: python -c 'from shutil import rmtree; rmtree("build", True); rmtree("dist", True)'
-    build: python -m build {posargs:--wheel}
-    # You can also explicitly use the `--sdist` flag if you really want to
+    build: python -m build {posargs}
 
 
 [testenv:{docs,doctests,linkcheck}]

--- a/tox.ini
+++ b/tox.ini
@@ -54,8 +54,7 @@ deps =
     build: build[virtualenv]
 commands =
     clean: python -c 'from shutil import rmtree; rmtree("build", True); rmtree("dist", True)'
-    build: python -m build {posargs:--wheel}
-    # You can also explicitly use the `--sdist` flag if you really want to
+    build: python -m build {posargs}
 
 
 [testenv:{docs,doctests,linkcheck}]


### PR DESCRIPTION
## Purpose
Fix problem with conda packages.
Closes #570

## Approach
- Start building sdist packages, that will in turn be published to PyPI again.