### PR TITLE
Update Python version in Read The Docs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,8 +16,12 @@ sphinx:
 formats:
   - pdf
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - {path: ., method: pip}

--- a/src/pyscaffold/templates/rtd_cfg.template
+++ b/src/pyscaffold/templates/rtd_cfg.template
@@ -16,8 +16,12 @@ sphinx:
 formats:
   - pdf
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt
     - {path: ., method: pip}


### PR DESCRIPTION
The `python.version` key in `.readthedocs.yaml` is deprecated. The recommended way is now `build.tools.python`. The Python version is also updated to Python 3.11 to be able to build documentation with modern language features, for instance for typing.

## Purpose

Documentation for code using modern language features won't be built by Read The Docs with the current Python 3.8 version. This PR fixes this by using Python 3.11 to build the documentation on Read The Docs.

## Approach

This PR updates the build environment to Ubuntu 22.04 and Python 3.11 and also migrates to the recommended way to specify Python versions.

## Resources & Links

https://docs.readthedocs.io/en/stable/config-file/v2.html#python-version