### PR TITLE
Update versions of containers in CI config

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -64,9 +64,9 @@ env:
 # ---- Task definitions ----
 
 typecheck_task:
-  name: typecheck (Linux - 3.9)
+  name: typecheck (Linux - 3.10)
   clone_script: *clone
-  container: {image: "python:3.9-buster"}  # most recent => better type support
+  container: {image: "python:3.10-bullseye"}  # most recent => better type support
   pip_cache: *pip-cache
   mypy_cache:
     folder: .mypy_cache
@@ -85,18 +85,21 @@ linux_mac_task:
   clone_script: *clone
   matrix:
     - name: test (Linux - 3.6)
-      container: {image: "python:3.6-buster"}
+      container: {image: "python:3.6-bullseye"}
+      allow_failures: true  # EoL
     - name: test (Linux - 3.7)
-      container: {image: "python:3.7-buster"}
+      container: {image: "python:3.7-bullseye"}
     - name: test (Linux - 3.8)
-      container: {image: "python:3.8-buster"}
+      container: {image: "python:3.8-bullseye"}
     - name: test (Linux - 3.9)
-      container: {image: "python:3.9-buster"}
+      container: {image: "python:3.9-bullseye"}
     - name: test (Linux - 3.10)
-      allow_failures: true  # Some packages (e.g. Sphinx) might still have some problems
-      container: {image: "python:3.10-buster"}
+      container: {image: "python:3.10-bullseye"}
+    - name: test (Linux - 3.11)
+      container: {image: "python:3.11-rc-bullseye"}
+      allow_failures: true  # Experimental
     - name: test (Linux - Anaconda)
-      container: {image: "continuumio/anaconda3:2021.05"}
+      container: {image: "continuumio/anaconda3:2021.11"}
       env:
         USING_CONDA: true
       extra_install_script:
@@ -186,15 +189,16 @@ windows_task:
 
 
 coverage_task:
-  name: coverage (Linux - 3.6)
+  name: coverage (Linux - 3.8)
   clone_script: *clone
-  container: {image: "python:3.6-buster"}
+  container: {image: "python:3.8-bullseye"}
   env:
     COVERAGE: yes
   depends_on:
-    - test (Linux - 3.6)
     - test (Linux - 3.7)
     - test (Linux - 3.8)
+    - test (Linux - 3.9)
+    - test (Linux - 3.10)
     - test (Linux - Anaconda)
     - test (OS X)
   pip_install_script:
@@ -212,7 +216,7 @@ linkcheck_task:
   # only_if: $CIRRUS_BRANCH == 'master'
   allow_failures: true
   clone_script: *clone
-  container: {image: "python:3.8-buster"}
+  container: {image: "python:3.8-bullseye"}
   depends_on:
     - test (Linux - 3.8)
   pip_cache: *pip-cache

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -107,7 +107,7 @@ linux_mac_task:
     - name: test (OS X)
       macos_instance: {image: "big-sur-xcode"}
       env:
-        PYTHON_VERSION: 3.7
+        PYTHON_VERSION: 3.9
         # ^  update when the default version of python in homebrew changes
         PATH: "${HOME}/.local/bin:${HOME}/Library/Python/${PYTHON_VERSION}/bin:/usr/local/opt/python/libexec/bin:${PATH}"
         # ^  add user and homebrew paths

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -60,16 +60,16 @@ linux_mac_task:
   # Use custom cloning since otherwise git tags are missing
   clone_script: *clone
   matrix:
-    - name: test (Linux - 3.6)
-      container: {image: "python:3.6-buster"}
     - name: test (Linux - 3.7)
-      container: {image: "python:3.7-buster"}
+      container: {image: "python:3.7-bullseye"}
     - name: test (Linux - 3.8)
-      container: {image: "python:3.8-buster"}
+      container: {image: "python:3.8-bullseye"}
     - name: test (Linux - 3.9)
-      container: {image: "python:3.9-buster"}
+      container: {image: "python:3.9-bullseye"}
+    - name: test (Linux - 3.10)
+      container: {image: "python:3.10-bullseye"}
     - name: test (Linux - Anaconda)
-      container: {image: "continuumio/anaconda3:2021.05"}
+      container: {image: "continuumio/anaconda3:2021.11"}
       extra_install_script:
         - conda install -y -c conda-forge virtualenv build setuptools setuptools-scm pip tox
     - name: test (OS X)
@@ -152,16 +152,17 @@ windows_task:
 
 
 coverage_task:
-  name: coverage (Linux - 3.6)
+  name: coverage (Linux - 3.8)
   clone_script: *clone
-  container: {image: "python:3.6-buster"}
+  container: {image: "python:3.8-bullseye"}
   env:
     COVERAGE: yes
     PRE_COMMIT_HOME: ${HOME}/.cache/pre-commit
   depends_on:
-    - test (Linux - 3.6)
     - test (Linux - 3.7)
     - test (Linux - 3.8)
+    - test (Linux - 3.9)
+    - test (Linux - 3.10)
     - test (Linux - Anaconda)
     - test (OS X)
   pip_install_script:

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -75,7 +75,7 @@ linux_mac_task:
     - name: test (OS X)
       macos_instance: {image: "big-sur-xcode"}
       env:
-        PYTHON_VERSION: 3.7
+        PYTHON_VERSION: 3.9
         # ^  update when the default version of python in homebrew changes
         PATH: "${HOME}/.local/bin:${HOME}/Library/Python/${PYTHON_VERSION}/bin:/usr/local/opt/python/libexec/bin:${PATH}"
         # ^  add user and homebrew paths


### PR DESCRIPTION
## Purpose
I noticed in the last PRs that the `coverage` task is failing. This is likely to be caused by some packages used in `pre-commit` dropping support for 3.6, so I decided to update our CI configs.

## Approach
- Update `coverage` task to use 3.8 (this is the default version in Ubuntu 20.04LTS, so I believe a lot of people would be using it).
- Remove 3.6 support in the Cirrus CI template (this version reached EoL the end of last year)
- Add 3.11 with `allow_failures` just for PyScaffold (not the template), so we start seeing if something will fail.
- Keep 3.6 on PyScaffold's own config, but add `allow_failures` (Ubuntu 18.04LTS still uses it, so even if we decide to not fix the bugs, we can know about them)

#### Open Questions and Pre-Merge TODOs
- In our Cirrus config file we have the following comment:
```yaml
    - name: test (OS X)
      macos_instance: {image: "big-sur-xcode"}
      env:
        PYTHON_VERSION: 3.7
        # ^  update when the default version of python in homebrew changes
```

@FlorianWilhelm do you know if 3.7 is still the version you get when you `brew install python`?
I could not find this information online... https://formulae.brew.sh/formula/python@3.7 does not say anything about this being the default version and if I remove the `@3.7` from the URL I get a 404 error...