### PR TITLE
Allow `venv_install` in config file

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,15 @@ Changelog
     Version 4.X.X, 2022-XX-XX
     -------------------------
 
+Development version
+===================
+
+Version 4.2.X, 2022-XX-XX
+-------------------------
+
+- Allow ``venv_install`` to be specified in config files.
+
+
 Current versions
 ================
 

--- a/src/pyscaffold/extensions/venv.py
+++ b/src/pyscaffold/extensions/venv.py
@@ -77,7 +77,7 @@ def run(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
 
         create(venv_path, opts.get("pretend"))
 
-    return struct, opts
+    return struct, _fix_opts(opts)
 
 
 def install_packages(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
@@ -184,3 +184,11 @@ class NotInstalled(ImportError):
 
     def __init__(self, msg: Optional[str] = None):
         super().__init__(msg or self.__doc__)
+
+
+def _fix_opts(opts: ScaffoldOpts) -> ScaffoldOpts:
+    pkgs = opts.get("venv_install")
+    if not pkgs:
+        return opts
+
+    return {**opts, "venv_install": deps.split(pkgs) if isinstance(pkgs, str) else pkgs}

--- a/src/pyscaffold/extensions/venv.py
+++ b/src/pyscaffold/extensions/venv.py
@@ -73,7 +73,7 @@ def run(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
     with chdir(project_path, **opts):
         if venv_path.is_dir():
             logger.report("skip", venv_path)
-            return struct, opts
+            return struct, _fix_opts(opts)
 
         create(venv_path, opts.get("pretend"))
 

--- a/tests/extensions/test_venv.py
+++ b/tests/extensions/test_venv.py
@@ -1,4 +1,5 @@
 from argparse import ArgumentError
+from inspect import cleandoc
 from itertools import chain, product
 from os import environ
 from pathlib import Path
@@ -209,3 +210,28 @@ def test_cli_with_venv_and_pretend(tmpfolder):
     # then the venv will not be created, or even the project itself
     assert not venv_path.exists()
     assert not proj_path.exists()
+
+
+@pytest.mark.slow
+def test_cli_with_venv_config(tmpfolder):
+    venv_path = Path(tmpfolder) / "proj/.venv"
+    # Given the venv does not exist yet
+    assert not venv_path.exists()
+    # and a config file exists containing venv
+    config = """
+    [pyscaffold]
+    extensions =
+        venv
+    venv_install =
+        pytest>=6.0.0
+    """
+    config_file = Path(tmpfolder, ".pyscaffold.cfg")
+    config_file.write_text(cleandoc(config), encoding="utf-8")
+    # when the CLI is invoked with that config file
+    cli.main(["proj", "--config", str(config_file)])
+    # then the venv will be created accordingly
+    assert venv_path.is_dir()
+    # with python, pip and the installed executables
+    assert list(venv_path.glob("*/python*"))
+    assert list(venv_path.glob("*/pip*"))
+    assert list(venv_path.glob("*/pytest*"))


### PR DESCRIPTION
## Purpose
Workaround INI limitation on list data structures for `venv_install`.

Closes #679

## Approach
- Split value if `venv_install` is a string.
