### PR TITLE
Fix tox publish pypi command

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -39,7 +39,7 @@ mentioned above and use tox_ to publish with::
 This will first upload your package `using TestPyPI`_, so you can be a good
 citizen of the Python world, check/test everything is fine, and then, when you
 are absolutely sure the moment has come for your package to shine, you can go
-ahead and run ``tox -e --publish -- --repository pypi`` [#feat2]_. Just
+ahead and run ``tox -e publish -- --repository pypi`` [#feat2]_. Just
 remember that for this to work, you have to first register a PyPI_ account (and
 also a TestPyPI_ one).
 


### PR DESCRIPTION
tox with --publish produces a usage error:
```shell
tox -e --publish -- --repository pypi
usage: tox [--version] [-h] [--help-ini] [-v] [-q] [--showconfig] [-l] [-a] [-c CONFIGFILE] [-e envlist] [--devenv ENVDIR] [--notest] [--sdistonly] [--skip-pkg-install] [-p [VAL]] [-o]
           [--parallel--safe-build] [--installpkg PATH] [--develop] [-i URL] [--pre] [-r] [--result-json PATH] [--discover PATH [PATH ...]] [--hashseed SEED] [--force-dep REQ]
           [--sitepackages] [--alwayscopy] [--no-provision [REQUIRES_JSON]] [-s [val]] [--workdir PATH]
           [args [args ...]]
tox: error: argument -e: expected one argument
```