### PR TITLE
Update pre-commit-config.template with maxkb arg

### DIFF
--- a/src/pyscaffold/templates/pre-commit-config.template
+++ b/src/pyscaffold/templates/pre-commit-config.template
@@ -6,6 +6,7 @@ repos:
   hooks:
   - id: trailing-whitespace
   - id: check-added-large-files
+    args: ['--maxkb=500']
   - id: check-ast
   - id: check-json
   - id: check-merge-conflict


### PR DESCRIPTION
This doesn't change it from the default, but it makes it a lot easier to adjust afterwards (often find myself looking it up or referring to a different example).
