### PR TITLE
Test more reliably if extension is EntryPoint

### DIFF
--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -82,9 +82,6 @@ def test_iterate_entry_points():
     ext_iter = extensions.iterate_entry_points()
     assert hasattr(ext_iter, "__iter__")
     ext_list = list(ext_iter)
-    # isinstance(...) doesn't work reliably as we don't know if setuptools using
-    # importlib.metadata or importlib_metadata for Python >= 3.8
-    assert all([e.__class__.__name__ == "EntryPoint" for e in ext_list])
     name_list = [e.name for e in ext_list]
     for ext in ("cirrus", "pre_commit", "no_skeleton", "namespace", "venv"):
         assert ext in name_list

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -82,7 +82,9 @@ def test_iterate_entry_points():
     ext_iter = extensions.iterate_entry_points()
     assert hasattr(ext_iter, "__iter__")
     ext_list = list(ext_iter)
-    assert all([isinstance(e, EntryPoint) for e in ext_list])
+    # isinstance(...) doesn't work reliably as we don't know if setuptools using
+    # importlib.metadata or importlib_metadata for Python >= 3.8
+    assert all([e.__class__.__name__ == "EntryPoint" for e in ext_list])
     name_list = [e.name for e in ext_list]
     for ext in ("cirrus", "pre_commit", "no_skeleton", "namespace", "venv"):
         assert ext in name_list


### PR DESCRIPTION
## Purpose
On the conda-forge [PR to release version 4.1.4](https://github.com/conda-forge/pyscaffold-feedstock/pull/44), we see a problem with the `test_iterate_entry_points` [unittest](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=441006&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d).

It seems the problem is that for Python versions greater than 3.8 we are checking for `importlib.metadata.EntryPoint` while setuptools seems to use `importlib_metadata.EntryPoint` (note the underscore) all of a sudden. The test was slightly altered to check for the right string name of the class.  One could even go so far an just remove the `assert` line as basically we are checking external behavior. 