### PR TITLE
Make some ruff fixes

### DIFF
--- a/src/pyscaffold/file_system.py
+++ b/src/pyscaffold/file_system.py
@@ -270,7 +270,7 @@ def on_ro_error(func, path, exc_info):
     sleep(0.5)
 
     if not Path(path).exists():
-        return
+        return None
 
     if not os.access(path, os.W_OK):
         # Is the error an access error ?

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,7 +246,7 @@ def tmpfolder(tmpdir):
 @pytest.fixture
 def git_mock(monkeypatch, logger):
     def _git(*args, **kwargs):
-        cmd = " ".join(["git"] + list(args))
+        cmd = " ".join(["git", *list(args)])
 
         logger.report("run", cmd, context=os.getcwd())
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -65,7 +65,7 @@ def set_writable(func, path, exc_info):
         try:
             return func(path)
         except FileNotFoundError:
-            return
+            return None
     else:
         # For some weird reason we do have rights to remove the dir,
         # let's try again a few times more slowly (maybe a previous OS call
@@ -75,7 +75,7 @@ def set_writable(func, path, exc_info):
             try:
                 return rmtree(path)
             except FileNotFoundError:
-                return
+                return None
             except OSError:
                 sleep((i + 1) * retry_interval)
 

--- a/tests/system/test_common.py
+++ b/tests/system/test_common.py
@@ -71,9 +71,8 @@ def test_putup_with_update(cwd, putup):
 
 def test_putup_with_update_dirty_workspace(cwd, putup):
     run(f"{putup} myproj")
-    with chdir("myproj"):
-        with open("setup.py", "w") as fh:
-            fh.write("DIRTY")
+    with chdir("myproj"), open("setup.py", "w") as fh:
+        fh.write("DIRTY")
     with pytest.raises(CalledProcessError):
         run(f"{putup} --update myproj")
     run(f"{putup} --update myproj --force")

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -23,7 +23,7 @@ def test_discover():
         return struct, opts
 
     def extension(actions):
-        return [fake_action] + actions
+        return [fake_action, *actions]
 
     # When discover is called,
     actions = discover([extension])

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -183,7 +183,7 @@ def test_config_file_default(monkeypatch):
 
 def test_best_fit_license():
     # If the name matches => return the name
-    for license in templates.licenses.keys():
+    for license in templates.licenses:
         assert info.best_fit_license(license) == license
     # Lower case
     assert info.best_fit_license("0bsd") == "0BSD"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -62,7 +62,7 @@ def test_all_licenses():
         "author": "myself",
         "year": 1832,
     }
-    for license in templates.licenses.keys():
+    for license in templates.licenses:
         opts["license"] = license
         assert templates.license(opts)
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -99,10 +99,10 @@ class VenvManager:
             # need to pass here as list since its args to coverage.py
             args = [subarg for arg in args for subarg in arg.split()]
             putup_path = Path(self.venv_path, "bin", "putup")
-            cmd = list(map(str, [putup_path] + args))
+            cmd = list(map(str, [putup_path, *args]))
         else:
             # need to pass here as string since it's the cmd itself
-            cmd = " ".join(["putup"] + list(map(str, args)))
+            cmd = " ".join(["putup", *list(map(str, args))])
         self.run(cmd, with_coverage=with_coverage, **kwargs)
         return self
 


### PR DESCRIPTION
## Purpose
_Describe the problem or feature in addition to a **link to the issues**._
[`ruff --select=RET502,SIM117,SIM118,RUF005 --fix .`](https://beta.ruff.rs)
Executes the following fixes:
```
  3	RET502 	[*] Do not implicitly `return None` in function able to return non-`None` value
  1	SIM117 	[*] Use a single `with` statement with multiple contexts instead of nested `with` statements
  2	SIM118 	[*] Use `license in templates.licenses` instead of `license in templates.licenses.keys()`
  4	RUF005 	[*] Consider `["git", *list(args)]` instead of concatenation
```

## Approach
_How does this change address the problem?_

#### Open Questions and Pre-Merge TODOs
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Resources & Links

_Links to blog posts, patterns, libraries or add-ons used to solve this problem_
