### PR TITLE
Fix `freebsd` problems in `.cirrus.yml`

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -120,12 +120,15 @@ macos_task:
   <<: *test-template
 
 freebsd_task:
-  name: test (freebsd - 3.8)
-  freebsd_instance: {image_family: freebsd-13-0}
+  name: test (freebsd - 3.9)
+  freebsd_instance: {image_family: freebsd-13-1}
   install_script:
     - pkg remove -y python lang/python
-    - pkg install -y git python38 py38-pip py38-gdbm py38-sqlite3 py38-tox py38-pipx vim
-    - ln -s /usr/local/bin/python3.8 /usr/local/bin/python
+    - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox # py39-pipx
+    - pip install -U pipx
+      # pipx in freebsd 2022Q3 is outdated/broken, so we obtain it with pip.
+      # Probably it is safe to `pkg install py39-pipx` directly after Oct/2022.
+    - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
   <<: *test-template
 
 windows_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -124,7 +124,7 @@ freebsd_task:
   freebsd_instance: {image_family: freebsd-13-1}
   install_script:
     - pkg remove -y python lang/python
-    - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox # py39-pipx
+    - pkg install -y git vim python39 py39-pip py39-gdbm py39-sqlite3 py39-tox # py39-pipx
     - pip install -U pipx
       # pipx in freebsd 2022Q3 is outdated/broken, so we obtain it with pip.
       # Probably it is safe to `pkg install py39-pipx` directly after Oct/2022.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     args: ['--fix=lf']
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.34.0
+  rev: v2.37.1
   hooks:
   - id: pyupgrade
     args: ['--py36-plus']

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -128,12 +128,15 @@ macos_task:
   <<: *test-template
 
 freebsd_task:
-  name: test (freebsd - 3.8)
-  freebsd_instance: {image_family: freebsd-13-0}
+  name: test (freebsd - 3.9)
+  freebsd_instance: {image_family: freebsd-13-1}
   install_script:
     - pkg remove -y python lang/python
-    - pkg install -y git python38 py38-pip py38-gdbm py38-sqlite3 py38-tox py38-pipx
-    - ln -s /usr/local/bin/python3.8 /usr/local/bin/python
+    - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox # py39-pipx
+    - pip install -U pipx
+      # pipx in freebsd 2022Q3 is outdated/broken, so we obtain it with pip.
+      # Probably it is safe to `pkg install py39-pipx` directly after Oct/2022.
+    - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
   <<: *test-template
 
 windows_task:


### PR DESCRIPTION
## Purpose
Fix problems that started to appear in Cirrus CI for freebsd 2022Q3.

## Approach
- Update packages
- Temporarily `pip` to install `pipx` (quarterly release of freebsd package for `pipx` is probably broken until Oct 2022).

## Resources & Links
The approach was tested in https://github.com/pyscaffold/ci-tester/pull/13.
