### PR TITLE
Fix documentation path to pyscaffold/default.cfg

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -194,7 +194,7 @@ The locations of the configuration files vary slightly across platforms, but in
 general the following rule applies:
 
 - Linux: ``$XDG_CONFIG_HOME/pyscaffold/default.cfg`` with fallback to ``~/.config/pyscaffold/default.cfg``
-- OSX: ``~/Library/Preferences/pyscaffold/default.cfg``
+- OSX: ``~/Library/Application Support/pyscaffold/default.cfg``
 - Windows(≥7): ``%APPDATA%\pyscaffold\pyscaffold\default.cfg``
 
 The file format resembles the ``setup.cfg`` generated automatically by


### PR DESCRIPTION
Putting boilerplate values in in this path has no effect:
~/Library/Preferences/pyscaffold/default.cfg

Putting them here works:
~/Library/Application\ Support/pyscaffold/default.cfg

<details><summary>Test script</summary>

```Bash
rm -rf ~/Library/Application\ Support/pyscaffold/
rm -rf ~/Library/Preferences/pyscaffold

mkdir -p ~/Library/Preferences/pyscaffold
cat <<'__eot__' >~/Library/Preferences/pyscaffold/default.cfg
[metadata]
author = Taylor Monacelli
author-email = taylormonacelli@gmail.com
license = MPL-2.0

[pyscaffold]
extensions =
    cirrus
__eot__

cd /tmp
rm -rf my_project
putup my_project >/dev/null

if grep taylormonacelli /tmp/my_project/setup.cfg
then
    exit 1
fi

mkdir -p ~/Library/Application\ Support/pyscaffold/
mv ~/Library/Preferences/pyscaffold/default.cfg ~/Library/Application\ Support/pyscaffold/

cd /tmp
rm -rf my_project
putup my_project >/dev/null

if ! grep -q taylormonacelli /tmp/my_project/setup.cfg
then
    exit 1
fi
```
