### PR TITLE
Add step to migration docs alerting about tags

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -394,8 +394,7 @@ How can I configure and debug the exact version exported by my package?
 Why do I see the error ``AssertionError: Can't parse version ...``?
     The way ``setuptools-scm`` parses git tags has some edge cases leading
     to this assertion error. The best way is to either remove the tag or
-    rename it to either a proper semantic version like ``v0.4.2`` or avoid
-    using any number (e.g. ``draft``).
+    rename it to a proper semantic version like ``v0.4.2``.
 
     Please also note that ``setuptools-scm`` may also fail if a single commit
     has multiple tags and at least one of them is problematic (``setuptools-scm``

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -391,7 +391,7 @@ How can I configure and debug the exact version exported by my package?
 
     (This requires the ``setuptools-scm`` package is installed in your environment)
 
-Why do I see the error ``AssertionError: cant parse version ...``?
+Why do I see the error ``AssertionError: Can't parse version ...``?
     There are some limitations with ``setuptools-scm`` and in some edge cases
     it might fail to parse specific tags.
     If that is happening to your project (other than removing the problematic tag),

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -391,6 +391,17 @@ How can I configure and debug the exact version exported by my package?
 
     (This requires the ``setuptools-scm`` package is installed in your environment)
 
+Why do I see the error ``AssertionError: cant parse version ...``?
+    There are some limitations with ``setuptools-scm`` and in some edge cases
+    it might fail to parse specific tags.
+    If that is happening to your project (other than removing the problematic tag),
+    you can try to re-run the relevant command after setting the
+    ``SETUPTOOLS_SCM_PRETEND_VERSION`` environment variable to overwrite the
+    default behavior.
+    Please also note that ``setuptools-scm`` may also fail if a single commit
+    has multiple tags and at least one of them is problematic (``setuptools-scm``
+    *will not* try multiple tags until it finds the correct one).
+
 
 .. _blog post by Ionel: https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure
 .. _src layout: https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -392,12 +392,11 @@ How can I configure and debug the exact version exported by my package?
     (This requires the ``setuptools-scm`` package is installed in your environment)
 
 Why do I see the error ``AssertionError: Can't parse version ...``?
-    There are some limitations with ``setuptools-scm`` and in some edge cases
-    it might fail to parse specific tags.
-    If that is happening to your project (other than removing the problematic tag),
-    you can try to re-run the relevant command after setting the
-    ``SETUPTOOLS_SCM_PRETEND_VERSION`` environment variable to overwrite the
-    default behavior.
+    The way ``setuptools-scm`` parses git tags has some edge cases leading
+    to this assertion error. The best way is to either remove the tag or
+    rename it to either a proper semantic version like ``v0.4.2`` or avoid
+    using any number (e.g. ``draft``).
+
     Please also note that ``setuptools-scm`` may also fail if a single commit
     has multiple tags and at least one of them is problematic (``setuptools-scm``
     *will not* try multiple tags until it finds the correct one).

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -44,7 +44,7 @@ Let's start:
    You can do that by running ``python -m setuptools_scm`` (after installing it
    in your environment). If the command succeeds you are good to go.
 
-   Please note that some very specific tag formats can be problematic.
+   Please note that some specific tag formats can be problematic.
    Check our :ref:`version-faq` for a workaround for this problem.
 
 #. In order to check that everything works, run ``pip install .`` and ``tox -e build``

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -39,6 +39,22 @@ Let's start:
    In most cases you will not need to make changes to the new ``setup.py`` file provided by PyScaffold.
    The only exceptions are if your project uses compiled resources, e.g. Cython.
 
+.. TODO check if this is the intended behaviour of setuptools-scm
+
+#. If you have any pre-existing `git tag`_ in your repository history, you will
+   need to ensure that the latest one in your current branch resembles a
+   :pep:`version identifier <440>` (e.g. `v0.42b`).
+   This is required because PyScaffold will configure :pypi:`setuptools-scm` to
+   automatically derive your project version from your repository tags.
+
+   You can check your tag history with ``git tag`` or ``git log --oneline``.
+
+   Also note that :pypi:`setuptools-scm` can fail to validate the project's
+   version if two tags exist for the same commit and one of them does not
+   correspond to a :pep:`version identifier <440>`.
+
+   Please check our :ref:`version-faq` for more information.
+
 #. In order to check that everything works, run ``pip install .`` and ``tox -e build``
    (or ``python -m build --wheel`` after installing ``build``).
    If those two commands don't work, check ``pyproject.toml``, ``setup.cfg``, ``setup.py`` as well as your package under ``src`` again.
@@ -55,3 +71,4 @@ Let's start:
 
 .. _documentation of setuptools: https://setuptools.pypa.io/en/stable/userguide/declarative_config.html
 .. _src layout: https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure
+.. _git tag: https://git-scm.com/book/en/v2/Git-Basics-Tagging

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -39,8 +39,6 @@ Let's start:
    In most cases you will not need to make changes to the new ``setup.py`` file provided by PyScaffold.
    The only exceptions are if your project uses compiled resources, e.g. Cython.
 
-.. TODO check if this is the intended behaviour of setuptools-scm
-
 #. If you have any pre-existing `git tag`_ in your repository history, you will
    need to ensure that the latest one in your current branch resembles a
    :pep:`version identifier <440>` (e.g. `v0.42b`).

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -40,18 +40,12 @@ Let's start:
    The only exceptions are if your project uses compiled resources, e.g. Cython.
 
 #. If you have any pre-existing `git tag`_ in your repository history, you will
-   need to ensure that the latest one in your current branch resembles a
-   :pep:`version identifier <440>` (e.g. `v0.42b`).
-   This is required because PyScaffold will configure :pypi:`setuptools-scm` to
-   automatically derive your project version from your repository tags.
+   need to ensure that the latest tag is compatible with :pypi:`setuptools-scm`.
+   You can do that by running ``python -m setuptools_scm`` (after installing it
+   in your environment). If the command succeeds you are good to go.
 
-   You can check your tag history with ``git tag`` or ``git log --oneline``.
-
-   Also note that :pypi:`setuptools-scm` can fail to validate the project's
-   version if two tags exist for the same commit and one of them does not
-   correspond to a :pep:`version identifier <440>`.
-
-   Please check our :ref:`version-faq` for more information.
+   Please note that some very specific tag formats can be problematic.
+   Check our :ref:`version-faq` for a workaround for this problem.
 
 #. In order to check that everything works, run ``pip install .`` and ``tox -e build``
    (or ``python -m build --wheel`` after installing ``build``).

--- a/src/pyscaffold/templates/tox_ini.template
+++ b/src/pyscaffold/templates/tox_ini.template
@@ -14,6 +14,7 @@ setenv =
     TOXINIDIR = {toxinidir}
 passenv =
     HOME
+    SETUPTOOLS_*
 extras =
     testing
 commands =
@@ -29,6 +30,7 @@ commands =
 # passenv =
 #     HOMEPATH
 #     PROGRAMDATA
+#     SETUPTOOLS_*
 # commands =
 #     pre-commit run --all-files {posargs:--show-diff-on-failure}
 
@@ -42,6 +44,8 @@ skip_install = True
 changedir = {toxinidir}
 deps =
     build: build[virtualenv]
+passenv =
+    SETUPTOOLS_*
 commands =
     clean: python -c 'import shutil; [shutil.rmtree(p, True) for p in ("build", "dist", "docs/_build")]'
     clean: python -c 'import pathlib, shutil; [shutil.rmtree(p, True) for p in pathlib.Path("src").glob("*.egg-info")]'
@@ -53,6 +57,8 @@ description =
     docs: Invoke sphinx-build to build the docs
     doctests: Invoke sphinx-build to run doctests
     linkcheck: Check for broken links in the documentation
+passenv =
+    SETUPTOOLS_*
 setenv =
     DOCSDIR = {toxinidir}/docs
     BUILDDIR = {toxinidir}/docs/_build

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ passenv =
     REQUESTS_CA_BUNDLE
     CURL_CA_BUNDLE
     USING_CONDA
+    SETUPTOOLS_*
 extras =
     # TODO: Uncomment `all` once all the extensions are updated
     #       to the new version of pyscaffold
@@ -64,6 +65,8 @@ skip_install = True
 changedir = {toxinidir}
 deps =
     build: build[virtualenv]
+passenv =
+    SETUPTOOLS_*
 commands =
     clean: python -c 'import shutil; [shutil.rmtree(p, True) for p in ("build", "dist", "docs/_build")]'
     clean: python -c 'import pathlib, shutil; [shutil.rmtree(p, True) for p in pathlib.Path("src").glob("*.egg-info")]'
@@ -75,6 +78,8 @@ description =
     docs: Invoke sphinx-build to build the docs
     doctests: Invoke sphinx-build to run doctests
     linkcheck: Check for broken links in the documentation
+passenv =
+    SETUPTOOLS_*
 setenv =
     DOCSDIR = {toxinidir}/docs
     BUILDDIR = {toxinidir}/docs/_build


### PR DESCRIPTION
## Purpose
In #649 we learn that `setuptools-scm` might have trouble with existing tags that don't resemble a version.

I don't know if it is intentional, but this is a confusing factor for new comers, specially if they want to migrate an existing repository to `pyscaffold`.

We should add least add some note about it. 

## Approach
- Add a note to the migration guides about verifying the tags.

#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

## Resources & Links

_Links to blog posts, patterns, libraries or addons used to solve this problem_
