### PR TITLE
Allow platformdirs 3.x (fix #719)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,18 @@ Changelog
     -------------------------
 
 
+Development version
+===================
+
+Version 4.5.0, 2023-XX-XX
+-------------------------
+
+- Change macOS default configuration dir from
+  ``~/Library/Preferences`` to ``~/Library/Application Support``.
+  This change is motivated by a change in the ``platformdirs`` dependency.
+  You can read more about the motivation in :github:`platformdirs/platformdirs#98`
+
+
 Current versions
 ================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Version 4.5.0, 2023-XX-XX
 -------------------------
 
 - Change macOS default configuration dir from
-  ``~/Library/Preferences`` to ``~/Library/Application Support``.
+  ``~/Library/Preferences`` to ``~/Library/Application Support``, :pr:`721`.
   This change is motivated by a change in the ``platformdirs`` dependency.
   You can read more about the motivation in :github:`platformdirs/platformdirs#98`
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,7 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx_copybutton",
     "sphinxemoji.sphinxemoji",
+    "sphinx_github_role",
 ]
 
 # TODO: Autodoc cannot leave type hints alone (without expansion), as result the docs
@@ -315,7 +316,7 @@ extlinks = {
     "pr": (f"{repository}/pull/%s", "PR #%s"),
     "discussion": (f"{repository}/discussions/%s", "discussion #%s"),
     "pypi": ("https://pypi.org/project/%s", "%s"),
-    "github": ("https://github.com/%s", "%s"),
+    # "github" is handled by sphinx_github_role
 }
 
 print(f"loading configurations for {project} {version} ...", file=sys.stderr)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,5 +8,6 @@ setuptools>=38.3
 setuptools_scm
 sphinx>=3.2.1
 sphinx-copybutton
+sphinx-github-role>=0.1,<2
 sphinxemoji
 tomlkit

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ package_dir =
     =src
 install_requires =
     importlib-metadata; python_version<"3.8"
-    platformdirs>=2,<3
+    platformdirs>=2,<4
     configupdater>=3.0,<4  # pyscaffoldext-custom-extension should have a compatible range
     setuptools>=46.1.0
     setuptools_scm>=5

--- a/src/pyscaffold/api.py
+++ b/src/pyscaffold/api.py
@@ -70,6 +70,7 @@ def bootstrap_options(opts=None, **kwargs):
     # ^  remove empty items, so we ensure setdefault works
 
     # Add options stored in config files:
+    info._migrate_old_config()
     default_files = [info.config_file(default=None)]
     opts.setdefault("config_files", [f for f in default_files if f and f.exists()])
     # ^  make sure the file exists before passing it ahead

--- a/src/pyscaffold/api.py
+++ b/src/pyscaffold/api.py
@@ -70,7 +70,7 @@ def bootstrap_options(opts=None, **kwargs):
     # ^  remove empty items, so we ensure setdefault works
 
     # Add options stored in config files:
-    info._migrate_old_config()
+    info._migrate_old_macos_config()
     default_files = [info.config_file(default=None)]
     opts.setdefault("config_files", [f for f in default_files if f and f.exists()])
     # ^  make sure the file exists before passing it ahead

--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -390,7 +390,7 @@ def config_file(name=CONFIG_FILE, prog=PKG_NAME, org=None, default=RAISE_EXCEPTI
     return dir / name
 
 
-def _old_macos_config_dir(new_dir):
+def _old_macos_config_dir(new_dir: Path) -> Path:
     return Path(
         str(new_dir)
         .replace(os.sep, "/")
@@ -398,7 +398,7 @@ def _old_macos_config_dir(new_dir):
     )
 
 
-def _migrate_old_config(prog=PKG_NAME, org=None):
+def _migrate_old_config(prog: str = PKG_NAME, org: Optional[str] = None):
     """Compensate for macOS backward incompatible change in platformdirs 3.0.0"""
     if not sys.platform.startswith("darwin"):
         return

--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -398,7 +398,7 @@ def _old_macos_config_dir(new_dir: Path) -> Path:
     )
 
 
-def _migrate_old_config(prog: str = PKG_NAME, org: Optional[str] = None):
+def _migrate_old_macos_config(prog: str = PKG_NAME, org: Optional[str] = None):
     """Compensate for macOS backward incompatible change in platformdirs 3.0.0"""
     if not sys.platform.startswith("darwin"):
         return

--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -412,7 +412,7 @@ def _migrate_old_macos_config(prog: str = PKG_NAME, org: Optional[str] = None):
         logger.report("move", str(old_dir), target=str(new_dir))
         new_dir.parent.mkdir(parents=True, exist_ok=True)
         old_dir.rename(new_dir)
-    except Exception:
+    except Exception:  # pragma: no cover
         logger.debug(
             "Error trying to migrate old macOS config dir. "
             "If you have an older PyScaffold config file, please make sure to "


### PR DESCRIPTION
## Purpose

This PR expands the allowed versions of the `platformdirs` dependency from 2.x only to 2.x *or* 3.x. This would fix https://github.com/pyscaffold/pyscaffold/issues/719 and is required downstream in Fedora Linux for compatibility with the current version of `platformdirs`.

## Approach

The upper version bound in `setup.cfg` is trivially adjusted.

#### Open Questions and Pre-Merge TODOs

[x] Ran `tox` locally with no regressions

## Resources & Links

The sole breaking change in the [changelog for `platformdirs` 3.0.0](https://github.com/platformdirs/platformdirs/blob/3.5.1/CHANGES.rst#platformdirs-300-2023-02-06) is:

- **BREAKING** Changed the config directory on macOS to point to ``*/Library/Application Support``
