### PR TITLE
Add colorama as a conditional dependency for Windows

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Version 4.2, 2022-XX-XX
 
 - Added ``--github-actions`` extension, :pr:`619`
 - Update and improve ``--gitlab`` extension, :pr:`622`
+- Added ``colorama`` as a runtime dependency for Windows, :pr:`624`
 
 
 Current versions

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
     setuptools_scm>=5
     tomlkit>=0.7.0,<2
     packaging>=20.7
+    colorama>=0.4.4; sys_platform == "win32"
 
 # packaging is versioned by year, not SemVer
 


### PR DESCRIPTION
## Purpose
As discussed in https://github.com/pyscaffold/pyscaffold/issues/609#issuecomment-1047596052, when we transitioned from v3 to v4 (and were finally allowed to have dependencies), we forgot to add a conditional dependency on `colorama` for windows. (And by "we", I mean that it was definitely me that forgot 😅...)

`colorama` is currently being checked on our `termui` code.

## Approach
- Add `colorama` as a conditional dependency for windows
  (obs `win32` is just the name of the architecture, it does not mean that Python runs on 32 bits. Currently there is no `win64`, and that would imply in a change in architecture).
