### PR TITLE
Ensure utf-8 is used in subprocess output for system tests

### DIFF
--- a/tests/system/helpers.py
+++ b/tests/system/helpers.py
@@ -62,7 +62,7 @@ def run(*args, **kwargs):
     if args[0] in ("python", "putup", "pip", "tox", "pytest", "pre-commit"):
         raise SystemError("Please specify an executable with explicit path")
 
-    opts = dict(stderr=STDOUT, universal_newlines=True)
+    opts = dict(stderr=STDOUT, universal_newlines=True, encoding="utf-8")
     opts.update(kwargs)
 
     try:


### PR DESCRIPTION
## Purpose
It looks like the windows tests are having problems with UTF-8 for `subprocess.check_output`

https://cirrus-ci.com/task/6297662698291200

## Approach
Let's try to use UTF-8 for subprocesses.