### PR TITLE
Remove unecessary setuptools-scm configuration from example

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -147,9 +147,8 @@ How can I use PyScaffold if my project is nested within a larger repository, e.g
         [tool.setuptools_scm]
         # See configuration details in https://github.com/pypa/setuptools_scm
         version_scheme = "no-guess-dev"
-        # ADD THE TWO LINES BELOW
+        # ADD THE LINE BELOW
         root = ".."
-        relative_to = "setup.py"
 
     2. ``setup.py``::
 


### PR DESCRIPTION
## Purpose
This is a follow up on a recent discussion on the setuptools_scm repository.

The recommendation is to consider `relative_to` always relative to `pyproject.toml` when `root` is given in the `[tool.setuptools_scm]` table.

## Approach
- Remove the configuration that is not necessary and might cause problems.

## Resources & Links
`https://github.com/pypa/setuptools_scm/issues/738`
