### PR TITLE
Fall back to pkgutil when Python >= 3.13

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ classifiers =
 [options]
 zip_safe = False
 packages = find_namespace:
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 package_dir =
     =src

--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -18,17 +18,15 @@ from .. import __version__ as pyscaffold_version
 from .. import dependencies as deps
 from .. import toml
 
-if sys.version_info[:2] >= (3, 7) and sys.version_info < (3, 13):
-    # TODO: Import directly (no need for workaround) when `python_requires = >= 3.7`
-    from importlib.resources import read_text  # pragma: no cover
-else:
-    from pkgutil import get_data  # pragma: no cover
+if sys.version_info[:2] >= (3, 9):
+    from importlib.resources import files
 
-    def read_text(package, resource, encoding="utf-8") -> str:  # pragma: no cover
-        data = get_data(package, resource)
-        if data is None:
-            raise FileNotFoundError(f"{resource!r} resource not found in {package!r}")
-        return data.decode(encoding)
+    def read_text(package: Union[str, ModuleType], resource: str) -> str:
+        """:meta private:"""
+        return files(package).joinpath(resource).read_text(encoding="utf-8")
+
+else:
+    from importlib.resources import read_text  # pragma: no cover
 
 
 ScaffoldOpts = Dict[str, Any]
@@ -120,7 +118,7 @@ def get_template(
     if isinstance(relative_to, ModuleType):
         relative_to = relative_to.__name__
 
-    data = read_text(relative_to, file_name, encoding="utf-8")
+    data = read_text(relative_to, file_name)
     # we assure that line endings are converted to '\n' for all OS
     content = data.replace(os.linesep, "\n")
     return string.Template(content)

--- a/src/pyscaffold/templates/__init__.py
+++ b/src/pyscaffold/templates/__init__.py
@@ -18,7 +18,7 @@ from .. import __version__ as pyscaffold_version
 from .. import dependencies as deps
 from .. import toml
 
-if sys.version_info[:2] >= (3, 7):
+if sys.version_info[:2] >= (3, 7) and sys.version_info < (3, 13):
     # TODO: Import directly (no need for workaround) when `python_requires = >= 3.7`
     from importlib.resources import read_text  # pragma: no cover
 else:

--- a/tests/demoapp_data/runner.py
+++ b/tests/demoapp_data/runner.py
@@ -6,11 +6,15 @@ import sys
 from difflib import unified_diff
 from pkgutil import get_data
 
-if sys.version_info[:2] >= (3, 7) and sys.version_info < (3, 13):
-    # TODO: Import directly (no need for conditional) when `python_requires = >= 3.7`
-    from importlib.resources import read_text
+if sys.version_info[:2] >= (3, 9):
+    from importlib.resources import files
+
+    def read_text(package, resource) -> str:
+        """:meta private:"""
+        return files(package).joinpath(resource).read_text(encoding="utf-8")
+
 else:
-    from importlib_resources import read_text
+    from importlib.resources import read_text  # pragma: no cover
 
 from . import __name__ as pkg_name
 from . import __version__ as pkg_version

--- a/tests/demoapp_data/runner.py
+++ b/tests/demoapp_data/runner.py
@@ -6,7 +6,7 @@ import sys
 from difflib import unified_diff
 from pkgutil import get_data
 
-if sys.version_info[:2] >= (3, 7):
+if sys.version_info[:2] >= (3, 7) and sys.version_info < (3, 13):
     # TODO: Import directly (no need for conditional) when `python_requires = >= 3.7`
     from importlib.resources import read_text
 else:


### PR DESCRIPTION
The `read_text` and other methods will be removed from Python 3.13.
As a stop gap measure  fall back to `pkgutil`.
