### PR TITLE
Use version instead of  mutable reference for black

### DIFF
--- a/src/pyscaffold/templates/pre-commit-config.template
+++ b/src/pyscaffold/templates/pre-commit-config.template
@@ -41,7 +41,7 @@ repos:
   - id: isort
 
 - repo: https://github.com/psf/black
-  rev: stable
+  rev: 23.12.0
   hooks:
   - id: black
     language_version: python3


### PR DESCRIPTION
## Purpose
A pre-commit autoupdate will be needed to make sure latest versions are used, but this commit just overcomes the `[WARNING] The 'rev' field of repo 'https://github.com/psf/black' appears to be a mutable reference...` message when running the pre-commit after project setup.

## Approach
By providing a version tag instead of `stable`, the `mutable reference.` is removed. 

