### PR TITLE
Replace `appdirs` with `platformdirs`

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -124,7 +124,7 @@ website.
    considered good practice. Package files should be read-only. If you need
    configuration files, or files that should be written at runtime, please
    consider doing so inside standard locations in the user's home folder
-   (`appdirs`_ is a good library for that).
+   (:pypi:`platformdirs` is a good library for that).
    If needed you can even create them at the first usage from a read-only
    template, which in turn can be a package file.
 
@@ -433,7 +433,6 @@ Check out our :ref:`Configuration <default-cfg>` section to get started.
 .. _dependency hell: https://en.wikipedia.org/wiki/Dependency_hell
 .. _pkg_resources: https://setuptools.pypa.io/en/stable/pkg_resources.html
 .. _make: https://en.wikipedia.org/wiki/Make_(software)
-.. _appdirs: https://pypi.org/project/appdirs/
 .. _wheels: https://realpython.com/python-wheels/
 .. _SPDX index: https://spdx.org/licenses/
 .. _Mozilla Public License 2.0: https://choosealicense.com/licenses/mpl-2.0/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,9 @@
 # Requirements file for ReadTheDocs, check .readthedocs.yml
-appdirs
 configupdater
 furo
 packaging
 Pillow
+platformdirs
 setuptools>=38.3
 setuptools_scm
 sphinx>=3.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ package_dir =
     =src
 install_requires =
     importlib-metadata; python_version<"3.8"
-    appdirs>=1.4.4,<2
+    platformdirs>=2.4.1,<3
     configupdater>=3.0,<4  # pyscaffoldext-custom-extension should have a compatible range
     setuptools>=46.1.0
     setuptools_scm>=5

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ package_dir =
     =src
 install_requires =
     importlib-metadata; python_version<"3.8"
-    platformdirs>=2.4.1,<3
+    platformdirs>=2,<3
     configupdater>=3.0,<4  # pyscaffoldext-custom-extension should have a compatible range
     setuptools>=46.1.0
     setuptools_scm>=5

--- a/src/pyscaffold/dependencies.py
+++ b/src/pyscaffold/dependencies.py
@@ -47,15 +47,15 @@ def split(requirements: str) -> List[str]:
 
 
 def deduplicate(requirements: Iterable[str]) -> List[str]:
-    """Given a sequence of individual requirement strings, e.g. ``["appdirs>=1.4.4",
-    "packaging>20.0"]``, remove the duplicated packages.
+    """Given a sequence of individual requirement strings, e.g.
+    ``["platformdirs>=1.4.4", "packaging>20.0"]``, remove the duplicated packages.
     If a package is duplicated, the last occurrence stays.
     """
     return list({attempt_pkg_name(r): r for r in requirements}.values())
 
 
 def remove(requirements: Iterable[str], to_remove: Iterable[str]) -> List[str]:
-    """Given a list of individual requirement strings, e.g.  ``["appdirs>=1.4.4",
+    """Given a list of individual requirement strings, e.g. ``["platformdirs>=1.4.4",
     "packaging>20.0"]``, remove the requirements in ``to_remove``.
     """
     removable = {attempt_pkg_name(r) for r in to_remove}

--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -11,7 +11,7 @@ from operator import itemgetter
 from pathlib import Path
 from typing import Optional, Set, cast, overload
 
-import appdirs
+import platformdirs
 from configupdater import ConfigUpdater
 from packaging.version import Version
 
@@ -341,7 +341,7 @@ def config_dir(prog=PKG_NAME, org=None, default=RAISE_EXCEPTION):
         Location somewhere in the user's home directory where to put the configs.
     """
     try:
-        return Path(appdirs.user_config_dir(prog, org, roaming=True))
+        return Path(platformdirs.user_config_dir(prog, org, roaming=True))
     except Exception as ex:
         if default is not RAISE_EXCEPTION:
             logger.debug("Error when finding config dir %s", ex, exc_info=True)

--- a/tests/extensions/test_venv.py
+++ b/tests/extensions/test_venv.py
@@ -36,9 +36,9 @@ def test_cli_opts():
     opts = parse("--venv", ".here")
     assert opts["venv"] == Path(".here")
     # venv-install
-    opts = parse("--venv-install", "appdirs>=1.1,<2", "six")
-    opts = parse("--venv-install", "appdirs>=1.1,<2", "six")
-    assert opts["venv_install"] == ["appdirs>=1.1,<2", "six"]
+    opts = parse("--venv-install", "platformdirs>=1.1,<2", "six")
+    opts = parse("--venv-install", "platformdirs>=1.1,<2", "six")
+    assert opts["venv_install"] == ["platformdirs>=1.1,<2", "six"]
     assert [e.name for e in opts["extensions"]] == ["venv"]
     # venv-install but no value
     with pytest.raises((ArgumentError, TypeError, SystemExit)):

--- a/tests/system/test_dependency_managers.py
+++ b/tests/system/test_dependency_managers.py
@@ -37,7 +37,7 @@ def dont_load_dotenv():
 def test_pipenv_works_with_pyscaffold(tmpfolder, venv_path, venv_run):
     # Given a project is created with pyscaffold
     # and it has some dependencies in setup.cfg
-    create_project(project_path="myproj", requirements=["appdirs"])
+    create_project(project_path="myproj", requirements=["platformdirs"])
 
     if any(ch in pyscaffold_version for ch in ("b", "a", "pre", "rc")):
         flags = "--pre"
@@ -68,7 +68,7 @@ def test_pipenv_works_with_pyscaffold(tmpfolder, venv_path, venv_run):
         # with the correct dependencies
         with open("Pipfile.lock") as fp:
             content = json.load(fp)
-            assert content["default"]["appdirs"]
+            assert content["default"]["platformdirs"]
             assert content["develop"]["flake8"]
 
         # and run things from inside pipenv's venv
@@ -81,7 +81,9 @@ def test_piptools_works_with_pyscaffold(tmpfolder, monkeypatch):
     find = partial(find_venv_bin, venv_path)
     # Given a project is created with pyscaffold
     # and it has some dependencies in setup.cfg
-    create_project(project_path="myproj", extensions=[Venv()], requirements=["appdirs"])
+    create_project(
+        project_path="myproj", extensions=[Venv()], requirements=["platformdirs"]
+    )
     with tmpfolder.join("myproj").as_cwd():
         requirements_in = Path("requirements.in")
         # When we install pip-tools
@@ -95,7 +97,7 @@ def test_piptools_works_with_pyscaffold(tmpfolder, monkeypatch):
         assert requirements_txt.exists()
         # with the correct dependencies
         content = requirements_txt.read_text()
-        assert "appdirs==" in content
+        assert "platformdirs==" in content
         assert "flake8==" in content
         assert "file:." in content
         # install the dependencies

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -4,30 +4,30 @@ from pyscaffold import dependencies as deps
 def test_split():
     assert deps.split(
         "\n    pyscaffold>=42.1.0,<43.0"
-        "\n    appdirs==1"
+        "\n    platformdirs==1"
         "\n    cookiecutter<8"
         "\n    mypkg~=9.0"
-    ) == ["pyscaffold>=42.1.0,<43.0", "appdirs==1", "cookiecutter<8", "mypkg~=9.0"]
+    ) == ["pyscaffold>=42.1.0,<43.0", "platformdirs==1", "cookiecutter<8", "mypkg~=9.0"]
     assert deps.split(
-        "\n    pyscaffold>=42.1.0,<43.0;appdirs==1"
+        "\n    pyscaffold>=42.1.0,<43.0;platformdirs==1"
         "\n    cookiecutter<8;mypkg~=9.0\n\n"
-    ) == ["pyscaffold>=42.1.0,<43.0", "appdirs==1", "cookiecutter<8", "mypkg~=9.0"]
+    ) == ["pyscaffold>=42.1.0,<43.0", "platformdirs==1", "cookiecutter<8", "mypkg~=9.0"]
     assert deps.split(
-        "pyscaffold>=42.1.0,<43.0; appdirs==1; cookiecutter<8; mypkg~=9.0; "
-    ) == ["pyscaffold>=42.1.0,<43.0", "appdirs==1", "cookiecutter<8", "mypkg~=9.0"]
+        "pyscaffold>=42.1.0,<43.0; platformdirs==1; cookiecutter<8; mypkg~=9.0; "
+    ) == ["pyscaffold>=42.1.0,<43.0", "platformdirs==1", "cookiecutter<8", "mypkg~=9.0"]
     assert deps.split(
-        "\n    pyscaffold>=42.1.0,<43.0;python_version>='3.4'; appdirs==1"
-    ) == ["pyscaffold>=42.1.0,<43.0;python_version>='3.4'", "appdirs==1"]
+        "\n    pyscaffold>=42.1.0,<43.0;python_version>='3.4'; platformdirs==1"
+    ) == ["pyscaffold>=42.1.0,<43.0;python_version>='3.4'", "platformdirs==1"]
     assert deps.split(
-        "\n    pyscaffold>=42.1.0,<43.0; python_version>='3.4'; appdirs==1"
-    ) == ["pyscaffold>=42.1.0,<43.0; python_version>='3.4'", "appdirs==1"]
+        "\n    pyscaffold>=42.1.0,<43.0; python_version>='3.4'; platformdirs==1"
+    ) == ["pyscaffold>=42.1.0,<43.0; python_version>='3.4'", "platformdirs==1"]
 
 
 def test_deduplicate():
     # no duplication => no effect
-    assert deps.deduplicate(["pyscaffold>=4,<5", "appdirs"]) == [
+    assert deps.deduplicate(["pyscaffold>=4,<5", "platformdirs"]) == [
         "pyscaffold>=4,<5",
-        "appdirs",
+        "platformdirs",
     ]
     # duplicated => the last one wins
     assert deps.deduplicate(
@@ -40,13 +40,13 @@ def test_deduplicate():
 
 def test_remove():
     assert deps.remove(
-        ["pyscaffold>=42.1.0,<43.0", "appdirs==1", "cookiecutter<8", "mypkg~=9.0"],
-        ["appdirs"],
+        ["pyscaffold>=42.1.0,<43.0", "platformdirs==1", "cookiecutter<8", "mypkg~=9.0"],
+        ["platformdirs"],
     ) == ["pyscaffold>=42.1.0,<43.0", "cookiecutter<8", "mypkg~=9.0"]
     assert deps.remove(
-        ["pyscaffold>=42.1.0,<43.0", "appdirs==1", "cookiecutter<8", "mypkg~=9.0"],
+        ["pyscaffold>=42.1.0,<43.0", "platformdirs==1", "cookiecutter<8", "mypkg~=9.0"],
         {"mypkg": 0},
-    ) == ["pyscaffold>=42.1.0,<43.0", "appdirs==1", "cookiecutter<8"]
+    ) == ["pyscaffold>=42.1.0,<43.0", "platformdirs==1", "cookiecutter<8"]
 
 
 def test_add():
@@ -56,8 +56,8 @@ def test_add():
         "django>=5.3.99999,<6",
     ]
     # No intersection
-    assert deps.add(["appdirs==1", "cookiecutter<8", "mypkg~=9.0"], own_deps) == [
-        "appdirs==1",
+    assert deps.add(["platformdirs==1", "cookiecutter<8", "mypkg~=9.0"], own_deps) == [
+        "platformdirs==1",
         "cookiecutter<8",
         "mypkg~=9.0",
         "setuptools_scm>=1.2.5,<2",
@@ -65,8 +65,8 @@ def test_add():
         "django>=5.3.99999,<6",
     ]
     # With intersection => own_deps win
-    assert deps.add(["appdirs==1", "pyscaffold<8", "mypkg~=9.0"], own_deps) == [
-        "appdirs==1",
+    assert deps.add(["platformdirs==1", "pyscaffold<8", "mypkg~=9.0"], own_deps) == [
+        "platformdirs==1",
         "pyscaffold>=42.1.0,<43",
         "mypkg~=9.0",
         "setuptools_scm>=1.2.5,<2",
@@ -84,8 +84,8 @@ def test_add_commented():
         "# a comment",
         "# comment-that>0==1<3; reminds.pep==508",
     ]
-    assert deps.add(["appdirs==1", "# a comment", "# mypkg~=2.0"], new_deps) == [
-        "appdirs==1",
+    assert deps.add(["platformdirs==1", "# a comment", "# mypkg~=2.0"], new_deps) == [
+        "platformdirs==1",
         "# a comment",
         "mypkg~=9.0",
         "setuptools_scm>=1.2.5,<2",

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -164,7 +164,7 @@ def test_config_dir_error(monkeypatch):
 
     # If for some reason something goes wrong when trying to find the config dir
     user_config_dir_mock = Mock(side_effect=SystemError)
-    monkeypatch.setattr(info.appdirs, "user_config_dir", user_config_dir_mock)
+    monkeypatch.setattr(info.platformdirs, "user_config_dir", user_config_dir_mock)
     # And no default value is given
     # Then an error should be raised
     with pytest.raises(exceptions.ImpossibleToFindConfigDir):


### PR DESCRIPTION
## Purpose
As discussed in #581, the community is moving past `appdirs` and towards `platformdirs`.
The idea of this PR is to replace this dependency with the more maintained one.

Closes #581.

## Approach
In the current release `platformdirs` is designed to have a backwards compatible API, so the approach I took in this PR is to blindly replace everything.

I also replaced the mentions in examples and documentations to promote the more maintained alternative.