### PR TITLE
Changing `Github Token` variable in template.

### DIFF
--- a/src/pyscaffold/templates/github_ci_workflow.template
+++ b/src/pyscaffold/templates/github_ci_workflow.template
@@ -87,7 +87,7 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           path-to-lcov: coverage.lcov
-          github-token: ${{ secrets.github_token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: ${{ matrix.platform }} - py${{ matrix.python }}
           parallel: true
 


### PR DESCRIPTION
Hello!

Running `pyscaffold` with the the Github Actions flag I've encountered that It fails to upload the code coverage report. By default, GitHub exposes the *Github Token* through the variable `secrets.GITHUB_TOKEN`  in [upper case]((https://docs.github.com/en/actions/security-guides/automatic-token-authentication)), while in the template it is used in lower case `secrets.github_token`.

Thanks,
Víctor