### PR TITLE
Modify Cirrus CI config to save resources

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,9 +62,9 @@ env:
 # ---- CI Pipeline ----
 
 build_task:
-  name: build (Linux - 3.10)
+  name: build and check (Linux - 3.11)
   alias: build
-  container: {image: "python:3.10-bullseye"}
+  container: {image: "python:3.11-bullseye"}
   clone_script: *clone
   dist_cache:  # build once and upload to be used by other tasks
     folder: dist
@@ -72,39 +72,24 @@ build_task:
     reupload_on_changes: true
   <<: *task-template
   install_script: pip install tox
-  build_script: tox -e clean,build
-
-check_task:
-  name: check (Linux - 3.11)
-  alias: check
-  depends_on: [build]
-  container: {image: "python:3.11-bullseye"}  # most recent => better types
-  dist_cache: {folder: dist, fingerprint_script: echo $CIRRUS_BUILD_ID}  # download
-  <<: *task-template
-  install_script: pip install tox
-  check_script: tox --installpkg dist/*.whl -e lint,typecheck
+  build_script: tox -e clean,lint,typecheck,build
 
 linux_task:
   matrix:
-    - name: test (Linux - 3.6)
-      container: {image: "python:3.6-bullseye"}
-      allow_failures: true  # EoL
     - name: test (Linux - 3.7)
       container: {image: "python:3.7-bullseye"}
-    - name: test (Linux - 3.8)
-      container: {image: "python:3.8-bullseye"}
-    - name: test (Linux - 3.9)
-      container: {image: "python:3.9-bullseye"}
     - name: test (Linux - 3.10)
       container: {image: "python:3.10-bullseye"}
-    - name: test (Linux - 3.11)
-      container: {image: "python:3.11-bullseye"}
+      skip: $BRANCH !=~ "^(main|master)$"
     - name: test (Linux - 3.12)
-      container: {image: "python:3.12-rc-bullseye"}
-      allow_failures: true  # Experimental
+      container: {image: "python:3.12-bullseye"}
+    # - name: test (Linux - 3.13)
+    #   container: {image: "python:3.13-rc-bookworm"}
+    #   allow_failures: true  # Experimental
   install_script:
     - python -m pip install --upgrade pip tox pipx
   <<: *test-template
+  alias: base-test
 
 mamba_task:
   name: test (Linux - mambaforge)
@@ -112,6 +97,7 @@ mamba_task:
   install_script:  # Overwrite template
     - mamba install -y pip pipx tox
   <<: *test-template
+  depends_on: [base-test]
 
 macos_task:
   name: test (macOS - brew)
@@ -122,6 +108,7 @@ macos_task:
   env:
     PATH: "/opt/homebrew/opt/python/libexec/bin:${PATH}"
   <<: *test-template
+  depends_on: [build, base-test]
 
 freebsd_task:
   name: test (freebsd - 3.9)
@@ -131,6 +118,7 @@ freebsd_task:
     - pkg install -y git vim python39 py39-pip py39-gdbm py39-sqlite3 py39-tox py39-pipx py39-tomli
     - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
   <<: *test-template
+  depends_on: [build, base-test]
 
 windows_task:
   name: test (Windows - 3.9.10)
@@ -148,6 +136,7 @@ windows_task:
     - pip install --upgrade certifi
     - python -m pip install -U pip tox pipx
   <<: *test-template
+  depends_on: [build, base-test]
 
 finalize_task:
   container: {image: "python:3.10-bullseye"}
@@ -171,7 +160,7 @@ linkcheck_task:
 # publish_task:
 #   name: publish (Linux - 3.10)
 #   container: {image: "python:3.10-bullseye"}
-#   depends_on: [check, build, test]
+#   depends_on: [build, base-test, test]
 #   only_if: $CIRRUS_TAG =~ 'v\d.*' && $CIRRUS_USER_PERMISSION == "admin"
 #   <<: *task-template
 #   dist_cache: {folder: dist, fingerprint_script: echo $CIRRUS_BUILD_ID}  # download

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -147,6 +147,7 @@ finalize_task:
 
 linkcheck_task:
   name: linkcheck (Linux - 3.10)
+  only_if: $BRANCH =~ "^(main|master)$"
   container: {image: "python:3.10-bullseye"}
   depends_on: [finalize]
   allow_failures: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: '^(docs/conf.py|docs/gfx)'
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.6.0
   hooks:
   - id: trailing-whitespace
   - id: check-added-large-files
@@ -24,7 +24,7 @@ repos:
     args: ['--py36-plus']
 
 - repo: https://github.com/PyCQA/autoflake
-  rev: v2.1.1
+  rev: v2.3.1
   hooks:
   - id: autoflake
     args: [
@@ -34,29 +34,29 @@ repos:
     ]
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.12.0
+  rev: 5.13.2
   hooks:
   - id: isort
 
 - repo: https://github.com/psf/black
-  rev: 23.3.0
+  rev: 24.8.0
   hooks:
   - id: black
     language_version: python3
 
 - repo: https://github.com/asottile/blacken-docs
-  rev: 1.14.0
+  rev: 1.18.0
   hooks:
   - id: blacken-docs
     additional_dependencies: [black]
 
 - repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
+  rev: 7.1.1
   hooks:
   - id: flake8
     additional_dependencies: [flake8-bugbear!=23.1.14]
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.5
+  rev: v2.3.0
   hooks:
   - id: codespell

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,7 +30,7 @@ Current versions
 Version 4.4.1, 2023-04-18
 -------------------------
 
-- Re-use pre-built wheels in CI for upgrade tests in :pr:`702`
+- Reuse pre-built wheels in CI for upgrade tests in :pr:`702`
 - Make security permissions explicit in GHA template :pr:`704`
 - Fix ``GITHUB_TOKEN`` variable in GHA template :pr:`715`
 

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -365,7 +365,7 @@ original ``sys.argv``.
 
 .. warning::
    The :obj:`~pyscaffold.extensions.interactive` extension is still
-   **experimental** and might not work exactly as expected. More importatly,
+   **experimental** and might not work exactly as expected. More importantly,
    due to limitations on the way :obj:`argparse` is implemented, there are
    several limitations and complexities on how to manipulate command line
    options when not using them directly.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -87,7 +87,7 @@ How can I embed PyScaffold into another application?
     :obj:`pyscaffold.api.create_project` in addition to :obj:`pyscaffold.api.NO_CONFIG`,
     :obj:`pyscaffold.log.DEFAULT_LOGGER`, :obj:`pyscaffold.log.logger` (partially,
     see details below), and the constructors for the extension classes belonging
-    to the :mod:`pyscaffold.extenstions` module (the other methods and functions
+    to the :mod:`pyscaffold.extensions` module (the other methods and functions
     are not considered part of the API). This API, as explicitly listed, follows
     `Semantic Versioning`_ and will not change in a backwards incompatible way
     between releases. The remaining methods and functions are not guaranteed to be stable.

--- a/docs/reasons.rst
+++ b/docs/reasons.rst
@@ -67,7 +67,7 @@ Extensible
     *Don't like something about PyScaffold?*
     *Wish the templates were a little different?*
     *Particular workflow? Different tools?*
-    *Have you got a nice set of templates that you would like to re-use?*
+    *Have you got a nice set of templates that you would like to reuse?*
 
     Well, go ahead and make PyScaffold yours…
     We have developed a :ref:`powerful extension system <extensions>` that

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """Setup file for PyScaffold."""
+
 from setuptools import setup
 
 if __name__ == "__main__":

--- a/src/pyscaffold/actions.py
+++ b/src/pyscaffold/actions.py
@@ -11,6 +11,7 @@ Note:
     other auxiliary functions, see :mod:`pyscaffold.structure`,
     :mod:`pyscaffold.update`.
 """
+
 import os
 from datetime import date, datetime
 from functools import reduce

--- a/src/pyscaffold/api.py
+++ b/src/pyscaffold/api.py
@@ -1,6 +1,7 @@
 """
 External API for accessing PyScaffold programmatically via Python.
 """
+
 from enum import Enum
 from functools import reduce
 from pathlib import Path

--- a/src/pyscaffold/exceptions.py
+++ b/src/pyscaffold/exceptions.py
@@ -2,6 +2,7 @@
 Functions for exception manipulation + custom exceptions used by PyScaffold to identify
 common deviations from the expected behavior.
 """
+
 import functools
 import logging
 import sys

--- a/src/pyscaffold/extensions/__init__.py
+++ b/src/pyscaffold/extensions/__init__.py
@@ -1,6 +1,7 @@
 """
 Built-in extensions for PyScaffold.
 """
+
 import argparse
 import sys
 import textwrap

--- a/src/pyscaffold/extensions/cirrus.py
+++ b/src/pyscaffold/extensions/cirrus.py
@@ -1,4 +1,5 @@
 """Extension that generates configuration for Cirrus CI."""
+
 from argparse import ArgumentParser
 from typing import List
 

--- a/src/pyscaffold/extensions/config.py
+++ b/src/pyscaffold/extensions/config.py
@@ -1,4 +1,5 @@
 """CLI options for using/saving preferences as PyScaffold config files."""
+
 import argparse
 from pathlib import Path
 from typing import TYPE_CHECKING, List

--- a/src/pyscaffold/extensions/github_actions.py
+++ b/src/pyscaffold/extensions/github_actions.py
@@ -1,4 +1,5 @@
 """Extension that generates configuration for GitHub Actions."""
+
 from argparse import ArgumentParser
 from typing import List
 

--- a/src/pyscaffold/extensions/gitlab_ci.py
+++ b/src/pyscaffold/extensions/gitlab_ci.py
@@ -1,6 +1,7 @@
 """
 Extension that generates configuration and script files for GitLab CI.
 """
+
 from argparse import ArgumentParser
 from typing import List
 

--- a/src/pyscaffold/extensions/interactive.py
+++ b/src/pyscaffold/extensions/interactive.py
@@ -22,6 +22,7 @@ Warning:
     The non-public functions are encapsulated in the functions :obj:`get_actions` and
     :obj:`format_args` in this file, in order to centralise the usage of non-public API.
 """
+
 import os
 import shlex
 import textwrap

--- a/src/pyscaffold/extensions/pre_commit.py
+++ b/src/pyscaffold/extensions/pre_commit.py
@@ -3,6 +3,7 @@ Extension that generates configuration files for Yelp `pre-commit`_.
 
 .. _pre-commit: https://pre-commit.com
 """
+
 from functools import partial
 from typing import List
 

--- a/src/pyscaffold/extensions/venv.py
+++ b/src/pyscaffold/extensions/venv.py
@@ -1,4 +1,5 @@
 """Create a virtual environment for the project"""
+
 import argparse
 from contextlib import suppress
 from pathlib import Path

--- a/src/pyscaffold/info.py
+++ b/src/pyscaffold/info.py
@@ -309,8 +309,7 @@ def get_curr_version(project_path: PathLike):
 
 
 @overload
-def config_dir(prog: str = PKG_NAME, org: Optional[str] = None) -> Path:
-    ...
+def config_dir(prog: str = PKG_NAME, org: Optional[str] = None) -> Path: ...
 
 
 @overload
@@ -318,8 +317,7 @@ def config_dir(
     prog: str = PKG_NAME,
     org: Optional[str] = None,
     default: Optional[Path] = RAISE_EXCEPTION,
-) -> Optional[Path]:
-    ...
+) -> Optional[Path]: ...
 
 
 def config_dir(prog=PKG_NAME, org=None, default=RAISE_EXCEPTION):
@@ -351,8 +349,7 @@ def config_dir(prog=PKG_NAME, org=None, default=RAISE_EXCEPTION):
 @overload
 def config_file(
     name: str = CONFIG_FILE, prog: str = PKG_NAME, org: Optional[str] = None
-) -> Path:
-    ...
+) -> Path: ...
 
 
 @overload
@@ -361,8 +358,7 @@ def config_file(
     prog: str = PKG_NAME,
     org: Optional[str] = None,
     default: Optional[Path] = RAISE_EXCEPTION,
-) -> Optional[Path]:
-    ...
+) -> Optional[Path]: ...
 
 
 def config_file(name=CONFIG_FILE, prog=PKG_NAME, org=None, default=RAISE_EXCEPTION):

--- a/src/pyscaffold/log.py
+++ b/src/pyscaffold/log.py
@@ -1,6 +1,7 @@
 """
 Custom logging infrastructure to provide execution information for the user.
 """
+
 import logging
 from collections import defaultdict
 from contextlib import contextmanager

--- a/src/pyscaffold/structure.py
+++ b/src/pyscaffold/structure.py
@@ -5,6 +5,7 @@
    contents. They will be called with PyScaffold's ``opts`` (:obj:`string.Template` via
    :obj:`~string.Template.safe_substitute`)
 """
+
 from copy import deepcopy
 from pathlib import Path
 from string import Template

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -71,9 +71,9 @@ env:
 # ---- CI Pipeline ----
 
 build_task:
-  name: build (Linux - 3.10)
+  name: build and check (Linux - 3.11)
   alias: build
-  container: {image: "python:3.10-bullseye"}
+  container: {image: "python:3.11-bullseye"}
   clone_script: *clone
   dist_cache:  # build once and upload to be used by other tasks
     folder: dist
@@ -81,38 +81,26 @@ build_task:
     reupload_on_changes: true
   <<: *task-template
   install_script: pip install tox
-  build_script: tox -e clean,build
-
-check_task:
-  name: check (Linux - 3.11)
-  alias: check
-  depends_on: [build]
-  container: {image: "python:3.11-bullseye"}  # most recent => better types
-  dist_cache: {folder: dist, fingerprint_script: echo $CIRRUS_BUILD_ID}  # download
-  <<: *task-template
-  install_script: pip install pre-commit
   check_script:
     - pre-commit run --all-files --show-diff-on-failure --color always
-    # - tox -e typecheck
+  build_script: tox -e clean,build
 
 linux_task:
   matrix:
-    - name: test (Linux - 3.7)
-      container: {image: "python:3.7-bullseye"}
     - name: test (Linux - 3.8)
       container: {image: "python:3.8-bullseye"}
-    - name: test (Linux - 3.9)
-      container: {image: "python:3.9-bullseye"}
     - name: test (Linux - 3.10)
       container: {image: "python:3.10-bullseye"}
-    - name: test (Linux - 3.11)
-      container: {image: "python:3.11-bullseye"}
+      skip: $BRANCH !=~ "^(main|master)$"
     - name: test (Linux - 3.12)
-      container: {image: "python:3.12-rc-bullseye"}
-      allow_failures: true  # Experimental
+      container: {image: "python:3.12-bullseye"}
+    # - name: test (Linux - 3.13)
+    #   container: {image: "python:3.13-rc-bookworm"}
+    #   allow_failures: true  # Experimental
   install_script:
     - python -m pip install --upgrade pip tox pipx
   <<: *test-template
+  alias: base-test
 
 mamba_task:
   name: test (Linux - mambaforge)
@@ -120,6 +108,7 @@ mamba_task:
   install_script:  # Overwrite template
     - mamba install -y pip pipx tox
   <<: *test-template
+  depends_on: [base-test]
 
 macos_task:
   name: test (macOS - brew)
@@ -130,6 +119,7 @@ macos_task:
   env:
     PATH: "/opt/homebrew/opt/python/libexec/bin:${PATH}"
   <<: *test-template
+  depends_on: [build, base-test]
 
 freebsd_task:
   name: test (freebsd - 3.9)
@@ -139,6 +129,7 @@ freebsd_task:
     - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox py39-pipx py39-tomli
     - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
   <<: *test-template
+  depends_on: [build, base-test]
 
 windows_task:
   name: test (Windows - 3.9.10)
@@ -155,6 +146,7 @@ windows_task:
     - pip install --upgrade certifi
     - python -m pip install -U pip tox pipx
   <<: *test-template
+  depends_on: [build, base-test]
 
 finalize_task:
   container: {image: "python:3.10-bullseye"}
@@ -176,7 +168,7 @@ linkcheck_task:
 publish_task:
   name: publish (Linux - 3.10)
   container: {image: "python:3.10-bullseye"}
-  depends_on: [check, build, test]
+  depends_on: [build, base-test, test]
   only_if: $CIRRUS_TAG =~ 'v\d.*' && $CIRRUS_USER_PERMISSION == "admin"
   <<: *task-template
   dist_cache: {folder: dist, fingerprint_script: echo $CIRRUS_BUILD_ID}  # download

--- a/src/pyscaffold/templates/cirrus.template
+++ b/src/pyscaffold/templates/cirrus.template
@@ -157,6 +157,7 @@ finalize_task:
 
 linkcheck_task:
   name: linkcheck (Linux - 3.10)
+  only_if: $BRANCH =~ "^(main|master)$"
   container: {image: "python:3.10-bullseye"}
   depends_on: [finalize]
   allow_failures: true

--- a/src/pyscaffold/templates/pre-commit-config.template
+++ b/src/pyscaffold/templates/pre-commit-config.template
@@ -2,7 +2,7 @@ exclude: '^docs/conf.py'
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.6.0
   hooks:
   - id: trailing-whitespace
   - id: check-added-large-files
@@ -19,14 +19,14 @@ repos:
 
 ## If you want to automatically "modernize" your Python code:
 # - repo: https://github.com/asottile/pyupgrade
-#   rev: v3.7.0
+#   rev: v3.17.0
 #   hooks:
 #   - id: pyupgrade
-#     args: ['--py37-plus']
+#     args: ['--py38-plus']
 
 ## If you want to avoid flake8 errors due to unused vars or imports:
 # - repo: https://github.com/PyCQA/autoflake
-#   rev: v2.1.1
+#   rev: v2.3.1
 #   hooks:
 #   - id: autoflake
 #     args: [
@@ -36,7 +36,7 @@ repos:
 #     ]
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.11.5
+  rev: 5.13.2
   hooks:
   - id: isort
 
@@ -48,13 +48,13 @@ repos:
 
 ## If like to embrace black styles even in the docs:
 # - repo: https://github.com/asottile/blacken-docs
-#   rev: v1.13.0
+#   rev: 1.18.0
 #   hooks:
 #   - id: blacken-docs
 #     additional_dependencies: [black]
 
 - repo: https://github.com/PyCQA/flake8
-  rev: 5.0.4
+  rev: 7.1.1
   hooks:
   - id: flake8
   ## You can add flake8 plugins via `additional_dependencies`:
@@ -62,6 +62,6 @@ repos:
 
 ## Check for misspells in documentation files:
 # - repo: https://github.com/codespell-project/codespell
-#   rev: v2.2.5
+#   rev: v2.3.0
 #   hooks:
 #   - id: codespell

--- a/src/pyscaffold/toml.py
+++ b/src/pyscaffold/toml.py
@@ -6,6 +6,7 @@ to swap implementations (e.g. replace `tomlkit`_ with `toml`_).
 .. _tomlkit: https://github.com/sdispater/tomlkit
 .. _toml: https://github.com/uiri/toml
 """
+
 from typing import Any, List, MutableMapping, NewType, Tuple, TypeVar, Union, cast
 
 import tomlkit

--- a/src/pyscaffold/update.py
+++ b/src/pyscaffold/update.py
@@ -1,6 +1,7 @@
 """
 Functionality to update one PyScaffold version to another
 """
+
 from enum import Enum
 from functools import reduce, wraps
 from itertools import chain

--- a/tests/extensions/test_config.py
+++ b/tests/extensions/test_config.py
@@ -32,12 +32,12 @@ def test_no_cli_opts(default_file):
     # Then no save_config or config_files should be found in the opts
     assert "save_files" not in cli_opts
 
-    # and config_files will be bootstraped with an empty list
+    # and config_files will be bootstrapped with an empty list
     # if the default file does not exist
     opts = api.bootstrap_options(cli_opts)
     assert opts["config_files"] == []
 
-    # or config_files will be bootstraped with the
+    # or config_files will be bootstrapped with the
     # default file if it exists
     default_file.write_text("[pyscaffold]\n")
     opts = api.bootstrap_options(cli_opts)

--- a/tests/system/test_common.py
+++ b/tests/system/test_common.py
@@ -241,7 +241,9 @@ def test_namespace_no_skeleton(cwd, putup):
     assert not (path / "skeleton.py").exists()
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="pre-commit requires Python 3.7+")
+@pytest.mark.skipif(
+    sys.version_info < (3, 8), reason="pre-commit hooks may require Python 3.8+"
+)
 def test_new_project_does_not_fail_pre_commit(cwd, pre_commit, putup):
     # Given pyscaffold is installed,
     # when we call putup with extensions and pre-commit

--- a/tests/system/test_dependency_managers.py
+++ b/tests/system/test_dependency_managers.py
@@ -79,7 +79,7 @@ def test_pipenv_works_with_pyscaffold(tmpfolder, monkeypatch, venv):
         venv.run("pipenv --bare run flake8 src/myproj/skeleton.py")
 
 
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     sys.version_info < (3, 8), reason="pip-compile may fail in old Python"
 )
 def test_piptools_works_with_pyscaffold(tmpfolder, monkeypatch):

--- a/tests/system/test_dependency_managers.py
+++ b/tests/system/test_dependency_managers.py
@@ -80,7 +80,7 @@ def test_pipenv_works_with_pyscaffold(tmpfolder, monkeypatch, venv):
 
 
 @pytest.mark.xfail(
-    sys.version_info < (3, 7), reason="pip-compile may fail in old Python"
+    sys.version_info < (3, 8), reason="pip-compile may fail in old Python"
 )
 def test_piptools_works_with_pyscaffold(tmpfolder, monkeypatch):
     venv_path = Path(str(tmpfolder), "myproj/.venv").resolve()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -220,7 +220,7 @@ def test_bootstrap_using_config_file(tmpfolder):
     new_opts = dict(project_path="another", config_files=[str(setup_cfg)])
     new_opts = bootstrap_options(new_opts)
 
-    # Finally, the bootstraped options should contain the same values
+    # Finally, the bootstrapped options should contain the same values
     # as the given config file
     assert new_opts["name"] == "my-proj"
     assert new_opts["package"] == "my_proj"


### PR DESCRIPTION


## Purpose
Recently Cirrus CI changed its free limits for open source. The idea behind this PR is to minimise the usage via a "fail fast" approach.


## Approach

The changes can be summarised as follows:

1. Run "build" and "check" inside the same container, so we save the time to spawn a separated container.
2. Decrease the amount of Linux containers used. I left the lower and upper limits for the Python version in PR builds and added an intermediary version to the master/main branch.
3. Wait until the Linux tests pass before running more expensive ones (Windows, OS X, FreeBSD).


## Resources & Links

https://cirrus-ci.org/blog/2023/07/17/limiting-free-usage-of-cirrus-ci/
