### PR TITLE
Remove outdated docs about `log` parameter for shell

### DIFF
--- a/src/pyscaffold/shell.py
+++ b/src/pyscaffold/shell.py
@@ -53,7 +53,6 @@ class ShellCommand:
 
     The produced command can be called with the following keyword arguments:
 
-        - **log** (*bool*): log activity when true. ``False`` by default.
         - **pretend** (*bool*): skip execution (but log) when pretending.
           ``False`` by default.
 


### PR DESCRIPTION
## Purpose
In commit 5dd87525169a899a9af70c5922263000f193be20 the ``log`` parameter was removed, but the docs are still mentioning it.

## Approach
- Remove the outdated line from docstring.