### PR TITLE
pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     args: ['--py36-plus']
 
 - repo: https://github.com/PyCQA/autoflake
-  rev: v2.0.0
+  rev: v2.0.1
   hooks:
   - id: autoflake
     args: [
@@ -34,12 +34,12 @@ repos:
     ]
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
   - id: isort
 
 - repo: https://github.com/psf/black
-  rev: 22.12.0
+  rev: 23.1.0
   hooks:
   - id: black
     language_version: python3

--- a/src/pyscaffold/exceptions.py
+++ b/src/pyscaffold/exceptions.py
@@ -32,7 +32,7 @@ def exceptions2exit(exception_list):
         def func_wrapper(*args, **kwargs):
             try:
                 func(*args, **kwargs)
-            except tuple(exception_list) as ex:
+            except exception_list as ex:
                 from .cli import get_log_level  # defer circular imports to avoid errors
 
                 if get_log_level() <= logging.DEBUG:


### PR DESCRIPTION
## Purpose
_Describe the problem or feature in addition to a **link to the issues**._

pre-commit is failing on https://pypi.org/project/flake8-bugbear
`src/pyscaffold/exceptions.py:35:13: B030 Except handlers should only be names of exception classes`

## Approach
_How does this change address the problem?_

#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

## Resources & Links

_Links to blog posts, patterns, libraries or addons used to solve this problem_
