### PR TITLE
Remove advice about `sdists` from the docs

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -25,9 +25,7 @@ compliant way, by just running::
     tox -e build
 
 Alternatively, if you are not a huge fan of isolated builds, or prefer running
-the commands yourself, you can execute ``python -m build --wheel --no-isolation``.
-Source distributions, i.e. ``sdist``, are only recommended if you absolutely need them.
-They are tricky to configure and may ignore several options in ``setup.cfg``.
+the commands yourself, you can execute ``python -m build --no-isolation``.
 
 Uploading to PyPI
 -----------------


### PR DESCRIPTION
## Purpose
Since now we found a good reason why using `sdist` is helpful (building conda packages), and it seems that the problems with `include_package_data` are solved in setuptools, I believe we no longer have to advise against them.

## Approach
- Simply remove the phrases in the docs advising against sdists
- Rely on `build` defaults

## Resources & Links

- [Experiments showing differences between sdists and wheels](https://github.com/abravalheri/experiment-setuptools-package-data#results-for-setuptools5920)
