### PR TITLE
before_script needs to be an array

### DIFF
--- a/src/pyscaffold/templates/gitlab_ci.template
+++ b/src/pyscaffold/templates/gitlab_ci.template
@@ -54,12 +54,14 @@ default:
 check:
   stage: prepare
   image: "python:3.10"
-  script: pipx run pre-commit run --all-files --show-diff-on-failure
+  script:
+    - pipx run pre-commit run --all-files --show-diff-on-failure
 
 build:
   stage: prepare
   image: "python:3.10"
-  script: tox -e clean,build
+  script:
+    - tox -e clean,build
   variables:
     GIT_DEPTH: "0"  # deep-clone
   artifacts:
@@ -106,7 +108,8 @@ mamba:
 upload-coverage:
   stage: finalize
   image: "python:3.10"
-  script: pipx run coveralls --finish
+  script:
+    - pipx run coveralls --finish
 
 publish:
   stage: release
@@ -121,4 +124,5 @@ publish:
     TWINE_REPOSITORY: pypi
     TWINE_USERNAME: __token__
     TWINE_PASSWORD: $PYPI_TOKEN
-  script: tox -e publish
+  script:
+    - tox -e publish


### PR DESCRIPTION
## Purpose
Fix Gitlab CI pipeline

```
jobs:mamba:before_script config should be an array containing strings and arrays of strings
```

## Approach
Converting the YAML object type to an array


#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

## Resources & Links

_Links to blog posts, patterns, libraries or addons used to solve this problem_
