### PR TITLE
add args (set to default) for check-added-large-files

### DIFF
--- a/src/pyscaffold/templates/pre-commit-config.template
+++ b/src/pyscaffold/templates/pre-commit-config.template
@@ -6,6 +6,7 @@ repos:
   hooks:
   - id: trailing-whitespace
   - id: check-added-large-files
+    args: ['--maxkb=500']
   - id: check-ast
   - id: check-json
   - id: check-merge-conflict


### PR DESCRIPTION
## Purpose
I usually add some images to my repos and often find that I get the check-added-large-files condition violated.

## Approach
Then, I usually have to go back to one of my other repos to remember what I did to adjust this. (e.g., https://github.com/sparks-baird/xtal2png/blob/main/.pre-commit-config.yaml). Having this in here set to the default would help users adjust the max pretty easily.
