### PR TITLE
Install missing template files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,10 @@ install_requires =
 # However we specify a higher version so we encourage users to update the
 # version they have installed...
 
+[options.package_data]
+pyscaffold.templates =
+	*.template
+
 [options.packages.find]
 where = src
 exclude =


### PR DESCRIPTION
## Purpose

FreeBSD ports uses sdist to build python modules. In this way, the template files are missing, therefore the following error occurs.

```
% putup
ERROR: There was an error loading 'pyscaffold.extensions.interactive'.
    Please make sure you have installed a version of the extension that is compatible
    with PyScaffold 4.6. You can also try unininstalling it.
```

```
% python3.11
Python 3.11.10 (main, Oct  7 2024, 15:23:45) [Clang 17.0.6 (https://github.com/llvm/llvm-project.git llvmorg-17.0.6-0-g600970 on freebsd13 Type "help", "copyright", "credits" or "license" for more information.
>>> from pyscaffold.extensions import interactive
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.11/site-packages/pyscaffold/extensions/interactive.py", line 42, in <module>
    HEADER = templates.get_template("header_interactive")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pyscaffold/templates/__init__.py", line 121, in get_template
    data = read_text(relative_to, file_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pyscaffold/templates/__init__.py", line 26, in read_text
    return files(package).joinpath(resource).read_text(encoding="utf-8")
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/pathlib.py", line 1058, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/pathlib.py", line 1044, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/usr/local/lib/python3.11/site-packages/pyscaffold/templates/header_interactive.template'
```

## Approach

This patch installs the missing template files and fix the module.

#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

## Resources & Links

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=281745
https://cgit.freebsd.org/ports/commit/?id=0d231ec121aee06a694a5024fafc35622d90263d
