### PR TITLE
Change note in skeleton to emphasize it can be removed/renamed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Version 4.2.2, 2022-05-26
 -------------------------
 
 - Update ``.github/workflows/ci.yml`` template, :pr:`637` and :pr:`640`
+- Update note in ``skeleton.py`` template clarifying file can be renamed, :pr:`641`
 
 
 Older versions

--- a/src/pyscaffold/templates/skeleton.template
+++ b/src/pyscaffold/templates/skeleton.template
@@ -13,7 +13,7 @@ Besides console scripts, the header (i.e. until ``_logger``...) of this file can
 also be used as template for Python modules.
 
 Note:
-    This skeleton file can be safely removed if not needed!
+    This file can be renamed depending on your needs or safely removed if not needed.
 
 References:
     - https://setuptools.pypa.io/en/latest/userguide/entry_point.html


### PR DESCRIPTION
## Purpose
Improve note on `skeleton.py` to clarify the document can be safely removed/renamed.

## Approach

See discussion #638.