### PR TITLE
Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,3 +23,4 @@ Contributors
 * Noah Pendleton
 * John Vandenberg
 * Ben Mares
+* Michał Górny

--- a/src/pyscaffold/dependencies.py
+++ b/src/pyscaffold/dependencies.py
@@ -8,7 +8,7 @@ from packaging.requirements import InvalidRequirement, Requirement
 
 # setuptools version is now enforced via `install_requires`
 
-BUILD = ("setuptools_scm>=5", "wheel")
+BUILD = ("setuptools_scm>=5",)
 """Dependencies that will be required to build the created project"""
 RUNTIME = ('importlib-metadata; python_version<"3.8"',)
 # TODO: Remove `importlib-metadata` when `python_requires = >= 3.8`
@@ -21,10 +21,6 @@ ISOLATED = ("setuptools>=46.1.0", "setuptools_scm[toml]>=5", *BUILD[1:])
 # Although version 36.6.0 introduces PEP517 implementation,
 # version 46.1.0 fix a bug with setuptools.finalize_distribution_options,
 # which is a hook used by setuptools_scm (better safe then sorry).
-
-# TODO: Maybe specify a min version for wheel?
-#       For the time being, there is an issue preventing us to do that:
-#       https://github.com/pypa/pep517/issues/86
 
 REQ_SPLITTER = re.compile(r";(?!\s*(python|platform|implementation|os|sys)_)", re.M)
 """Regex to split requirements that considers both `setup.cfg specs`_ and `PEP 508`_

--- a/tests/system/test_common.py
+++ b/tests/system/test_common.py
@@ -38,7 +38,7 @@ def test_ensure_inside_test_venv(putup):
     assert ".tox" in putup
 
 
-BUILD_DEPS = ["wheel", "setuptools_scm"]
+BUILD_DEPS = ["setuptools_scm"]
 
 
 def test_putup(cwd, putup):

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -331,7 +331,7 @@ def pyproject_from_old_extension(tmpfolder):
     """Old pyproject.toml file as produced by pyscaffoldext-pyproject"""
     config = """\
     [build-system]
-    requires = ["setuptools", "wheel"]
+    requires = ["setuptools"]
     """
     pyproject = Path(tmpfolder) / "pyproject.toml"
     pyproject.write_text(dedent(config))


### PR DESCRIPTION
## Purpose
The `wheel` dependency in pyproject.toml is redundant, as it is added by the backend
automatically.  Listing it explicitly in the documentation was a historical mistake and has been fixed since.

## Approach
By removing it.

#### Open Questions and Pre-Merge TODOs
- [ ] Should I update the generated `pyproject.toml` scaffolds myself?

## Resources & Links

[https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a](commit updating setuptools docs)
