### PR TITLE
In GitHub actions template, by default use bdist_wheel instead of sdist

### DIFF
--- a/src/pyscaffold/templates/github_ci_workflow.template
+++ b/src/pyscaffold/templates/github_ci_workflow.template
@@ -36,7 +36,7 @@ jobs:
       - name: Run static analysis and format checkers
         run: pipx run pre-commit run --all-files --show-diff-on-failure
       - name: Build package distribution files
-        run: pipx run tox -e clean,build
+        run: pipx run tox -e clean,build -- --wheel
       - name: Record the path of wheel distribution
         id: wheel-distribution
         run: echo "::set-output name=path::$(ls dist/*.whl)"


### PR DESCRIPTION
## Purpose
More than just the `src` folder is getting added to the distribution which helped me discover `sdist` is still being used instead of `bdist_wheel` https://github.com/pyscaffold/pyscaffold/issues/684 (related to https://github.com/pyscaffold/pyscaffold/issues/404).

## Approach
Use the `--wheel` option. I noticed in https://github.com/pyscaffold/pyscaffold/commit/d21853e256a7af6551bc78539a00ef4581d8cd16 it was mentioned that `python -m build --wheel` could be used, and this commit uses the posarg via the `-- --wheel` syntax.

#### Open Questions and Pre-Merge TODOs

## Resources & Links

- GH actions runner that includes much more than `src` and led to a "File too large" error: https://github.com/sparks-baird/self-driving-lab-demo/actions/runs/3679664930
- GH actions runner with the `-- --wheel` fix: https://github.com/sparks-baird/self-driving-lab-demo/actions/runs/3679976374/jobs/6225043874
