### PR TITLE
Simplify git command, by letting exceptions go through

### DIFF
--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -86,8 +86,6 @@ def email() -> str:
 def is_git_installed() -> bool:
     """Check if git is installed"""
     logger.report("check", "is git installed...")
-    if shell.git is None:
-        return False
     try:
         shell.git("--version")
     except ShellCommandException:

--- a/src/pyscaffold/repo.py
+++ b/src/pyscaffold/repo.py
@@ -92,8 +92,6 @@ def get_git_root(default: Optional[T] = None) -> Union[None, T, str]:
     Returns:
         str: top-level path or *default*
     """
-    if shell.git is None:
-        return default
     try:
         return next(shell.git("rev-parse", "--show-toplevel"))
     except ShellCommandException:

--- a/src/pyscaffold/shell.py
+++ b/src/pyscaffold/shell.py
@@ -108,9 +108,8 @@ class ShellCommand:
         try:
             completed = self.run(*args, **kwargs)
         except FileNotFoundError as e:
-            msg = f"{e.strerror}: {e.filename}"
-            logger.report("info", f'last command failed with "{msg}"')
-            raise ShellCommandException(msg) from e
+            logger.report("info", f'last command failed with "{e!s}"')
+            raise ShellCommandException(str(e)) from e
 
         try:
             completed.check_returncode()

--- a/src/pyscaffold/shell.py
+++ b/src/pyscaffold/shell.py
@@ -43,6 +43,10 @@ the case the environment variables EDITOR and VISUAL are not set.
 """
 
 
+_GIT_CMD = "git"
+_GIT_CMD_WIN = "git.exe"
+
+
 class ShellCommand:
     """Shell command that can be called with flags like git('add', 'file')
 
@@ -142,7 +146,7 @@ def shell_command_error2exit_decorator(func: Callable):
 
 # ToDo: Change this to just `cache` from Python 3.9 on.
 @lru_cache(maxsize=None)
-def get_git_cmd(**args):
+def get_git_cmd(**args) -> ShellCommand:
     """Retrieve the git shell command depending on the current platform
 
     Args:
@@ -151,21 +155,14 @@ def get_git_cmd(**args):
     if IS_WINDOWS:  # pragma: no cover
         # ^  CI setup does not aggregate Windows coverage
         for shell in (True, False):
-            git = ShellCommand("git.exe", shell=shell, **args)
+            cmd = ShellCommand(_GIT_CMD_WIN, shell=shell, **args)
             try:
-                git("--version")
+                cmd("--version")
             except ShellCommandException:
                 continue
-            return git
-        else:
-            return None
-    else:
-        git = ShellCommand("git", **args)
-        try:
-            git("--version")
-        except ShellCommandException:
-            return None
-        return git
+            return cmd  # available and works with either shell=True or shell=False
+        return cmd  # not available, but we return it anyway for better error messages
+    return ShellCommand(_GIT_CMD, **args)
 
 
 def command_exists(cmd: str) -> bool:
@@ -174,10 +171,7 @@ def command_exists(cmd: str) -> bool:
     Args:
         cmd: executable name
     """
-    if shutil.which(cmd) is None:
-        return False
-    else:
-        return True
+    return shutil.which(cmd) is not None
 
 
 def get_executable(
@@ -229,7 +223,7 @@ def get_command(
     return ShellCommand(executable, **kwargs)
 
 
-def get_editor(**kwargs):
+def get_editor(**kwargs) -> str:
     """Get an available text editor program"""
     from_env = os.getenv("VISUAL") or os.getenv("EDITOR")
     if from_env:
@@ -264,7 +258,7 @@ def join(parts: Iterable[Union[str, PathLike]]) -> str:
 
 def git(*args, **kwargs) -> Iterator[str]:
     """Command for git"""
-    return get_git_cmd()(*args, **kwargs)
+    return get_git_cmd()(*args, **kwargs)  # delayed, so errors show up with --verbose
 
 
 #: Command for python

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -274,9 +274,17 @@ def nogit_mock(monkeypatch):
 
 
 @pytest.fixture
-def nonegit_mock(monkeypatch):
-    monkeypatch.setattr("pyscaffold.shell.git", None)
+def nogit_cmd_mock(monkeypatch):
+    # With this fixture we still allow all the code paths in `get_git_cmd` to be
+    # traversed during tests, so we improve the chances of catching errors.
+    monkeypatch.setattr("pyscaffold.shell._GIT_CMD", "git-cmd.not-installed")
+    monkeypatch.setattr("pyscaffold.shell._GIT_CMD_WIN", "git-cmd.not-installed.exe")
+
+    from pyscaffold import shell
+
+    shell.get_git_cmd.cache_clear()  # force reloading _GIT_CMD
     yield
+    shell.get_git_cmd.cache_clear()  # force reloading _GIT_CMD
 
 
 @pytest.fixture

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -58,7 +58,7 @@ def test_git_is_wrongely_installed(nogit_mock):
     assert not info.is_git_installed()
 
 
-def test_git_is_not_installed(nonegit_mock):
+def test_git_is_not_installed(nogit_cmd_mock):
     assert not info.is_git_installed()
 
 
@@ -76,7 +76,7 @@ def test_is_git_not_configured(noconfgit_mock):
     assert not info.is_git_configured()
 
 
-def test_check_git_not_installed(nonegit_mock):
+def test_check_git_not_installed(nogit_cmd_mock):
     with pytest.raises(exceptions.GitNotInstalled):
         info.check_git()
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -133,15 +133,3 @@ def test_get_git_root_with_nogit(tmpfolder, nogit_mock):
     with chdir(project):
         git_root = repo.get_git_root(default=".")
     assert git_root == "."
-
-
-def test_get_git_root_with_nonegit(tmpfolder, nonegit_mock):
-    project = "my_project"
-    struct = {
-        "my_file": "Some other content",
-        "my_dir": {"my_file": "Some more content"},
-    }
-    structure.create_structure(struct, {"project_path": project})
-    with chdir(project):
-        git_root = repo.get_git_root(default=".")
-    assert git_root == "."


### PR DESCRIPTION
## Purpose
This is an attempt to improve the UX when the git command is not installed.
As we can see in #712, the error might not be very intuitive to understand.

## Approach
In this PR I am tried to simplify the code paths and let the shell exception happen.
(After looking at the commit history for the file I can see that we encountered in the past a lot of problems and with the we accumulated very sophisticated checks. It seems to me that we no longer need to return `None` in `pyscaffold.shell.get_git_cmd`, because now it will be executed lazily and therefore wait until the logging is properly configured).
