### PR TITLE
Update macos instances on cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -112,7 +112,8 @@ mamba_task:
 
 macos_task:
   name: test (macOS - brew)
-  macos_instance: {image: "big-sur-xcode"}
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode
   brew_cache: {folder: "$HOME/Library/Caches/Homebrew"}
   install_script: brew install python tox pipx
   env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -115,11 +115,9 @@ macos_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
   brew_cache: {folder: "$HOME/Library/Caches/Homebrew"}
-  install_script:
-    - brew install python tox pipx
-    - brew link --overwrite python
+  install_script: brew install python tox pipx
   env:
-    PATH: "/usr/local/opt/python/libexec/bin:${PATH}"
+    PATH: "/opt/homebrew/opt/python/libexec/bin:${PATH}"
   <<: *test-template
 
 freebsd_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -115,7 +115,9 @@ macos_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
   brew_cache: {folder: "$HOME/Library/Caches/Homebrew"}
-  install_script: brew install python tox pipx
+  install_script:
+    - brew install python tox pipx
+    - brew link --overwrite python
   env:
     PATH: "/usr/local/opt/python/libexec/bin:${PATH}"
   <<: *test-template

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -120,7 +120,8 @@ mamba_task:
 
 macos_task:
   name: test (macOS - brew)
-  macos_instance: {image: "big-sur-xcode"}
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode
   brew_cache: {folder: "$HOME/Library/Caches/Homebrew"}
   install_script: brew install python tox pipx
   env:

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -123,7 +123,9 @@ macos_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
   brew_cache: {folder: "$HOME/Library/Caches/Homebrew"}
-  install_script: brew install python tox pipx
+  install_script:
+    - brew install python tox pipx
+    - brew link --overwrite python
   env:
     PATH: "/usr/local/opt/python/libexec/bin:${PATH}"
   <<: *test-template

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -123,11 +123,9 @@ macos_task:
   macos_instance:
     image: ghcr.io/cirruslabs/macos-monterey-xcode
   brew_cache: {folder: "$HOME/Library/Caches/Homebrew"}
-  install_script:
-    - brew install python tox pipx
-    - brew link --overwrite python
+  install_script: brew install python tox pipx
   env:
-    PATH: "/usr/local/opt/python/libexec/bin:${PATH}"
+    PATH: "/opt/homebrew/opt/python/libexec/bin:${PATH}"
   <<: *test-template
 
 freebsd_task:

--- a/tests/system/test_common.py
+++ b/tests/system/test_common.py
@@ -254,8 +254,6 @@ def test_new_project_does_not_fail_pre_commit(cwd, pre_commit, putup):
         # then the newly generated files should not result in errors when
         # pre-commit runs...
         try:
-            print(f"{list(Path().glob('*'))=}")
-            print(f"{Path('.pre-commit-config.yaml').read_text()=}")
             run(f"{pre_commit} install")
             run(f"{pre_commit} run --all")
         except CalledProcessError as ex:

--- a/tests/system/test_common.py
+++ b/tests/system/test_common.py
@@ -254,6 +254,8 @@ def test_new_project_does_not_fail_pre_commit(cwd, pre_commit, putup):
         # then the newly generated files should not result in errors when
         # pre-commit runs...
         try:
+            print(f"{list(Path().glob('*'))=}")
+            print(f"{Path('.pre-commit-config.yaml').read_text()=}")
             run(f"{pre_commit} install")
             run(f"{pre_commit} run --all")
         except CalledProcessError as ex:


### PR DESCRIPTION
## Purpose
It seems that Cirrus has removed support for the version of macOS previously used by PyScaffold.

## Approach
Update the image.

## Resources & Links
https://cirrus-ci.org/blog/2022/11/08/sunsetting-intel-macos-instances/
