### PR TITLE
Bump versions of build dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,18 +13,20 @@ Changelog
 Development version
 ===================
 
+* Bump versions of build dependencies on ``setuptools`` and ``setuptools-scm``.
+
+
+Current versions
+================
+
 Version 4.6.0, 2024-09-23
 -------------------------
 
 * Modify Cirrus CI template to save resources, :pr:`735`
 * Update Cirrus CI configuration, :pr:`752`
-* Update Gitlab CI template, :pr:`756
-* Prefer `importlib.resources.files` instead of `importlib.resources.read_text` or `pkgutil.get_data`, :pr:`747`
-* Update version caps for dependency on `platformdirs`, :pr:`755`
-
-
-Current versions
-================
+* Update Gitlab CI template, :pr:`756`
+* Prefer ``importlib.resources.files`` instead of ``importlib.resources.read_text`` or ``pkgutil.get_data``, :pr:`747`
+* Update version caps for dependency on ``platformdirs``, :pr:`755`
 
 Version 4.5.0, 2023-06-20
 -------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # AVOID CHANGING REQUIRES: IT WILL BE UPDATED BY PYSCAFFOLD!
-requires = ["setuptools>=46.1.0", "setuptools_scm[toml]>=5"]
+requires = ["setuptools>=61.2", "setuptools_scm>=7"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/src/pyscaffold/templates/pyproject_toml.template
+++ b/src/pyscaffold/templates/pyproject_toml.template
@@ -1,6 +1,6 @@
 [build-system]
 # AVOID CHANGING REQUIRES: IT WILL BE UPDATED BY PYSCAFFOLD!
-requires = ["setuptools>=46.1.0", "setuptools_scm[toml]>=5"]
+requires = ["setuptools>=61.2", "setuptools_scm>=7"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Old versions of setuptools and setuptools-scm may have some bugs, so it might make sense to update.