### PR TITLE
Revamp `--gitlab` extension

### DIFF
--- a/src/pyscaffold/extensions/gitlab_ci.py
+++ b/src/pyscaffold/extensions/gitlab_ci.py
@@ -1,18 +1,28 @@
 """
 Extension that generates configuration and script files for GitLab CI.
 """
-
+from argparse import ArgumentParser
 from typing import List
 
 from .. import structure
 from ..actions import Action, ActionParams, ScaffoldOpts, Structure
 from ..operations import no_overwrite
 from ..templates import get_template
-from . import Extension
+from . import Extension, include
+from .pre_commit import PreCommit
 
 
 class GitLab(Extension):
     """Generate GitLab CI configuration files"""
+
+    def augment_cli(self, parser: ArgumentParser):
+        """Augments the command-line interface parser.
+        See :obj:`~pyscaffold.extension.Extension.augment_cli`.
+        """
+        parser.add_argument(
+            self.flag, help=self.help_text, nargs=0, action=include(PreCommit(), self)
+        )
+        return self
 
     def activate(self, actions: List[Action]) -> List[Action]:
         """Activate extension, see :obj:`~pyscaffold.extension.Extension.activate`."""

--- a/src/pyscaffold/templates/gitlab_ci.template
+++ b/src/pyscaffold/templates/gitlab_ci.template
@@ -1,70 +1,119 @@
----
 # This file is a template, and might need editing before it works on your project.
 
-# Official language image. Look for the different tagged releases at:
-# image: "python:2.7"
+stages:
+  - prepare
+  - test
+  - finalize
+  - release
 
-# Pick zero or more services to be used on all builds.
-# Only needed when using a docker container to run your tests in.
-# Check out: https://docs.gitlab.com/ce/ci/docker/using_docker_images.html#what-is-service
+variables:
+  # Change cache dirs to be inside the project (can only cache local items)
+  PIP_CACHE_DIR: $CI_PROJECT_DIR/.cache/pip
+  PIPX_HOME: $CI_PROJECT_DIR/.cache/pipx
+  PRE_COMMIT_HOME: $CI_PROJECT_DIR/.cache/pre-commit
+  # Coveralls configuration
+  CI_NAME: gitlab-ci
+  CI_BRANCH: $CI_COMMIT_REF_NAME
+  CI_BUILD_NUMBER: $CI_PIPELINE_ID
+  CI_BUILD_URL: $CI_PIPELINE_URL
 
-# services:
-#   - mysql:latest
-#   - redis:latest
-#   - postgres:latest
+workflow:
+  rules:
+    # Restrict the number of times the pipeline runs to save resources/limits
+    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
+      variables:
+        # Specific merge request configurations for coveralls
+        CI_BRANCH: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
+        CI_PULL_REQUEST: $CI_MERGE_REQUEST_IID
+    - if: $CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS && $CI_PIPELINE_SOURCE == 'push'
+      when: never  # Avoid running the pipeline twice (push + merge request)
+    - if: $CI_COMMIT_BRANCH || $CI_COMMIT_TAG
+    # You can also set recurring execution of the pipeline, see:
+    # https://docs.gitlab.com/ee/ci/pipelines/schedules.html
 
-# variables:
-#   POSTGRES_DB: database_name
-
-# Cache packages in between builds
 cache:
+  key: pip-pipx-pre-commit-$CI_JOB_IMAGE
   paths:
-    - vendor/python
+    - .cache/pip
+    - .cache/pipx
+    - .cache/pre-commit
 
-# This is a basic example for a packages or script which doesn't use
-# services such as redis or postgres
-before_script:
-  - python -v                                   # Print out Python version for debugging
-  # Setup git
-  - apt-get install git
-  - git config --global user.email "you@example.com"
-  - git config --global user.name "Your Name"
-  # Install dependencies for the testing environment
-  - pip install -U pip setuptools tox
+default:
+  before_script:
+    - python --version  # useful for debugging
+    # Setup git (used for setuptools-scm)
+    - git config --global user.email "you@example.com"
+    - git config --global user.name "Your Name"
+    # Install dependencies for the testing environment
+    - pip install -U pip tox pipx
+
+check:
+  stage: prepare
+  image: "python:3.10"
+  script: pipx run pre-commit run --all-files --show-diff-on-failure
+
+build:
+  stage: prepare
+  image: "python:3.10"
+  script: tox -e clean,build
+  variables:
+    GIT_DEPTH: "0"  # deep-clone
+  artifacts:
+    expire_in: 1 day
+    paths: [dist]
 
 .test_script: &test_script
+  dependencies: [build]
+  variables:
+    COVERALLS_PARALLEL: "true"
+    COVERALLS_FLAG_NAME: $CI_JOB_NAME
   script:
-    - tox
-  # OR if you don't use tox:
-  # - pytest
-
-# Run in different environments
-py36:
-  image: "python:3.6"
-  <<: *test_script
+    - tox --installpkg dist/*.whl -- -rFEx --durations 10 --color yes
+    - pipx run coverage lcov -o coverage.lcov
+    - pipx run coveralls --submit coverage.lcov
 
 py37:
+  stage: test
   image: "python:3.7"
   <<: *test_script
 
 py38:
+  stage: test
   image: "python:3.8"
   <<: *test_script
 
 py39:
+  stage: test
   image: "python:3.9"
   <<: *test_script
 
+py310:
+  stage: test
+  image: "python:3.10"
+  <<: *test_script
 
-docs:
-  script:
-    - tox -e docs
+mamba:
+  stage: test
+  image: "condaforge/mambaforge"
+  before_script: mamba install -y pip tox pipx
+  <<: *test_script
 
-# This deploy job uses a simple deploy flow to Heroku, other providers, e.g. AWS Elastic Beanstalk
-# are supported too: https://github.com/travis-ci/dpl
-#deploy:
-#  type: deploy
-#  environment: production
-#  script:
-#    - tox -e build
-#    - dpl --provider=heroku --app=$HEROKU_APP_NAME --api-key=$HEROKU_PRODUCTION_KEY
+upload-coverage:
+  stage: finalize
+  image: "python:3.10"
+  script: pipx run coveralls --finish
+
+publish:
+  stage: release
+  dependencies: [build]
+  image: "python:3.10"
+  rules: [if: $CI_COMMIT_TAG]
+  variables:
+    # See: https://pypi.org/help/#apitoken
+    # Needs a PYPI_TOKEN protected variable to be configured for `v*` tags, see:
+    # https://docs.gitlab.com/ee/ci/variables/#add-a-cicd-variable-to-a-project
+    # https://docs.gitlab.com/ee/user/project/protected_tags.html
+    TWINE_REPOSITORY: pypi
+    TWINE_USERNAME: __token__
+    TWINE_PASSWORD: $PYPI_TOKEN
+  script: tox -e publish

--- a/tests/extensions/test_gitlab_ci.py
+++ b/tests/extensions/test_gitlab_ci.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+import sys
+from os.path import exists as path_exists
+
+from pyscaffold.api import create_project
+from pyscaffold.cli import run
+from pyscaffold.extensions.gitlab_ci import GitLab
+
+
+def test_create_project_with_gitlab_ci(tmpfolder):
+    # Given options with the GitLab extension,
+    opts = dict(project_path="proj", extensions=[GitLab()])
+
+    # when the project is created,
+    create_project(opts)
+
+    # then files from GitLab extension should exist
+    assert path_exists("proj/.gitlab-ci.yml")
+
+
+def test_create_project_without_gitlab_ci(tmpfolder):
+    # Given options without the GitLab extension,
+    opts = dict(project_path="proj")
+
+    # when the project is created,
+    create_project(opts)
+
+    # then GitLab files should not exist
+    assert not path_exists("proj/.gitlab-ci.yml")
+
+
+def test_cli_with_gitlab_ci(tmpfolder):
+    # Given the command line with the GitLab option,
+    sys.argv = ["pyscaffold", "--gitlab", "proj"]
+
+    # when pyscaffold runs,
+    run()
+
+    # then files from GitLab and other extensions automatically added should
+    # exist
+    assert path_exists("proj/.gitlab-ci.yml")
+    assert path_exists("proj/tox.ini")
+    assert path_exists("proj/.pre-commit-config.yaml")
+
+
+def test_cli_with_gitlab_ci_and_pretend(tmpfolder):
+    # Given the command line with the GitLab and pretend options
+    sys.argv = ["pyscaffold", "--pretend", "--gitlab", "proj"]
+
+    # when pyscaffold runs,
+    run()
+
+    # then GitLab files should not exist
+    assert not path_exists("proj/.gitlab-ci.yml")
+    # (or the project itself)
+    assert not path_exists("proj")
+
+
+def test_cli_without_gitlab_ci(tmpfolder):
+    # Given the command line without the GitLab option,
+    sys.argv = ["pyscaffold", "proj"]
+
+    # when pyscaffold runs,
+    run()
+
+    # then GitLab files should not exist
+    assert not path_exists("proj/.gitlab-ci.yml")


### PR DESCRIPTION
The previous version of the template for the GitLab CI was added to PyScaffold a while ago and never revised.

Although it seems that it was working (surprisingly), it also didn't offer the same features as CirrusCI or the proposed GitHub Actions.

This change is a revamp on that template that tries to offer more or less the same level of functionality our other CI configs offer.

It was tested against a replica of the `ci-tester` repository on GitLab:

- https://gitlab.com/pyscaffold/ci-tester

This is the pipeline output:

- https://gitlab.com/pyscaffold/ci-tester/-/commit/e8e3a777b972bc839a9b32d7c0c0678184ef2756