### PR TITLE
rename `.readthedocs.yml` to `.readthedocs.yaml`

### DIFF
--- a/src/pyscaffold/structure.py
+++ b/src/pyscaffold/structure.py
@@ -126,7 +126,7 @@ def define_structure(struct: Structure, opts: ScaffoldOpts) -> ActionParams:
         # Tools
         ".gitignore": (get_template("gitignore"), NO_OVERWRITE),
         ".coveragerc": (get_template("coveragerc"), NO_OVERWRITE),
-        ".readthedocs.yml": (get_template("rtd_cfg"), NO_OVERWRITE),
+        ".readthedocs.yaml": (get_template("rtd_cfg"), NO_OVERWRITE),
         # Project configuration
         "pyproject.toml": (templates.pyproject_toml, NO_OVERWRITE),
         "setup.py": get_template("setup_py"),


### PR DESCRIPTION
The content looks like it's been updated to the new configuration format (https://github.com/pyscaffold/pyscaffold/blob/master/src/pyscaffold/templates/rtd_cfg.template); the file just isn't named what I expected based on the docs. I recently ran into issues with building on sphinx due to using the old file format. Maybe it doesn't matter to readthedocs if it's `.yml` vs. `.yaml`, but I figured  I'd bring it up.

https://colab.research.google.com/gist/sgbaird/6e503e7f069260b039d6e86aeaf62721/pyscaffold-rtd-cfg-file.ipynb

## Purpose
Rename `.readthedocs.yml` to `.readthedocs.yaml` to be consistent with the readthedocs docs https://docs.readthedocs.io/en/stable/config-file/v2.html

![image](https://github.com/pyscaffold/pyscaffold/assets/45469701/da31fc5f-6363-41c9-9b18-239e9229c4ef)

https://github.com/pyscaffold/pyscaffold/issues/727

## Approach
Rename file