### PR TITLE
Depricate set-output

### DIFF
--- a/src/pyscaffold/templates/github_ci_workflow.template
+++ b/src/pyscaffold/templates/github_ci_workflow.template
@@ -39,7 +39,7 @@ jobs:
         run: pipx run tox -e clean,build
       - name: Record the path of wheel distribution
         id: wheel-distribution
-        run: echo "::set-output name=path::$(ls dist/*.whl)"
+        run: echo "path=$(ls dist/*.whl)" >> $GITHUB_OUTPUT
       - name: Store the distribution files for use in other stages
         # `tests` and `publish` will use the same pre-built distributions,
         # so we make sure to release the exact same package that was tested


### PR DESCRIPTION

## Purpose
set-output has been depricated: https://github.com/pyscaffold/pyscaffold/issues/687

## Approach
Just need to switch 
        run: echo "::set-output name=path::$(ls dist/*.whl)"
to 
        run: echo "::set-output name=path::$(ls dist/*.whl)"

#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

## Resources & Links

[_Links to blog posts, patterns, libraries or addons used to solve this problem_](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
