### PR TITLE
Add codespell to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,3 +55,8 @@ repos:
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear]
+
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.2
+  hooks:
+  - id: codespell

--- a/src/pyscaffold/templates/pre-commit-config.template
+++ b/src/pyscaffold/templates/pre-commit-config.template
@@ -53,7 +53,7 @@ repos:
   ## You can add flake8 plugins via `additional_dependencies`:
   #  additional_dependencies: [flake8-bugbear]
 
-## Check for mispells in documentation files:
+## Check for misspells in documentation files:
 # - repo: https://github.com/codespell-project/codespell
 #   rev: v2.2.2
 #   hooks:

--- a/src/pyscaffold/templates/pre-commit-config.template
+++ b/src/pyscaffold/templates/pre-commit-config.template
@@ -52,3 +52,9 @@ repos:
   - id: flake8
   ## You can add flake8 plugins via `additional_dependencies`:
   #  additional_dependencies: [flake8-bugbear]
+
+## Check for mispells in documentation files:
+# - repo: https://github.com/codespell-project/codespell
+#   rev: v2.2.2
+#   hooks:
+#   - id: codespell


### PR DESCRIPTION
## Purpose
As a feature add `codespell` to the pre-commit config.

## Approach
This does not interfere with the current behaviour:
the new hook is not activated by default, the user has to opt-in by uncommenting it.
