### PR TITLE
Avoid problematic tox 4.0 and 4.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -107,7 +107,7 @@ mamba_task:
   name: test (Linux - mambaforge)
   container: {image: "condaforge/mambaforge"}
   install_script:  # Overwrite template
-    - mamba install -y pip tox pipx
+    - mamba install -y pip pipx 'tox!=4.0.*,!=4.1.*'
   <<: *test-template
 
 macos_task:

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -115,7 +115,7 @@ mamba_task:
   name: test (Linux - mambaforge)
   container: {image: "condaforge/mambaforge"}
   install_script:  # Overwrite template
-    - mamba install -y pip tox pipx
+    - mamba install -y pip pipx 'tox!=4.0.*,!=4.1.*'
   <<: *test-template
 
 macos_task:

--- a/src/pyscaffold/templates/gitlab_ci.template
+++ b/src/pyscaffold/templates/gitlab_ci.template
@@ -102,7 +102,7 @@ mamba:
   stage: test
   image: "condaforge/mambaforge"
   before_script:
-    - mamba install -y pip tox pipx
+    - mamba install -y pip pipx 'tox!=4.0.*,!=4.1.*'
   <<: *test_script
 
 upload-coverage:


### PR DESCRIPTION
## Purpose
There seems to be a bug with tox 4.0.* and 4.1.* (see `https://github.com/tox-dev/tox/issues/2442`).
While this have already been fixed in the latest tox published in PyPI, conda's distribution seems to be behind.

## Approach
Temporarily add a version restriction...
On platforms using `pip` this should not be necessary since `pip` should already be downloading the latest version from PyPI...
