### PR TITLE
Add pyenv's .python-version into .gitignore

### DIFF
--- a/src/pyscaffold/templates/gitignore.template
+++ b/src/pyscaffold/templates/gitignore.template
@@ -51,3 +51,4 @@ MANIFEST
 # Per-project virtualenvs
 .venv*/
 .conda*/
+.python-version


### PR DESCRIPTION
## Purpose
Some people use pyenv local, which introduces in a .python-version in the cwd. This is susceptible to be tracked by git

## Approach
Adds .python-version to gitignore

## Resources & Links

Debatable whether this is the best approach (https://stackoverflow.com/questions/54315206/should-we-gitignore-the-python-version-file#comment95589915_54315206) . This has arguably caused more problems than it solves as different contributors have different virtual environment management mechanisms
