### PR TITLE
Fix `${qual_pkg}` in coverage config

### DIFF
--- a/src/pyscaffold/templates/coveragerc.template
+++ b/src/pyscaffold/templates/coveragerc.template
@@ -1,7 +1,7 @@
 # .coveragerc to control coverage.py
 [run]
 branch = True
-source = ${package}
+source = ${qual_pkg}
 # omit = bad_file.py
 
 [paths]

--- a/tests/extensions/test_namespace.py
+++ b/tests/extensions/test_namespace.py
@@ -77,6 +77,10 @@ def test_create_project_with_namespace(tmpfolder):
     # and plain structure should not exist
     assert not Path("my-proj/src/my_proj/__init__.py").exists()
 
+    # coverage should be configured correctly
+    assert "source = ns.ns2.my_proj" in Path("my-proj/.coveragerc").read_text()
+    assert "--cov ns.ns2.my_proj" in Path("my-proj/setup.cfg").read_text()
+
 
 def test_create_project_with_empty_namespace(tmpfolder):
     for j, ns in enumerate(["", None, False]):


### PR DESCRIPTION
## Purpose
As previously identified in https://github.com/pyscaffold/pyscaffold/pull/587#discussion_r808751179, the `.coveragerc` template uses the wrong variable in the substitution.

## Approach
- Replace `${package}` with `${qual_pkg}` in the template
- Add test case to capture the problem and avoid regressions.