### PR TITLE
Fix broken Pytest link

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -511,7 +511,7 @@ our docs. We have enumerated a few :doc:`reasons for using PyScaffold
 .. _PyScaffold organization: https://github.com/pyscaffold
 .. _pyscaffoldext-dsproject: https://github.com/pyscaffold/pyscaffoldext-dsproject
 .. _pyscaffoldext-markdown: https://github.com/pyscaffold/pyscaffoldext-markdown
-.. _Pytest can drop you: https://docs.pytest.org/en/stable/usage.html#dropping-to-pdb-python-debugger-at-the-start-of-a-test
+.. _Pytest can drop you: https://docs.pytest.org/en/stable/how-to/failures.html#using-python-library-pdb-with-pytest
 .. _pytest: https://docs.pytest.org/en/stable/
 .. _Python Software Foundation's Code of Conduct: https://www.python.org/psf/conduct/
 .. _Read the Docs: https://docs.readthedocs.io/en/stable/versions.html

--- a/src/pyscaffold/templates/contributing.template
+++ b/src/pyscaffold/templates/contributing.template
@@ -341,7 +341,7 @@ on PyPI_, the following steps can be used to release a new version for
 .. _pre-commit: https://pre-commit.com/
 .. _PyPI: https://pypi.org/
 .. _PyScaffold's contributor's guide: https://pyscaffold.org/en/stable/contributing.html
-.. _Pytest can drop you: https://docs.pytest.org/en/stable/usage.html#dropping-to-pdb-python-debugger-at-the-start-of-a-test
+.. _Pytest can drop you: https://docs.pytest.org/en/stable/how-to/failures.html#using-python-library-pdb-with-pytest
 .. _Python Software Foundation's Code of Conduct: https://www.python.org/psf/conduct/
 .. _reStructuredText: https://www.sphinx-doc.org/en/master/usage/restructuredtext/
 .. _Sphinx: https://www.sphinx-doc.org/en/master/


### PR DESCRIPTION
## Purpose
Both PyScaffold's own `CONTRIBUTING.rst` and generated file contain a broken link for the pytest website (probably due to the recent release of v7).

Closes #585.

## Approach
- The link was replaced with a different link for a similar content
